### PR TITLE
Remove pure grids + fix some CSS problems on small phones

### DIFF
--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -31,10 +31,14 @@ h6 {
 }
 
 %page-container {
-  max-width: 1170px;
+  max-width: 960px;
   margin: 0 auto;
   padding-left: $space-md;
   padding-right: $space-md;
+
+  @include xl {
+    max-width: 1170px;
+  }
 }
 
 main {
@@ -48,15 +52,27 @@ main {
 }
 
 header {
-  padding: $space-lg 0 $space-xl 0;
+  padding: $space-xs 0 0 0;
   text-align: left;
   font-size: 2em;
 
   @include sm {
-    .canada-flag {
+    padding: $space-lg 0 $space-xl 0;
+  }
+
+  .canada-flag {
+    width: 272px;
+    @include xs {
+      width: 282px;
+    }
+    @include sm {
       width: 360px;
     }
   }
+}
+
+li:not(:last-of-type) {
+  padding-bottom: $space-xxs;
 }
 
 summary {

--- a/public/scss/_error-list.scss
+++ b/public/scss/_error-list.scss
@@ -1,11 +1,16 @@
 .error-list {
-    padding: $space-sm;
-    background: $color-red-light;
-    border-left: 4px solid $color-red;
+  padding: $space-sm;
+  background: $color-red-light;
+  border-left: 4px solid $color-red;
 
-    &__header {
-        margin-top: $space-xs;
-    }
+  &__header {
+    margin-top: $space-xs;
+  }
+
+  margin-top: $space-sm;
+  @include sm {
+    margin: 0;
+  }
 }
 
 .validation-message {

--- a/public/scss/_footer.scss
+++ b/public/scss/_footer.scss
@@ -16,12 +16,31 @@ footer {
       list-style: none;
       margin: 0;
       padding: 0;
-      margin-bottom: $space-md;
+      margin-bottom: $space-xl;
+
+      @include sm {
+        margin-bottom: $space-md;
+      }
     }
 
     li {
-      display: inline-block;
-      margin-right: $space-md;
+      margin-right: $space-sm;
+
+      &::before {
+        content: '\2022';
+        color: $color-blue-light;
+        display: inline-block;
+        // bullets are about 5px, so add space to compensate
+        width: calc(#{$space-sm} + 5px);
+      }
+
+      @include sm {
+        &:first-of-type::before {
+          content: none;
+          width: 0;
+        }
+        display: inline-block;
+      }
     }
 
     a {
@@ -31,9 +50,10 @@ footer {
 
   .canada-wordmark {
     margin-bottom: $space-md;
+    width: 147.2px;
   }
 
-  @include sm {
+  @include md {
     .page--container {
       display: flex;
       justify-content: space-between;

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -16,7 +16,7 @@
 form.pure-form.pure-form-stacked {
   margin: $space-xl 0;
 
-  > div > div:not(.button-left) {
+  > div:not(.button-left) {
     margin-bottom: $space-lg;
   }
 

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -15,9 +15,30 @@
 
 form.pure-form.pure-form-stacked {
   margin: $space-xl 0;
+  max-width: 300px;
 
+  @include sm {
+    max-width: 400px;
+
+    .w-3-4 {
+      width: 75%;
+    }
+    .w-1-2 {
+      width: 50%;
+    }
+    .w-1-4 {
+      width: 24%;
+    }
+  }
+}
+
+form.pure-form.pure-form-stacked {
   > div:not(.button-left) {
     margin-bottom: $space-lg;
+  }
+
+  .pure-form-message {
+    padding: 0;
   }
 
   label,
@@ -62,12 +83,25 @@ form.pure-form.pure-form-stacked {
     font-family: 'Noto Sans', sans-serif;
   }
 
-  @include sm {
-    .button-left {
-      padding-right: $space-xs;
+  .buttons {
+    display: flex;
+    justify-content: space-between;
+    flex-direction: column;
+
+    .buttons--left,
+    .buttons--right {
+      flex: 1;
     }
-    .button-right {
-      padding-left: $space-xs;
+
+    @include sm {
+      flex-direction: row;
+
+      .buttons--left {
+        margin-right: $space-xs;
+      }
+      .buttons--right {
+        margin-left: $space-xs;
+      }
     }
   }
 }

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -14,7 +14,7 @@
 }
 
 form.pure-form.pure-form-stacked {
-  margin: $space-xl 0;
+  margin-top: $space-xl;
   max-width: 300px;
 
   @include sm {
@@ -33,7 +33,7 @@ form.pure-form.pure-form-stacked {
 }
 
 form.pure-form.pure-form-stacked {
-  > div:not(.button-left) {
+  > div:not(:last-of-type) {
     margin-bottom: $space-lg;
   }
 

--- a/public/scss/_mixins.scss
+++ b/public/scss/_mixins.scss
@@ -13,6 +13,12 @@
     }
 */
 
+/* ≥ 336px */
+@mixin xs {
+  @media screen and (min-width: 21em) {
+    @content;
+  }
+}
 /* ≥ 568px */
 @mixin sm {
   @media screen and (min-width: 35.5em) {

--- a/public/styles.scss
+++ b/public/styles.scss
@@ -2,8 +2,6 @@
 @import '../node_modules/purecss/build/base';
 @import '../node_modules/purecss/build/buttons-core';
 @import '../node_modules/purecss/build/forms';
-@import '../node_modules/purecss/build/grids';
-@import '../node_modules/purecss/build/grids-responsive';
 @import '../node_modules/purecss/build/tables';
 
 /* Utilities */

--- a/views/_includes/footer.pug
+++ b/views/_includes/footer.pug
@@ -8,5 +8,5 @@ footer
           a(href='#') Terms and conditions
         li
           a(href='#') Privacy
-    .canada-wordmark.pure-u-1-4
+    .canada-wordmark
       img(src='/img/wmms-blk.svg', alt='Symbol of the Government of Canada')

--- a/views/base.pug
+++ b/views/base.pug
@@ -23,14 +23,14 @@ html(lang='en')
       header
         .page--container
           //- can also potentially put these as strings in our locales file
-          .canada-flag.pure-u-1-2
+          .canada-flag
             if getLocale() == 'fr'
               img(src='/img/sig-blk-fr.svg', alt='Gouvernement du Canada')
             else
               img(src='/img/sig-blk-en.svg', alt='Government of Canada')
 
       main
-        if errors 
+        if errors
           include _includes/errorList.pug
 
         block content

--- a/views/login/code.pug
+++ b/views/login/code.pug
@@ -13,7 +13,7 @@ block content
         div
           label(for='code') Personal access code
           span.pure-form-message For Example: A23XGY12
-          input#code(class={['has-error']: errors && errors.code} name='code', type='text', value=data.code, autocomplete='off' aria-describedby=(errors && errors.code ? 'code_error' : false))
+          input.w-3-4#code(class={['has-error']: errors && errors.code} name='code', type='text', value=data.code, autocomplete='off' aria-describedby=(errors && errors.code ? 'code_error' : false))
           if errors
             span.validation-message #{errors.code.msg}
 
@@ -24,7 +24,8 @@ block content
 
         input#redirect(name='redirect', type='hidden', value='/login/sin')
 
-        .button-left
-          button(type='submit') Continue
-        .button-right
-          a.button-link.transparent.full-width(href='/clear') Cancel
+        .buttons
+          .buttons--left
+            button(type='submit') Continue
+          .buttons--right
+            a.button-link.transparent.full-width(href='/clear') Cancel

--- a/views/login/code.pug
+++ b/views/login/code.pug
@@ -9,23 +9,23 @@ block content
 
   p Your personal access code is the 8 character code found in your notification letter.
 
-    form.pure-form.pure-form-stacked(method='post')
-        div
-          label(for='code') Personal access code
-          span.pure-form-message For Example: A23XGY12
-          input.w-3-4#code(class={['has-error']: errors && errors.code} name='code', type='text', value=data.code, autocomplete='off' aria-describedby=(errors && errors.code ? 'code_error' : false))
-          if errors
-            span.validation-message #{errors.code.msg}
+  form.pure-form.pure-form-stacked(method='post')
+    div
+      label(for='code') Personal access code
+      span.pure-form-message For Example: A23XGY12
+      input.w-3-4#code(class={['has-error']: errors && errors.code} name='code', type='text', value=data.code, autocomplete='off' aria-describedby=(errors && errors.code ? 'code_error' : false))
+      if errors
+        span.validation-message #{errors.code.msg}
 
-        div
-          details.
-            <summary><span>Help with personal access code</span></summary>
-            <p>Your code is on the personally-addressed letter. It is case insensitive.</p>
+    div
+      details.
+        <summary><span>Help with personal access code</span></summary>
+        <p>Your code is on the personally-addressed letter. It is case insensitive.</p>
 
-        input#redirect(name='redirect', type='hidden', value='/login/sin')
+    input#redirect(name='redirect', type='hidden', value='/login/success')
 
-        .buttons
-          .buttons--left
-            button(type='submit') Continue
-          .buttons--right
-            a.button-link.transparent.full-width(href='/clear') Cancel
+    .buttons
+      .buttons--left
+        button(type='submit') Continue
+      .buttons--right
+        a.button-link.transparent.full-width(href='/clear') Cancel

--- a/views/login/code.pug
+++ b/views/login/code.pug
@@ -10,7 +10,6 @@ block content
   p Your personal access code is the 8 character code found in your notification letter.
 
     form.pure-form.pure-form-stacked(method='post')
-      .pure-u-4-5.pure-u-sm-1-2.pure-u-md-1-3
         div
           label(for='code') Personal access code
           span.pure-form-message For Example: A23XGY12
@@ -25,7 +24,7 @@ block content
 
         input#redirect(name='redirect', type='hidden', value='/login/sin')
 
-        .button-left.pure-u-1.pure-u-sm-1-2
+        .button-left
           button(type='submit') Continue
-        .button-right.pure-u-1.pure-u-sm-1-2
+        .button-right
           a.button-link.transparent.full-width(href='/clear') Cancel

--- a/views/login/sin.pug
+++ b/views/login/sin.pug
@@ -11,21 +11,23 @@ block content
 
   p Please enter your Social Insurance Number (SIN) in the field below.
 
-    form.pure-form.pure-form-stacked(method='post')
-      .pure-u-4-5.pure-u-sm-1-2.pure-u-md-1-3
-        div
-          label(for='sin') Social Insurance Number
-          span.pure-form-message For Example: 123 456 789
-          input#sin(name='sin', type='text', value=data.sin, autocomplete='off')
+  form.pure-form.pure-form-stacked(method='post')
+    div
+      label(for='sin') Social Insurance Number
+      span.pure-form-message For Example: 123 456 789
+      input.w-3-4#sin(class={['has-error']: errors && errors.code} name='sin', type='text', value=data.code, autocomplete='off' aria-describedby=(errors && errors.code ? 'code_error' : false))
+      if errors
+        span.validation-message #{errors.code.msg}
 
-        div
-          details.
-            <summary><span>Help with Social Insurance Number (SIN)</span></summary>
-            <p>This is sample text that should be changed</p>
+    div
+      details.
+        <summary><span>Help with Social Insurance Number (SIN)</span></summary>
+        <p>This is sample text that should be changed</p>
 
-        input#redirect(name='redirect', type='hidden', value='/login/success')
+    input#redirect(name='redirect', type='hidden', value='/login/sin')
 
-        .button-left.pure-u-1.pure-u-sm-1-2
-          button(type='submit') Continue
-        .button-right.pure-u-1.pure-u-sm-1-2
-          a.button-link.transparent.full-width(href='/clear') Cancel
+    .buttons
+      .buttons--left
+        button(type='submit') Continue
+      .buttons--right
+        a.button-link.transparent.full-width(href='/clear') Cancel


### PR DESCRIPTION
I've been using [PureCSS](https://purecss.io) for base styling, and in a few places I was using [Pure Grids](https://purecss.io/grids/) (basically utility classes where you write stuff like `.pure-u-4-5.pure-u-sm-1-2.pure-u-md-1-3`).

I found the grids to be sort of useful initially but then when I was trying to make the footer expand and collapse how you would expect, I found the grids stuff was just a big pain actually. 

So I removed them and then did a bit of an audit of styling issues in the app.

- made the government flag look normal size on small screens
- the spacing between the header and the main title isn't so large anymore on small screens
- list items have some padding underneath
- the footer links have dots separating them like on canada.ca pages ([here's an example](https://www.canada.ca/en/revenue-agency/services/e-services/e-services-businesses/efile-electronic-filers/apply-efile.html))
- the footer links collapse properly on a mobile phone

Should look better on small screens and pure grids is gone.

There is some work to be done separating some of our new CSS but that's for later PRs

## Screenshots

### landing page header

| before | after |
|--------|-------|
|   ![claim-tax-benefits azurewebsites net_start (1)](https://user-images.githubusercontent.com/2454380/60814987-aa735f00-a164-11e9-9436-e363c09d70b8.png)  |   ![localhost_3005_start (4)](https://user-images.githubusercontent.com/2454380/60814991-ac3d2280-a164-11e9-98bc-981be07992b7.png)   |

### login page footer

| before | after |
|--------|-------|
|   ![claim-tax-benefits azurewebsites net_login_code (1)](https://user-images.githubusercontent.com/2454380/60814930-8dd72700-a164-11e9-9d62-27dfb0d414fd.png)    |   ![localhost_3005_login_code (3)](https://user-images.githubusercontent.com/2454380/60814923-8b74cd00-a164-11e9-8214-31d224bf01c1.png)   |





