### PR TITLE
Login with access code + put user data into session

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -11,8 +11,11 @@ var API = (function(user) {
     return null
   }
 
+  const getMatches = () => [_user.login.code]
+
   return {
     getUser,
+    getMatches,
   }
 })(user)
 

--- a/api/index.spec.js
+++ b/api/index.spec.js
@@ -11,3 +11,9 @@ test('returns null with a nonexistent login.code', () => {
   const user = API.getUser('H3LLY34H')
   expect(user).toBe(null)
 })
+
+test('returns matching login code as an array', () => {
+  const codes = API.getMatches()
+  expect(codes).toBeInstanceOf(Array)
+  expect(codes.length).toBe(1)
+})

--- a/api/index.spec.js
+++ b/api/index.spec.js
@@ -1,7 +1,7 @@
 const API = require('./index')
 
 test('returns expected user with correct login.code', () => {
-  const user = API.getUser('ABCD1234')
+  const user = API.getUser('QWER1234')
   expect(user).not.toBe(null)
   expect(user.personal.firstName).toBe('Gabrielle')
   expect(user.personal.lastName).toBe('Roy')

--- a/api/user.json
+++ b/api/user.json
@@ -1,6 +1,6 @@
 {
   "login": {
-    "code": "ABCD1234"
+    "code": "QWER1234"
   },
   "personal": {
     "firstName": "Gabrielle",

--- a/formSchemas.js
+++ b/formSchemas.js
@@ -1,15 +1,21 @@
-const loginSchema = {
-    code: {
-      isLength: {
-        errorMessage: 'Must be 8 characters',
-        options: { min: 8, max: 8 }
-      },
-      isAlphanumeric: {
-          errorMessage: 'Code can only contain letters and numbers'
-      }
-    },
-  }
+const API = require('./api')
 
-  module.exports = {
-    loginSchema
-  }
+const loginSchema = {
+  code: {
+    isLength: {
+      errorMessage: 'Must be 8 characters',
+      options: { min: 8, max: 8 },
+    },
+    isAlphanumeric: {
+      errorMessage: 'Code can only contain letters and numbers',
+    },
+    isIn: {
+      options: [API.getMatches()],
+      errorMessage: 'errors.login.code',
+    },
+  },
+}
+
+module.exports = {
+  loginSchema,
+}

--- a/formSchemas.js
+++ b/formSchemas.js
@@ -11,7 +11,7 @@ const loginSchema = {
     },
     customSanitizer: {
       options: value => {
-        return value.toUpperCase()
+        return value ? value.toUpperCase() : value
       },
     },
     isIn: {

--- a/formSchemas.js
+++ b/formSchemas.js
@@ -3,11 +3,16 @@ const API = require('./api')
 const loginSchema = {
   code: {
     isLength: {
-      errorMessage: 'Must be 8 characters',
+      errorMessage: 'errors.login.length',
       options: { min: 8, max: 8 },
     },
     isAlphanumeric: {
-      errorMessage: 'Code can only contain letters and numbers',
+      errorMessage: 'errors.login.alphanumeric',
+    },
+    customSanitizer: {
+      options: value => {
+        return value.toUpperCase()
+      },
     },
     isIn: {
       options: [API.getMatches()],

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,6 +1,8 @@
 {
-	"This service is to claim tax benefits online.": "This service is to claim tax benefits online.",
-	"Claim tax benefits": "Claim tax benefits",
-	"Please correct the errors on the page": "Please correct the errors on the page",
-	"errors.login.code": "Sorry, login code not recognized."
+  "This service is to claim tax benefits online.": "This service is to claim tax benefits online.",
+  "Claim tax benefits": "Claim tax benefits",
+  "Please correct the errors on the page": "Please correct the errors on the page",
+  "errors.login.length": "Access code must be 8 characters",
+  "errors.login.alphanumeric": "Access code should only contain letters and numbers",
+  "errors.login.code": "Access code not recognized"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,5 +1,6 @@
 {
 	"This service is to claim tax benefits online.": "This service is to claim tax benefits online.",
 	"Claim tax benefits": "Claim tax benefits",
-	"Please correct the errors on the page": "Please correct the errors on the page"
+	"Please correct the errors on the page": "Please correct the errors on the page",
+	"errors.login.code": "Sorry, login code not recognized."
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -2,5 +2,7 @@
   "This service is to claim tax benefits online.": "Ce service consiste à demander des avantages fiscaux en ligne.",
   "Claim tax benefits": "Réclamer des avantages fiscaux",
   "Please correct the errors on the page": "Please correct the errors on the page",
-  "errors.login.code": "Sorry, login code not recognized."
+  "errors.login.length": "Access code must be 8 characters",
+  "errors.login.alphanumeric": "Access code should only contain letters and numbers",
+  "errors.login.code": "Access code not recognized"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,4 +1,6 @@
 {
   "This service is to claim tax benefits online.": "Ce service consiste à demander des avantages fiscaux en ligne.",
-  "Claim tax benefits": "Réclamer des avantages fiscaux"
+  "Claim tax benefits": "Réclamer des avantages fiscaux",
+  "Please correct the errors on the page": "Please correct the errors on the page",
+  "errors.login.code": "Sorry, login code not recognized."
 }

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -1,9 +1,10 @@
 const { validationResult, checkSchema } = require('express-validator')
 const { errorArray2ErrorObject } = require('./../../utils.js')
 const { loginSchema } = require('./../../formSchemas.js')
+const API = require('../../api')
 
 module.exports = function(app) {
-  // redirect from "/login" → "/login/accessCode"
+  // redirect from "/login" → "/login/code"
   app.get('/login', (req, res) => res.redirect('/login/code'))
   app.get('/login/code', (req, res) => res.render('login/code', { data: req.session || {} }))
   app.post('/login/code', checkSchema(loginSchema), postLoginCode)
@@ -27,19 +28,25 @@ const validateRedirect = req => {
 const postLoginCode = (req, res) => {
   const redirect = validateRedirect(req, res)
 
-  //If code is not set, set it to null
-  let accessCode = req.body.code || null
-  req.session.accessCode = accessCode
-
   const errors = validationResult(req)
 
   if (!errors.isEmpty()) {
-    res
+    // clear session
+    req.session = null
+
+    return res
       .status(422)
       .render('login/code', { data: req.session || {}, errors: errorArray2ErrorObject(errors) })
-  } else if (accessCode && redirect) {
-    return res.redirect(redirect)
   }
+
+  let user = API.getUser(req.body.code || null)
+
+  if (!user) {
+    throw new Error(`[POST ${req.path}] user not found for access code "${req.body.code}"`)
+  }
+
+  req.session = user
+  return res.redirect(redirect)
 }
 
 const postSIN = (req, res) => {

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -34,9 +34,10 @@ const postLoginCode = (req, res) => {
     // clear session
     req.session = null
 
-    return res
-      .status(422)
-      .render('login/code', { data: req.session || {}, errors: errorArray2ErrorObject(errors) })
+    return res.status(422).render('login/code', {
+      data: { code: req.body.code } || {},
+      errors: errorArray2ErrorObject(errors),
+    })
   }
 
   let user = API.getUser(req.body.code || null)

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -41,7 +41,7 @@ describe('Test /login responses', () => {
       const $ = cheerio.load(response.text)
       expect($('.error-list__header').text()).toEqual('Please correct the errors on the page')
       expect($('.error-list__list').children()).toHaveLength(1)
-      expect($('.validation-message').text()).toEqual('Must be 8 characters')
+      expect($('.validation-message').text()).toEqual('Access code must be 8 characters')
       expect($('#code').attr('aria-describedby')).toEqual('code_error')
     })
 
@@ -50,7 +50,7 @@ describe('Test /login responses', () => {
         .post('/login/code')
         .send({ redirect: '/' })
       const $ = cheerio.load(response.text)
-      expect($('.validation-message').text()).toEqual('Must be 8 characters')
+      expect($('.validation-message').text()).toEqual('Access code must be 8 characters')
       expect($('#code').attr('aria-describedby')).toEqual('code_error')
     })
   })
@@ -76,12 +76,15 @@ describe('Test /login responses', () => {
     expect(response.statusCode).toBe(422)
   })
 
-  test('it redirects to /login/success if a valid code is provided', async () => {
-    const response = await request(app)
-      .post('/login/code')
-      .send({ code: 'A23XGY12', redirect: '/' })
-    expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toEqual('/')
+  const codes = ['QWER1234', 'qwer1234']
+  codes.map(code => {
+    test(`it redirects if a valid code is provided: "${code}"`, async () => {
+      const response = await request(app)
+        .post('/login/code')
+        .send({ code, redirect: '/' })
+      expect(response.statusCode).toBe(302)
+      expect(response.headers.location).toEqual('/')
+    })
   })
 
   test('it returns a 200 response for /login/success', async () => {

--- a/utils.js
+++ b/utils.js
@@ -13,13 +13,12 @@
   }
 */
 const errorArray2ErrorObject = (errors = []) => {
-    return errors.array({ onlyFirstError: true }).reduce((map, obj) => {
-        map[obj.param] = obj
-        return map
-    }, {})
+  return errors.array({ onlyFirstError: true }).reduce((map, obj) => {
+    map[obj.param] = obj
+    return map
+  }, {})
 }
 
-
-  module.exports = {
-    errorArray2ErrorObject
-  }
+module.exports = {
+  errorArray2ErrorObject,
+}

--- a/views/_includes/errorList.pug
+++ b/views/_includes/errorList.pug
@@ -3,4 +3,4 @@ div.error-list(role='alert')
     ol#formErrors.error-list__list
         each error in errors
             li.error-list__list-item
-                a(class='error-list__link' id=error.param+'_error' href='#'+error.param) #{error.msg}
+                a(class='error-list__link' id=error.param+'_error' href='#'+error.param) #{__(error.msg)}

--- a/views/login/code.pug
+++ b/views/login/code.pug
@@ -14,7 +14,7 @@ block content
     form.pure-form.pure-form-stacked(method='post')
       div
         label(for='code') Personal access code
-        span.pure-form-message For Example: A23XGY12
+        span.pure-form-message For Example: QWER1234
         input.w-3-4#code(class={['has-error']: errors && errors.code} name='code', type='text', value=data.code, autocomplete='off' aria-describedby=(errors && errors.code ? 'code_error' : false))
         if errors
           span.validation-message #{__(errors.code.msg)}

--- a/views/login/code.pug
+++ b/views/login/code.pug
@@ -17,7 +17,7 @@ block content
         span.pure-form-message For Example: A23XGY12
         input.w-3-4#code(class={['has-error']: errors && errors.code} name='code', type='text', value=data.code, autocomplete='off' aria-describedby=(errors && errors.code ? 'code_error' : false))
         if errors
-          span.validation-message #{errors.code.msg}
+          span.validation-message #{__(errors.code.msg)}
 
       div
         details.

--- a/views/login/success.pug
+++ b/views/login/success.pug
@@ -7,9 +7,9 @@ block content
 
   h1 #{title}
 
-  if data.accessCode
-    p Great! Thanks so much!
-    p Your personal access code is “<strong>#{data.accessCode}</strong>”
+  if data.login
+    p Thanks so much, #{data.personal.firstName} #{data.personal.lastName}!
+    p Your personal access code is “<strong>#{data.login.code}</strong>”
   else
     p Whoops, you don’t have an access code.
     p Please return to the start page.


### PR DESCRIPTION
Previously, we were accepting an access code as long as it was formatted correctly and then displaying it on the next page.

Since our app works by accepting a user's access code and then pulling in a bunch of user data, I've changed the access code validation to only work if a matching access code is found (currently there is only one: `QWER1234`), and then user data is inserted into the session. Just to do something with it, I inserted the user's name onto the following 'success' page.  I also updated the hint on the page to give the correct access code, and rewrote a few of the tests.

I've also changed the error messages into dot notation so that we can translate them when the time comes.

## Screenshot

<img width="1552" alt="Screen Shot 2019-07-08 at 9 16 57 AM" src="https://user-images.githubusercontent.com/2454380/60813346-882c1200-a161-11e9-8831-e42f0a12ef2f.png">
