### PR TITLE
Add continuous deployment steps to GitHub actions workflow

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -38,7 +38,7 @@ action "Run jest unit tests" {
 action "If master branch" {
   uses = "actions/bin/filter@3c0b4f0e63ea54ea5df2914b4fabf383368cd0da"
   needs = ["Lint Dockerfile", "Run JS linter", "Run jest unit tests", "Scan for secrets"]
-  args = "branch github-actions-2-more-actions"
+  args = "branch master"
 }
 
 action "Build a Docker container" {

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -31,49 +31,49 @@ action "Run jest unit tests" {
 }
 
 action "If master branch" {
-  uses = "actions/bin/filter@24a566c2524e05ebedadef0a285f72dc9b631411"
+  uses = "actions/bin/filter@3c0b4f0e63ea54ea5df2914b4fabf383368cd0da"
   needs = ["Lint Dockerfile", "Run JS linter", "Run jest unit tests"]
   args = "branch github-actions-2-more-actions"
 }
 
 action "Build a Docker container" {
-  uses = "actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108"
+  uses = "actions/docker/cli@86ff551d26008267bb89ac11198ba7f1d807b699"
   needs = ["If master branch"]
   args = "build -t base --build-arg GITHUB_SHA_ARG=$GITHUB_SHA ."
 }
 
 action "Login to Docker Hub" {
-  uses = "actions/docker/login@8cdf801b322af5f369e00d85e9cf3a7122f49108"
+  uses = "actions/docker/login@86ff551d26008267bb89ac11198ba7f1d807b699"
   needs = ["If master branch"]
   secrets = ["DOCKER_USERNAME", "DOCKER_PASSWORD"]
 }
 
 action "Tag :latest" {
-  uses = "actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108"
+  uses = "actions/docker/cli@86ff551d26008267bb89ac11198ba7f1d807b699"
   needs = ["Build a Docker container"]
   args = "tag base cdssnc/cra-claim-tax-benefits:latest"
 }
 
 action "Tag :$GITHUB_SHA" {
-  uses = "actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108"
+  uses = "actions/docker/cli@86ff551d26008267bb89ac11198ba7f1d807b699"
   needs = ["Tag :latest"]
   args = "tag base cdssnc/cra-claim-tax-benefits:$GITHUB_SHA"
 }
 
 action "Push container to Docker Hub" {
-  uses = "actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108"
+  uses = "actions/docker/cli@86ff551d26008267bb89ac11198ba7f1d807b699"
   needs = ["Login to Docker Hub", "Tag :$GITHUB_SHA"]
   args = "push cdssnc/cra-claim-tax-benefits"
 }
 
 action "Login to Azure" {
-  uses = "Azure/github-actions/login@d0e5a0afc6b9d8d19c9ade8e2446ef3c20e260d4"
+  uses = "Azure/github-actions/login@843845a95833e81c790d80c6e2fa714ccbd5e145"
   secrets = ["AZURE_SERVICE_APP_ID", "AZURE_SERVICE_PASSWORD", "AZURE_SERVICE_TENANT"]
   needs = ["Push container to Docker Hub"]
 }
 
 action "Update container image in Azure App Service for Containers" {
-  uses = "Azure/github-actions/cli@d0e5a0afc6b9d8d19c9ade8e2446ef3c20e260d4"
+  uses = "Azure/github-actions/cli@843845a95833e81c790d80c6e2fa714ccbd5e145"
   needs = ["Login to Azure"]
   env = {
     AZURE_SCRIPT = "az webapp config container set --resource-group cdscracollab-innovation-rg --name claim-tax-benefits --docker-custom-image-name cdssnc/cra-claim-tax-benefits:$GITHUB_SHA"

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -2,7 +2,12 @@ workflow "Run tests on push" {
   on = "push"
   resolves = [
     "Update container image in Azure App Service for Containers",
+    "Scan for secrets",
   ]
+}
+
+action "Scan for secrets" {
+  uses = "docker://cdssnc/seekret-github-action"
 }
 
 action "Lint Dockerfile" {
@@ -32,7 +37,7 @@ action "Run jest unit tests" {
 
 action "If master branch" {
   uses = "actions/bin/filter@3c0b4f0e63ea54ea5df2914b4fabf383368cd0da"
-  needs = ["Lint Dockerfile", "Run JS linter", "Run jest unit tests"]
+  needs = ["Lint Dockerfile", "Run JS linter", "Run jest unit tests", "Scan for secrets"]
   args = "branch github-actions-2-more-actions"
 }
 

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,8 +1,7 @@
 workflow "Run tests on push" {
   on = "push"
   resolves = [
-    "Lint Dockerfile",
-    "Run jest unit tests",
+    "Push container to Docker Hub",
   ]
 }
 
@@ -29,4 +28,40 @@ action "Run jest unit tests" {
   needs = [
     "Install npm dependencies"
   ]
+}
+
+action "If master branch" {
+  uses = "actions/bin/filter@24a566c2524e05ebedadef0a285f72dc9b631411"
+  needs = ["Lint Dockerfile", "Run JS linter", "Run jest unit tests"]
+  args = "branch github-actions-2-more-actions"
+}
+
+action "Build a Docker container" {
+  uses = "actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108"
+  needs = ["If master branch"]
+  args = "build -t base --build-arg GITHUB_SHA_ARG=$GITHUB_SHA ."
+}
+
+action "Login to Docker Hub" {
+  uses = "actions/docker/login@8cdf801b322af5f369e00d85e9cf3a7122f49108"
+  needs = ["If master branch"]
+  secrets = ["DOCKER_USERNAME", "DOCKER_PASSWORD"]
+}
+
+action "Tag :latest" {
+  uses = "actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108"
+  needs = ["Build a Docker container"]
+  args = "tag base cdssnc/cra-claim-tax-benefits:latest"
+}
+
+action "Tag :$GITHUB_SHA" {
+  uses = "actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108"
+  needs = ["Tag :latest"]
+  args = "tag base cdssnc/cra-claim-tax-benefits:$GITHUB_SHA"
+}
+
+action "Push container to Docker Hub" {
+  uses = "actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108"
+  needs = ["Login to Docker Hub", "Tag :$GITHUB_SHA"]
+  args = "push cdssnc/cra-claim-tax-benefits"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:lts-alpine
 LABEL maintainer="paul.craig@cds-snc.ca"
 
+ARG GITHUB_SHA_ARG
+ENV GITHUB_SHA=$GITHUB_SHA_ARG
+
 COPY . /src
 
 WORKDIR /src

--- a/app.js
+++ b/app.js
@@ -59,6 +59,9 @@ app.use(helmet())
 // gzip response body compression.
 app.use(compression())
 
+// Adding GITHUB_SHA to locals so that we can access it in our templates
+app.locals.GITHUB_SHA = process.env.GITHUB_SHA || null
+
 // configure routes
 require('./routes/start/start.controller')(app)
 require('./routes/login/login.controller')(app)

--- a/views/base.pug
+++ b/views/base.pug
@@ -4,8 +4,10 @@ html(lang='en')
     // Required meta tags
     meta(charset='utf-8')
     meta(name='viewport', content='width=device-width, initial-scale=1, shrink-to-fit=no')
-    meta(name="description" content="[WIP] A benefit signup prototype by the Canadian Digital Service")
-    link(rel="shortcut icon" href="/favicon.png" type="image/x-icon" sizes="32x32")
+    meta(name='description' content='[WIP] A benefit signup prototype by the Canadian Digital Service')
+    if GITHUB_SHA
+      meta(name='keywords' content=`GITHUB_SHA=${GITHUB_SHA}`)
+    link(rel='shortcut icon' href='/favicon.png' type='image/x-icon' sizes='32x32')
     link(rel='preconnect', href='https://fonts.gstatic.com/', crossorigin='')
     link(href='https://fonts.googleapis.com/css?family=Lato:700|Noto+Sans:400,700&display=fallback', rel='stylesheet')
     link(rel='stylesheet', href='/styles.css')


### PR DESCRIPTION
This PR does 4 things.

### 1. Added optional `GITHUB_SHA` env var to a <meta> tag in the <head>

If we update some configuration or write tests or something, we may not be able to tell by looking at the live app if it really updated. Adding a github SHA var to the header gives us an easy way to check what version of the app we're running. Possibly we could use this in other places in our code (for example, error logs) but that's a down-the-road idea.

### 2. Added workflow steps to build a container and then push it to Docker Hub

Once the container is reliably getting built and uploaded, we can update our running Azure App Service app.

### 3. Updates the currently running container on CRA's Azure

Zero-downtime deploys are super cool.

### 4. Adds a "Scan for secrets" action 

This action is owned and operated by CDS: https://github.com/cds-snc/github-actions/tree/master/seekret

If it finds anything that looks like a super secret key, it will fail the build. Could result in false positives but worth keeping in as a sense-check.