### PR TITLE
Add app.json file to enable Heroku Review Apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,11 @@
+{
+  "name": "claim-tax-benefits",
+  "description": "We believe that preparing returns on behalf of people who are eligible for CVITP will result in more people receiving benefits",
+  "formation": {},
+  "addons": [],
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    }
+  ]
+}


### PR DESCRIPTION
This is needed to enable [Heroku review apps](https://devcenter.heroku.com/articles/github-integration-review-apps).

From the docs:

> Review apps run the code in any GitHub pull request in a complete, disposable Heroku app. Review apps each have a unique URL you can share, making them a great way to propose, test, and merge changes to your code base.

Review apps are super helpful when collaborating on a codebase
and the setup is actually fairly straightforward (especially
once you've set it up 4 times already).

After this is merged, I can tinker around in the Heroku interface
and turn on the "build an app every PR" feature.