### PR TITLE
Feature/html validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ typings/
 # CSS files are compiled
 public/styles.css
 public/styles.css*
+
+**/**/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,4 @@ typings/
 public/styles.css
 public/styles.css*
 
-**/**/.DS_Store
+.DS_Store

--- a/formSchemas.js
+++ b/formSchemas.js
@@ -4,6 +4,9 @@ const loginSchema = {
         errorMessage: 'Must be 8 characters',
         options: { min: 8, max: 8 }
       },
+      isAlphanumeric: {
+          errorMessage: 'Code can only contain letters and numbers'
+      }
     },
   }
 

--- a/formSchemas.js
+++ b/formSchemas.js
@@ -1,6 +1,5 @@
 const loginSchema = {
     code: {
-      in: ['body'],
       isLength: {
         errorMessage: 'Must be 8 characters',
         options: { min: 8 }

--- a/formSchemas.js
+++ b/formSchemas.js
@@ -1,0 +1,13 @@
+const loginSchema = {
+    code: {
+      in: ['body'],
+      isLength: {
+        errorMessage: 'Must be 8 characters',
+        options: { min: 8 }
+      },
+    },
+  }
+
+  module.exports = {
+    loginSchema
+  }

--- a/formSchemas.js
+++ b/formSchemas.js
@@ -2,7 +2,7 @@ const loginSchema = {
     code: {
       isLength: {
         errorMessage: 'Must be 8 characters',
-        options: { min: 8 }
+        options: { min: 8, max: 8 }
       },
     },
   }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,5 @@
 {
-  "This service is to claim tax benefits online.": "This service is to claim tax benefits online.",
-  "Claim tax benefits": "Claim tax benefits"
+	"This service is to claim tax benefits online.": "This service is to claim tax benefits online.",
+	"Claim tax benefits": "Claim tax benefits",
+	"Please correct the errors on the page": "Please correct the errors on the page"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "claim-tax-benefits",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -222,47 +222,6 @@
       "requires": {
         "exec-sh": "^0.3.2",
         "minimist": "^1.2.0"
-      }
-    },
-    "@hapi/address": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
-      "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
-    },
-    "@hapi/hoek": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
-      "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
-    },
-    "@hapi/joi": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.0.tgz",
-      "integrity": "sha512-n6kaRQO8S+kepUTbXL9O/UOL788Odqs38/VOfoCrATDtTvyfiO3fgjlSRaNkHabpTLgM7qru9ifqXlXbXk8SeQ==",
-      "requires": {
-        "@hapi/address": "2.x.x",
-        "@hapi/hoek": "6.x.x",
-        "@hapi/marker": "1.x.x",
-        "@hapi/topo": "3.x.x"
-      }
-    },
-    "@hapi/marker": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/marker/-/marker-1.0.0.tgz",
-      "integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA=="
-    },
-    "@hapi/topo": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.2.tgz",
-      "integrity": "sha512-r+aumOqJ5QbD6aLPJWqVjMAPsx5pZKz+F5yPqXZ/WWG9JTtHbQqlzrJoknJ0iJxLj9vlXtmpSdjlkszseeG8OA==",
-      "requires": {
-        "@hapi/hoek": "8.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.0.1.tgz",
-          "integrity": "sha512-cctMYH5RLbElaUpZn3IJaUj9QNQD8iXDnl7xNY6KB1aFD2ciJrwpo3kvZowIT75uA+silJFDnSR2kGakALUymg=="
-        }
       }
     },
     "@jest/console": {
@@ -2810,6 +2769,15 @@
           "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
         }
+      }
+    },
+    "express-validator": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.1.1.tgz",
+      "integrity": "sha512-AF6YOhdDiCU7tUOO/OHp2W++I3qpYX7EInMmEEcRGOjs+qoubwgc5s6Wo3OQgxwsWRGCxXlrF73SIDEmY4y3wg==",
+      "requires": {
+        "lodash": "^4.17.11",
+        "validator": "^11.0.0"
       }
     },
     "extend": {
@@ -9152,6 +9120,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-11.0.0.tgz",
+      "integrity": "sha512-+wnGLYqaKV2++nUv60uGzUJyJQwYVOin6pn1tgEiFCeCQO60yeu3Og9/yPccbBX574kxIcEJicogkzx6s6eyag=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "test": "node node_modules/jest/bin/jest.js"
   },
   "dependencies": {
-    "@hapi/joi": "^15.1.0",
     "app-root-path": "^2.2.1",
     "compression": "^1.7.4",
     "connect-redis": "^3.4.1",
@@ -25,6 +24,7 @@
     "dotenv": "^8.0.0",
     "express": "~4.17.1",
     "express-session": "^1.16.2",
+    "express-validator": "^6.1.1",
     "helmet": "^3.18.0",
     "i18n": "^0.8.3",
     "morgan": "~1.9.1",

--- a/public/scss/_error-list.scss
+++ b/public/scss/_error-list.scss
@@ -1,0 +1,13 @@
+.error-list-wrapper {
+    padding: 15px;
+    background: #f3e9e8;
+    border-left: 4px solid $color-red;
+
+    h3 {
+        margin-top: 10px;
+    }
+}
+
+.validation-message {
+  color: $color-red;
+}

--- a/public/scss/_error-list.scss
+++ b/public/scss/_error-list.scss
@@ -1,10 +1,10 @@
 .error-list {
-    padding: 15px;
-    background: #f3e9e8;
+    padding: $space-sm;
+    background: $color-red-light;
     border-left: 4px solid $color-red;
 
     &__header {
-        margin-top: 10px;
+        margin-top: $space-xs;
     }
 }
 

--- a/public/scss/_error-list.scss
+++ b/public/scss/_error-list.scss
@@ -1,9 +1,9 @@
-.error-list-wrapper {
+.error-list {
     padding: 15px;
     background: #f3e9e8;
     border-left: 4px solid $color-red;
 
-    h3 {
+    &__header {
         margin-top: 10px;
     }
 }

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -47,6 +47,10 @@ form.pure-form.pure-form-stacked {
     margin-top: 0;
     padding: $space-xxs;
 
+    &.has-error {
+      border: 2px solid $color-red;
+    }
+
     &:focus {
       @include focus();
       border-color: $color-black;

--- a/public/scss/_variables.scss
+++ b/public/scss/_variables.scss
@@ -6,6 +6,7 @@ $color-yellow: #ffbf47;
 $color-white: #ffffff;
 $color-black: #000000;
 $color-red: #af3c43;
+$color-red-light: #f3e9e8;
 $color-purple: #7834bc;
 
 // spacing units

--- a/public/styles.scss
+++ b/public/styles.scss
@@ -13,6 +13,7 @@
 /* App-wide styles */
 @import './scss/_base';
 @import './scss/_forms';
+@import './scss/_error-list';
 
 /* Partials */
 @import './scss/footer';

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -1,10 +1,6 @@
 const { validationResult, checkSchema } = require('express-validator')
-const {
-  errorArray2ErrorObject
-} = require('./../../utils.js')
-const {
-  loginSchema
-} = require('./../../formSchemas.js')
+const { errorArray2ErrorObject } = require('./../../utils.js')
+const { loginSchema } = require('./../../formSchemas.js')
 
 module.exports = function(app) {
   // redirect from "/login" → "/login/accessCode"
@@ -27,11 +23,11 @@ const postCode = (req, res) => {
   let accessCode = req.body.code || null
   req.session = accessCode ? { code: accessCode } : null
 
-  if (accessCode && redirect) {
-    return res.redirect(redirect)
-  }
-
   const errors = validationResult(req)
 
-  res.status(422).render('login/code', { title: 'Enter access code', data: req.session || {}, errors: errorArray2ErrorObject(errors) })
+  if(!errors.isEmpty()) {
+    res.status(422).render('login/code', { title: 'Enter access code', data: req.session || {}, errors: errorArray2ErrorObject(errors) })
+  } else if (accessCode && redirect) {
+    return res.redirect(redirect)
+  }
 }

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -1,10 +1,18 @@
+const { validationResult, checkSchema } = require('express-validator')
+const {
+  errorArray2ErrorObject
+} = require('./../../utils.js')
+const {
+  loginSchema
+} = require('./../../formSchemas.js')
+
 module.exports = function(app) {
   // redirect from "/login" → "/login/accessCode"
   app.get('/login', (req, res) => res.redirect('/login/code'))
   app.get('/login/code', (req, res) =>
     res.render('login/code', { title: 'Enter access code', data: req.session || {} }),
   )
-  app.post('/login/code', postCode)
+  app.post('/login/code', checkSchema(loginSchema), postCode)
   app.get('/login/success', (req, res) =>
     res.render('login/success', { title: 'Your access code', data: req.session || {} }),
   )
@@ -23,5 +31,7 @@ const postCode = (req, res) => {
     return res.redirect(redirect)
   }
 
-  res.status(422).render('login/code', { title: 'Enter access code', data: req.session || {} })
+  const errors = validationResult(req)
+
+  res.status(422).render('login/code', { title: 'Enter access code', data: req.session || {}, errors: errorArray2ErrorObject(errors) })
 }

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -55,6 +55,20 @@ describe('Test /login responses', () => {
     })
   })
 
+  test('it does not allow a code more than 8 characters', async () => {
+    const response = await request(app)
+      .post('/login/code')
+      .send({ code: 'A23XGY12111', redirect: '/' })
+    expect(response.statusCode).toBe(422)
+  })
+
+  test('it does not allow a code less than 8 characters', async () => {
+    const response = await request(app)
+      .post('/login/code')
+      .send({ code: 'A23X', redirect: '/' })
+    expect(response.statusCode).toBe(422)
+  })
+
   test('it redirects to /login/success if a valid code is provided', async () => {
     const response = await request(app)
       .post('/login/code')

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -33,6 +33,28 @@ describe('Test /login responses', () => {
     expect(response.statusCode).toBe(422)
   })
 
+  describe('Error list tests', () => {
+    test('it renders the error-list for /login/code', async () => {
+      const response = await request(app)
+        .post('/login/code')
+        .send({ redirect: '/' })
+      const $ = cheerio.load(response.text)
+      expect($('.error-list__header').text()).toEqual('Please correct the error on the page')
+      expect($('.error-list__list').children()).toHaveLength(1)
+      expect($('.validation-message').text()).toEqual('Must be 8 characters')
+      expect($('#code').attr('aria-describedby')).toEqual('code_error')
+    })
+
+    test('it renders an inline error for /login/code with appropriate describedby', async () => {
+      const response = await request(app)
+        .post('/login/code')
+        .send({ redirect: '/' })
+      const $ = cheerio.load(response.text)
+      expect($('.validation-message').text()).toEqual('Must be 8 characters')
+      expect($('#code').attr('aria-describedby')).toEqual('code_error')
+    })
+  })
+
   test('it redirects to /login/success if a valid code is provided', async () => {
     const response = await request(app)
       .post('/login/code')

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -58,7 +58,7 @@ describe('Test /login responses', () => {
   test('it redirects to /login/success if a valid code is provided', async () => {
     const response = await request(app)
       .post('/login/code')
-      .send({ code: 'OK', redirect: '/' })
+      .send({ code: 'A23XGY12', redirect: '/' })
     expect(response.statusCode).toBe(302)
     expect(response.headers.location).toEqual('/')
   })

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -69,6 +69,13 @@ describe('Test /login responses', () => {
     expect(response.statusCode).toBe(422)
   })
 
+  test('it does not allow non-alphanumeric characters', async () => {
+    const response = await request(app)
+      .post('/login/code')
+      .send({ code: 'A23X456@', redirect: '/' })
+    expect(response.statusCode).toBe(422)
+  })
+
   test('it redirects to /login/success if a valid code is provided', async () => {
     const response = await request(app)
       .post('/login/code')

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -39,7 +39,7 @@ describe('Test /login responses', () => {
         .post('/login/code')
         .send({ redirect: '/' })
       const $ = cheerio.load(response.text)
-      expect($('.error-list__header').text()).toEqual('Please correct the error on the page')
+      expect($('.error-list__header').text()).toEqual('Please correct the errors on the page')
       expect($('.error-list__list').children()).toHaveLength(1)
       expect($('.validation-message').text()).toEqual('Must be 8 characters')
       expect($('#code').attr('aria-describedby')).toEqual('code_error')

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,29 @@
+const pickEditSchema = (req, res, next) => {
+    const question = require(`./questions/${req.params.id}.js`)
+    return checkSchema(question.schema)[0](req, res, next)
+}
+/*
+  original format is an array of error objects: https://express-validator.github.io/docs/validation-result-api.html
+  convert that to an object where the key is the parameter name and value is the error object
+  ie,
+  [
+    { param: 'name', msg: 'Cannot be empty', ... },
+    { param: 'number', msg: 'Cannot be empty', ... }
+  ]
+  to
+  {
+    name: { param: 'name', msg: 'Cannot be empty', ... },
+    number: { param: 'number', msg: 'Cannot be empty', ... }
+  }
+*/
+const errorArray2ErrorObject = (errors = []) => {
+    return errors.array({ onlyFirstError: true }).reduce((map, obj) => {
+        map[obj.param] = obj
+        return map
+    }, {})
+}
+
+
+  module.exports = {
+    errorArray2ErrorObject
+  }

--- a/utils.js
+++ b/utils.js
@@ -1,7 +1,3 @@
-const pickEditSchema = (req, res, next) => {
-    const question = require(`./questions/${req.params.id}.js`)
-    return checkSchema(question.schema)[0](req, res, next)
-}
 /*
   original format is an array of error objects: https://express-validator.github.io/docs/validation-result-api.html
   convert that to an object where the key is the parameter name and value is the error object

--- a/views/_includes/errorList.pug
+++ b/views/_includes/errorList.pug
@@ -1,6 +1,9 @@
 div.error-list-wrapper(role='alert')
-    p There are #{Object.keys(errors).length} errors on the page
+    if (Object.keys(errors).length > 1)
+        h3 Please correct the #{Object.keys(errors).length} errors on the page
+    else
+        h3 Please correct the error on the page
     ol#formErrors.error-list
-    each error in errors
-        li.error-list__error
-            a(class='error-list__link' id=error.param+'_error' href='#'+error.param) #{error.msg}
+        each error in errors
+            li.error-list__error
+                a(class='error-list__link' id=error.param+'_error' href='#'+error.param) #{error.msg}

--- a/views/_includes/errorList.pug
+++ b/views/_includes/errorList.pug
@@ -1,8 +1,5 @@
 div.error-list(role='alert')
-    if (Object.keys(errors).length > 1)
-        h3.error-list__header Please correct the #{Object.keys(errors).length} errors on the page
-    else
-        h3.error-list__header Please correct the error on the page
+    h3.error-list__header #{__('Please correct the errors on the page')}
     ol#formErrors.error-list__list
         each error in errors
             li.error-list__list-item

--- a/views/_includes/errorList.pug
+++ b/views/_includes/errorList.pug
@@ -1,9 +1,9 @@
-div.error-list-wrapper(role='alert')
+div.error-list(role='alert')
     if (Object.keys(errors).length > 1)
-        h3 Please correct the #{Object.keys(errors).length} errors on the page
+        h3.error-list__header Please correct the #{Object.keys(errors).length} errors on the page
     else
-        h3 Please correct the error on the page
-    ol#formErrors.error-list
+        h3.error-list__header Please correct the error on the page
+    ol#formErrors.error-list__list
         each error in errors
-            li.error-list__error
+            li.error-list__list-item
                 a(class='error-list__link' id=error.param+'_error' href='#'+error.param) #{error.msg}

--- a/views/_includes/errorList.pug
+++ b/views/_includes/errorList.pug
@@ -1,0 +1,6 @@
+div.error-list-wrapper(role='alert')
+    p There are #{Object.keys(errors).length} errors on the page
+    ol#formErrors.error-list
+    each error in errors
+        li.error-list__error
+            a(class='error-list__link' id=error.param+'_error' href='#'+error.param) #{error.msg}

--- a/views/base.pug
+++ b/views/base.pug
@@ -27,6 +27,9 @@ html(lang='en')
               img(src='/img/sig-blk-en.svg', alt='Government of Canada')
 
       main
+        if errors 
+          include _includes/errorList.pug
+
         block content
 
       include _includes/footer.pug

--- a/views/login/code.pug
+++ b/views/login/code.pug
@@ -14,7 +14,9 @@ block content
         div
           label(for='code') Personal access code
           span.pure-form-message For Example: A23XGY12
-          input#code(name='code', type='text', value=data.code, autocomplete='off' aria-describedby=(errors ? 'code_error' : false))
+          input#code(class={['has-error']: errors && errors.code} name='code', type='text', value=data.code, autocomplete='off' aria-describedby=(errors && errors.code ? 'code_error' : false))
+          if errors
+            span.validation-message #{errors.code.msg}
 
         div
           details.

--- a/views/login/code.pug
+++ b/views/login/code.pug
@@ -4,9 +4,6 @@ block content
 
   h1 #{title}
 
-  if errors 
-    include ../_includes/errorList.pug
-
   p Your personal access code is the 8 character code found in your notification letter.
 
     form.pure-form.pure-form-stacked(method='post')

--- a/views/login/code.pug
+++ b/views/login/code.pug
@@ -4,6 +4,9 @@ block content
 
   h1 #{title}
 
+  if errors 
+    include ../_includes/errorList.pug
+
   p Your personal access code is the 8 character code found in your notification letter.
 
     form.pure-form.pure-form-stacked(method='post')
@@ -11,7 +14,7 @@ block content
         div
           label(for='code') Personal access code
           span.pure-form-message For Example: A23XGY12
-          input#code(name='code', type='text', value=data.code, autocomplete='off')
+          input#code(name='code', type='text', value=data.code, autocomplete='off' aria-describedby=(errors ? 'code_error' : false))
 
         div
           details.


### PR DESCRIPTION
## This PR covers the following trello tickets:
- [Add form validation to HTML prototype](https://trello.com/c/8D5rgaWX/108-add-form-validation-to-html-prototype)
- [Add error summary element to HTML prototype](https://trello.com/c/KjG2Nq44/109-add-error-summary-element-to-html-prototype)

Just enter nothing on the page asking for your code to see.

## What it do
I've added this html validation setup to the login page, which may seem overkill, but will serve as reference for how to set this up.

Schemas for validation are contained in one file right now, and we import them where appropriate.

Essentially we check the schema in our route, nab the validation results with `validationResult`, and if there are errors, render the page with the errors using the `errorArray2ErrorObject` function I 100% stole from @pcraig3 

When errors are present, we include `errorList`, which list out the errors on the page, and links to the appropriate input. This error list div has a `role=alert` for some [https://www.w3.org/TR/WCAG20-TECHS/ARIA19.html](error accessibility standards)

Additionally, when there are errors, we get an inline error, and the input gets a `aria-describedby` which links up the appropriate message in the error list. The input also gets a red border as visual indication beyond the error below.

## How to do
I've made some assumptions here, and based on review things may change, but for implementing this, the main points to look at are:

- write your schema in `formSchemas.js`
- check your schema in your controller file when making request (`login.controller.js` ~line 15)
- store the results (`login.controller.js` ~line 34) -- this example is a bit different as at this point we know there are errors, you might run an extra `if(!errors.isEmpty())`
- render appropriate page with errors being passed to `errorObject2ErrorArray()` (`login.controller.js` ~line 36)

and then for your inputs, make sure you're checking if it should have the class `has-error`, if it should have an `aria-describedby` and a trailing error message in a span:
```
input#code(class={['has-error']: errors && errors.code} name='code', type='text', value=data.code, autocomplete='off' aria-describedby=(errors && errors.code ? 'code_error' : false))
          if errors
            span.validation-message #{errors.code.msg}
```


![image](https://user-images.githubusercontent.com/6607541/60676797-cb2e7280-9e4d-11e9-9cc2-0375b3e20dac.png)


