### PR TITLE
Feature/marital status page

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
     "linebreak-style": 0,
     "quotes": ["error", "single"],
     "comma-dangle": ["error", "always-multiline"],
-    "semi": ["error", "never"]
+    "semi": ["error", "never"],
+    "no-console": "error"
   }
 }

--- a/bin/www
+++ b/bin/www
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable no-console */
 
 /**
  * Module dependencies.

--- a/formSchemas.js
+++ b/formSchemas.js
@@ -38,11 +38,12 @@ const sinSchema = {
   },
 }
 
+//TODO: We'll want to store this array of marital options somewhere. This is temporary. I'll also want to use that later to create the radio buttons dynamically, to avoid having to update multiple files
 const maritalStatusSchema = {
   maritalStatus: {
-    isLength: {
+    isIn: {
       errorMessage: 'errors.maritalStatus.maritalStatus',
-      options: { min: 1 }
+      options: [['Married','Widowed','Divorced','Separated','Single']]
     }
   }
 }

--- a/formSchemas.js
+++ b/formSchemas.js
@@ -21,6 +21,16 @@ const loginSchema = {
   },
 }
 
+const maritalStatusSchema = {
+  maritalStatus: {
+    isLength: {
+      errorMessage: 'errors.maritalStatus.maritalStatus',
+      options: { min: 1 }
+    }
+  }
+}
+
 module.exports = {
   loginSchema,
+  maritalStatusSchema
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,11 +1,12 @@
 {
-  "This service is to claim tax benefits online.": "This service is to claim tax benefits online.",
-  "Claim tax benefits": "Claim tax benefits",
-  "Please correct the errors on the page": "Please correct the errors on the page",
-  "errors.login.length": "Access code must be 8 characters",
-  "errors.login.alphanumeric": "Access code should only contain letters and numbers",
-  "errors.login.code": "Access code not recognized",
-  "errors.login.numericSIN": "Your SIN should only be numbers",
-  "errors.login.lengthSIN": "Your SIN should have 9 numbers",
-  "errors.maritalStatus.maritalStatus": "You must select one of the options below"
+	"This service is to claim tax benefits online.": "This service is to claim tax benefits online.",
+	"Claim tax benefits": "Claim tax benefits",
+	"Please correct the errors on the page": "Please correct the errors on the page",
+	"errors.login.length": "Access code must be 8 characters",
+	"errors.login.alphanumeric": "Access code should only contain letters and numbers",
+	"errors.login.code": "Access code not recognized",
+	"errors.login.numericSIN": "Your SIN should only be numbers",
+	"errors.login.lengthSIN": "Your SIN should have 9 numbers",
+	"errors.maritalStatus.maritalStatus": "You must select one of the options",
+	"Invalid value": "Invalid value"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,8 +1,9 @@
 {
-  "This service is to claim tax benefits online.": "This service is to claim tax benefits online.",
-  "Claim tax benefits": "Claim tax benefits",
-  "Please correct the errors on the page": "Please correct the errors on the page",
-  "errors.login.length": "Access code must be 8 characters",
-  "errors.login.alphanumeric": "Access code should only contain letters and numbers",
-  "errors.login.code": "Access code not recognized"
+	"This service is to claim tax benefits online.": "This service is to claim tax benefits online.",
+	"Claim tax benefits": "Claim tax benefits",
+	"Please correct the errors on the page": "Please correct the errors on the page",
+	"errors.login.length": "Access code must be 8 characters",
+	"errors.login.alphanumeric": "Access code should only contain letters and numbers",
+	"errors.login.code": "Access code not recognized",
+	"errors.maritalStatus.maritalStatus": "You must select one of the options below"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -7,5 +7,5 @@
   "errors.login.code": "Access code not recognized",
   "errors.login.numericSIN": "Votre numéro d'assurance sociale devrait être composer de 9 chiffres",
   "errors.login.lengthSIN": "Your SIN should have 9 numbers",
-  "errors.maritalStatus.maritalStatus": "You must select one of the options below"
+  "errors.maritalStatus.maritalStatus": "You must select one of the options"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -4,5 +4,6 @@
   "Please correct the errors on the page": "Please correct the errors on the page",
   "errors.login.length": "Access code must be 8 characters",
   "errors.login.alphanumeric": "Access code should only contain letters and numbers",
-  "errors.login.code": "Access code not recognized"
+  "errors.login.code": "Access code not recognized",
+  "errors.maritalStatus.maritalStatus": "You must select one of the options below"
 }

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -85,13 +85,23 @@ form.pure-form.pure-form-stacked {
   }
 }
 
+.fieldset {
+  border: 0;
+  padding: 0;
+
+  &__legend {
+    font-weight: 600;
+    font-size: 19px;
+    font-size: 1.1875rem;
+  }
+}
+
 .radios {
   $radioClass: &;
 
   &__item {
-    font-weight: 400;
-    font-size: 16px;
-    font-size: 1rem;
+    font-size: 19px;
+    font-size: 1.1875rem;
     line-height: 1.25;
     display: block;
     position: relative;

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -84,3 +84,71 @@ form.pure-form.pure-form-stacked {
     }
   }
 }
+
+.radios {
+  $radioClass: &;
+
+  &__item {
+    font-weight: 400;
+    font-size: 16px;
+    font-size: 1rem;
+    line-height: 1.25;
+    display: block;
+    position: relative;
+    min-height: 40px;
+    margin-bottom: 10px;
+    padding-left: 40px;
+  }
+
+  &__input {
+    cursor: pointer;
+    position: absolute;
+    z-index: 1;
+    top: -2px;
+    left: -2px;
+    width: 44px;
+    height: 44px;
+    margin: 0;
+    opacity: 0; 
+    
+    &:checked + #{$radioClass}__label::after {
+      opacity: 1;
+    } 
+  }
+
+  &__label {
+    display: inline-block;
+    margin-bottom: 0;
+    padding: 8px 15px 5px;
+    cursor: pointer;
+    -ms-touch-action: manipulation;
+    touch-action: manipulation;
+
+    &::before {
+      content: "";
+      -webkit-box-sizing: border-box;
+      box-sizing: border-box;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 40px;
+      height: 40px;
+      border: 2px solid currentColor;
+      border-radius: 50%;
+      background: transparent;
+    }
+
+    &::after {
+      content: "";
+      position: absolute;
+      top: 10px;
+      left: 10px;
+      width: 0;
+      height: 0;
+      border: 10px solid currentColor;
+      border-radius: 50%;
+      opacity: 0;
+      background: currentColor;
+    }
+  }
+}

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -35,7 +35,7 @@ form.cra-form {
     font-size: inherit;
   }
 
-  label {
+  label:not(.radios__label) {
     font-weight: 700;
     display: block;
   }
@@ -131,6 +131,11 @@ form.cra-form {
     &:checked + #{$radioClass}__label::after {
       opacity: 1;
     } 
+
+    &:focus + #{$radioClass}__label::before {
+      -webkit-box-shadow: 0 0 0 3px $color-yellow;
+      box-shadow: 0 0 0 3px $color-yellow;
+    }
   }
 
   &__label {

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -93,7 +93,13 @@ form.pure-form.pure-form-stacked {
     font-weight: 600;
     font-size: 19px;
     font-size: 1.1875rem;
+    border-bottom: 0;
   }
+}
+
+// add this class because I was fighting pure form too much
+.benefits-form {
+  margin-bottom: $space-xl;
 }
 
 .radios {

--- a/public/scss/_variables.scss
+++ b/public/scss/_variables.scss
@@ -22,5 +22,4 @@ $space-xl: 40px;
 $space-xxl: 60px;
 
 // other vars
-
 $height-footer: 80px;

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -57,10 +57,5 @@ const postSIN = (req, res) => {
   }
 
   //Success, we can redirect to the next page
-  if (sin) {
-    return res.redirect(req.body.redirect)
-  }
-
-  //Sad Trombone
-  res.status(422).render('login/sin', { title: 'Enter your SIN', data: req.session || {} })
+  return res.redirect(req.body.redirect)
 }

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -45,7 +45,7 @@ const postSIN = (req, res) => {
   req.session.sin = sin
 
   //Success, we can redirect to the next page
-  if (sin && redirect) {
+  if (sin) {
     return res.redirect(req.body.redirect)
   }
 

--- a/routes/personal/personal.controller.js
+++ b/routes/personal/personal.controller.js
@@ -4,7 +4,9 @@ const { maritalStatusSchema } = require('./../../formSchemas.js')
 
 module.exports = function(app) {
   app.get('/personal/address', (req, res) => res.render('personal/address'))
-  app.get('/personal/maritalStatus', (req, res) => res.render('personal/maritalStatus'))
+
+  app.get('/personal/maritalStatus', (req, res) => res.render('personal/maritalStatus', { data: req.session || {} }))
+
   app.get('/personal/maritalStatus/edit', (req, res) => res.render('personal/maritalStatus-edit'))
   app.post('/personal/maritalStatus/edit', checkSchema(maritalStatusSchema),validateRedirect, postMaritalStatus)
 }
@@ -13,19 +15,17 @@ const postMaritalStatus = (req, res) => {
 
   const errors = validationResult(req)
 
+  let maritalStatus = req.body.maritalStatus || null
+  req.session.personal = {
+    maritalStatus: maritalStatus,
+  }
+
   if (!errors.isEmpty()) {
     return res.status(422).render('personal/maritalStatus-edit', {
+      data: { maritalStatus: req.body.maritalStatus } || {},
       errors: errorArray2ErrorObject(errors),
     })
   }
 
-  console.log(req.body.maritalStatus)
-  //-TODO: this temporary, until we have user flow in place
-  return res.status(200).render(req.body.redirect, { 
-    data: {
-      personal: {
-        maritalStatus: req.body.maritalStatus,
-      },
-    },
-  })
+  return res.redirect(req.body.redirect)
 }

--- a/routes/personal/personal.controller.js
+++ b/routes/personal/personal.controller.js
@@ -1,5 +1,31 @@
+const { validationResult, checkSchema } = require('express-validator')
+const { errorArray2ErrorObject, validateRedirect } = require('./../../utils.js')
+const { maritalStatusSchema } = require('./../../formSchemas.js')
+
 module.exports = function(app) {
   app.get('/personal/address', (req, res) => res.render('personal/address'))
   app.get('/personal/maritalStatus', (req, res) => res.render('personal/maritalStatus'))
   app.get('/personal/maritalStatus/edit', (req, res) => res.render('personal/maritalStatus-edit'))
+  app.post('/personal/maritalStatus/edit', checkSchema(maritalStatusSchema),validateRedirect, postMaritalStatus)
+}
+
+const postMaritalStatus = (req, res) => {
+
+  const errors = validationResult(req)
+
+  if (!errors.isEmpty()) {
+    return res.status(422).render('personal/maritalStatus-edit', {
+      errors: errorArray2ErrorObject(errors),
+    })
+  }
+
+  console.log(req.body.maritalStatus)
+  //-TODO: this temporary, until we have user flow in place
+  return res.status(200).render(req.body.redirect, { 
+    data: {
+      personal: {
+        maritalStatus: req.body.maritalStatus
+      }
+    } 
+  })
 }

--- a/routes/personal/personal.controller.js
+++ b/routes/personal/personal.controller.js
@@ -1,3 +1,5 @@
 module.exports = function(app) {
   app.get('/personal/address', (req, res) => res.render('personal/address'))
+  app.get('/personal/maritalStatus', (req, res) => res.render('personal/maritalStatus'))
+  app.get('/personal/maritalStatus/edit', (req, res) => res.render('personal/maritalStatus-edit'))
 }

--- a/routes/personal/personal.controller.js
+++ b/routes/personal/personal.controller.js
@@ -24,8 +24,8 @@ const postMaritalStatus = (req, res) => {
   return res.status(200).render(req.body.redirect, { 
     data: {
       personal: {
-        maritalStatus: req.body.maritalStatus
-      }
-    } 
+        maritalStatus: req.body.maritalStatus,
+      },
+    },
   })
 }

--- a/routes/personal/personal.spec.js
+++ b/routes/personal/personal.spec.js
@@ -1,9 +1,43 @@
 const request = require('supertest')
+const cheerio = require('cheerio')
 const app = require('../../app.js')
+const API = require('../../api/index')
 
 describe('Test /[personal] responses', () => {
   test('it returns a 200 response for the /personal/address path', async () => {
     const response = await request(app).get('/personal/address')
     expect(response.statusCode).toBe(200)
+  })
+
+  describe('Test /personal/[maritalStatus] responses', () => {
+    test('it returns a 200 response for the /personal/maritalStatus path', async () => {
+      const response = await request(app).get('/personal/maritalStatus')
+      expect(response.statusCode).toBe(200)
+    })
+
+    test('it has Married selected by default', async () => {
+      const response = await request(app).get('/personal/maritalStatus')
+      const $ = cheerio.load(response.text)
+      expect($('td div').text()).toEqual('Married')
+    })
+
+    test('it returns a 200 response for the /personal/maritalStatus/edit path', async () => {
+      const response = await request(app).get('/personal/maritalStatus/edit')
+      expect(response.statusCode).toBe(200)
+    })
+
+    test('it defaults to Married being checked for /personal/maritalStatus/edit path', async () => {
+      const response = await request(app).get('/personal/maritalStatus/edit')
+      const $ = cheerio.load(response.text)
+      expect($('#maritalStatusMarried').attr('checked')).toEqual('checked')
+    })
+
+    test('it checks the stored marital status by default for /personal/maritalStatus/edit path', async () => {
+      const user = API.getUser('QWER1234') 
+      const response = await request(app).get('/personal/maritalStatus/edit', {data: user})
+      const $ = cheerio.load(response.text)
+      expect($('input[name=maritalStatus]:checked').val().toLowerCase).toEqual(user.personal.maritalStatus.toLowerCase)
+    })
+
   })
 })

--- a/routes/personal/personal.spec.js
+++ b/routes/personal/personal.spec.js
@@ -39,5 +39,22 @@ describe('Test /[personal] responses', () => {
       expect($('input[name=maritalStatus]:checked').val().toLowerCase).toEqual(user.personal.maritalStatus.toLowerCase)
     })
 
+    test('it returns a 422 with no marital status', async () => {
+      const response = await request(app).post('/personal/maritalStatus/edit').send({ redirect: '/personal/maritalStatus'})
+      expect(response.statusCode).toBe(422)
+    })
+
+    test('it returns a 422 with fake marital status', async () => {
+      const response = await request(app).post('/personal/maritalStatus/edit').send({ maritalStatus: 'cat lady', redirect: '/personal/maritalStatus'})
+      expect(response.statusCode).toBe(422)
+    })
+
+    test('it returns a 302 with valid marital status', async () => {
+      const response = await request(app)
+        .post('/personal/maritalStatus/edit')
+        .send({redirect: '/personal/maritalStatus', maritalStatus: 'Widowed'})
+      expect(response.statusCode).toBe(302)
+    })
+
   })
 })

--- a/utils.js
+++ b/utils.js
@@ -19,6 +19,20 @@ const errorArray2ErrorObject = (errors = []) => {
   }, {})
 }
 
+/* Middleware */
+
+//POST functions that handle setting the login data in the session and handle redirecting to the next page or sending an error to the client.
+//Note that this is not the only error validation, see routes defined above.
+const validateRedirect = (req, res, next) => {
+  let redirect = req.body.redirect || null
+  
+  if (!redirect) {
+    throw new Error(`[POST ${req.path}] 'redirect' parameter missing`)
+  }
+  return next()
+}
+
 module.exports = {
   errorArray2ErrorObject,
+  validateRedirect
 }

--- a/views/personal/maritalStatus-edit.pug
+++ b/views/personal/maritalStatus-edit.pug
@@ -12,26 +12,28 @@ block content
 
     checked=(data && data.personal.maritalStatus.toLowerCase()=='married')
 
-  div
-    fieldset.fieldset
-        legend
-            p.fieldset__legend Marital Status
-        .radios
-            .radios__item
-                input.radios__input(id="maritalStatusMarried" name="maritalStatus" type="radio" value="Married or common-law" checked=(data && data.personal.maritalStatus.toLowerCase()=='married' || !data))
-                label.radios__label(for="maritalStatusMarried") Married or common-law
-            .radios__item
-                input.radios__input(id="maritalStatusWidowed" name="maritalStatus" type="radio" value="Widowed" checked=(data && data.personal.maritalStatus.toLowerCase()=='widowed'))
-                label.radios__label(for="maritalStatusWidowed") Widowed
-            .radios__item
-                input.radios__input(id="maritalStatusDivorced" name="maritalStatus" type="radio" value="Divorced" checked=(data && data.personal.maritalStatus.toLowerCase()=='divorced'))
-                label.radios__label(for="maritalStatusDivorced") Divorced
-            .radios__item
-                input.radios__input(id="maritalStatusSeparated" name="maritalStatus" type="radio" value="Separated" checked=(data && data.personal.maritalStatus.toLowerCase()=='separated'))
-                label.radios__label(for="maritalStatusSeparated") Separated
-            .radios__item
-                input.radios__input(id="maritalStatusSingle" name="maritalStatus" type="radio" value="Single" checked=(data && data.personal.maritalStatus.toLowerCase()=='single'))
-                label.radios__label(for="maritalStatusSingle") Single
+
+  form.benefits-form(method='post')
+    div
+        fieldset.fieldset
+            legend.fieldset__legend 
+                p Marital Status
+            .radios
+                .radios__item
+                    input.radios__input(id="maritalStatusMarried" name="maritalStatus" type="radio" value="Married" checked=(data && data.personal.maritalStatus.toLowerCase()=='married' || !data))
+                    label.radios__label(for="maritalStatusMarried") Married or common-law
+                .radios__item
+                    input.radios__input(id="maritalStatusWidowed" name="maritalStatus" type="radio" value="Widowed" checked=(data && data.personal.maritalStatus.toLowerCase()=='widowed'))
+                    label.radios__label(for="maritalStatusWidowed") Widowed
+                .radios__item
+                    input.radios__input(id="maritalStatusDivorced" name="maritalStatus" type="radio" value="Divorced" checked=(data && data.personal.maritalStatus.toLowerCase()=='divorced'))
+                    label.radios__label(for="maritalStatusDivorced") Divorced
+                .radios__item
+                    input.radios__input(id="maritalStatusSeparated" name="maritalStatus" type="radio" value="Separated" checked=(data && data.personal.maritalStatus.toLowerCase()=='separated'))
+                    label.radios__label(for="maritalStatusSeparated") Separated
+                .radios__item
+                    input.radios__input(id="maritalStatusSingle" name="maritalStatus" type="radio" value="Single" checked=(data && data.personal.maritalStatus.toLowerCase()=='single'))
+                    label.radios__label(for="maritalStatusSingle") Single
 
   div
     details.

--- a/views/personal/maritalStatus-edit.pug
+++ b/views/personal/maritalStatus-edit.pug
@@ -10,36 +10,38 @@ block content
   div
     p Please choose the correct status from the options listed below.
 
-    checked=(data && data.personal.maritalStatus.toLowerCase()=='married')
-
-
-  form.benefits-form(method='post')
+  form.cra-form(method='post')
     div
         fieldset.fieldset
             legend.fieldset__legend 
                 p Marital Status
             .radios
                 .radios__item
-                    input.radios__input(id="maritalStatusMarried" name="maritalStatus" type="radio" value="Married" checked=(data && data.personal.maritalStatus.toLowerCase()=='married' || !data))
+                    input.radios__input(id="maritalStatusMarried" name="maritalStatus" type="radio" value="Married" checked=(data && data.personal.maritalStatus.toLowerCase()=='married' || !data) aria-describedby=(errors ? 'maritalStatus_error' : false))
                     label.radios__label(for="maritalStatusMarried") Married or common-law
                 .radios__item
-                    input.radios__input(id="maritalStatusWidowed" name="maritalStatus" type="radio" value="Widowed" checked=(data && data.personal.maritalStatus.toLowerCase()=='widowed'))
+                    input.radios__input(id="maritalStatusWidowed" name="maritalStatus" type="radio" value="Widowed" checked=(data && data.personal.maritalStatus.toLowerCase()=='widowed') aria-describedby=(errors ? 'maritalStatus_error' : false))
                     label.radios__label(for="maritalStatusWidowed") Widowed
                 .radios__item
-                    input.radios__input(id="maritalStatusDivorced" name="maritalStatus" type="radio" value="Divorced" checked=(data && data.personal.maritalStatus.toLowerCase()=='divorced'))
+                    input.radios__input(id="maritalStatusDivorced" name="maritalStatus" type="radio" value="Divorced" checked=(data && data.personal.maritalStatus.toLowerCase()=='divorced') aria-describedby=(errors ? 'maritalStatus_error' : false))
                     label.radios__label(for="maritalStatusDivorced") Divorced
                 .radios__item
-                    input.radios__input(id="maritalStatusSeparated" name="maritalStatus" type="radio" value="Separated" checked=(data && data.personal.maritalStatus.toLowerCase()=='separated'))
+                    input.radios__input(id="maritalStatusSeparated" name="maritalStatus" type="radio" value="Separated" checked=(data && data.personal.maritalStatus.toLowerCase()=='separated') aria-describedby=(errors ? 'maritalStatus_error' : false))
                     label.radios__label(for="maritalStatusSeparated") Separated
                 .radios__item
-                    input.radios__input(id="maritalStatusSingle" name="maritalStatus" type="radio" value="Single" checked=(data && data.personal.maritalStatus.toLowerCase()=='single'))
+                    input.radios__input(id="maritalStatusSingle" name="maritalStatus" type="radio" value="Single" checked=(data && data.personal.maritalStatus.toLowerCase()=='single') aria-describedby=(errors ? 'maritalStatus_error' : false))
                     label.radios__label(for="maritalStatusSingle") Single
+            if errors
+              span.validation-message #{__(errors.maritalStatus.msg)}
+    div
+      details.
+        <summary><span>Help with editing marital status</span></summary>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
 
-  div
-    details.
-      <summary><span>Help with editing marital status</span></summary>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    input#redirect(name='redirect', type='hidden', value='personal/maritalStatus')
 
-  .buttons-row
-    a.button-link(href='/personal/maritalStatus') Change Marital Status
-    a.button-link.transparent(href='/personal/maritalStatus') Cancel
+    .buttons
+      .buttons--left
+        button(type='submit') Change Marital Status
+      .buttons--right
+        a.button-link.transparent(href='/personal/maritalStatus') Cancel

--- a/views/personal/maritalStatus-edit.pug
+++ b/views/personal/maritalStatus-edit.pug
@@ -10,25 +10,27 @@ block content
   div
     p Please choose the correct status from the options listed below.
 
+    checked=(data && data.personal.maritalStatus.toLowerCase()=='married')
+
   div
-    fieldset
+    fieldset.fieldset
         legend
-            p Marital Status
+            p.fieldset__legend Marital Status
         .radios
             .radios__item
-                input.radios__input(id="maritalStatusMarried" name="maritalStatus" type="radio" value="Married or common-law")
+                input.radios__input(id="maritalStatusMarried" name="maritalStatus" type="radio" value="Married or common-law" checked=(data && data.personal.maritalStatus.toLowerCase()=='married' || !data))
                 label.radios__label(for="maritalStatusMarried") Married or common-law
             .radios__item
-                input.radios__input(id="maritalStatusWidowed" name="maritalStatus" type="radio" value="Widowed")
+                input.radios__input(id="maritalStatusWidowed" name="maritalStatus" type="radio" value="Widowed" checked=(data && data.personal.maritalStatus.toLowerCase()=='widowed'))
                 label.radios__label(for="maritalStatusWidowed") Widowed
             .radios__item
-                input.radios__input(id="maritalStatusDivorced" name="maritalStatus" type="radio" value="Divorced")
+                input.radios__input(id="maritalStatusDivorced" name="maritalStatus" type="radio" value="Divorced" checked=(data && data.personal.maritalStatus.toLowerCase()=='divorced'))
                 label.radios__label(for="maritalStatusDivorced") Divorced
             .radios__item
-                input.radios__input(id="maritalStatusSeparated" name="maritalStatus" type="radio" value="Separated")
+                input.radios__input(id="maritalStatusSeparated" name="maritalStatus" type="radio" value="Separated" checked=(data && data.personal.maritalStatus.toLowerCase()=='separated'))
                 label.radios__label(for="maritalStatusSeparated") Separated
             .radios__item
-                input.radios__input(id="maritalStatusSingle" name="maritalStatus" type="radio" value="Single")
+                input.radios__input(id="maritalStatusSingle" name="maritalStatus" type="radio" value="Single" checked=(data && data.personal.maritalStatus.toLowerCase()=='single'))
                 label.radios__label(for="maritalStatusSingle") Single
 
   div
@@ -37,5 +39,5 @@ block content
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
 
   .buttons-row
-    a.button-link(href='#') Change Marital Status
-    a.button-link.transparent(href='#') Cancel
+    a.button-link(href='/personal/maritalStatus') Change Marital Status
+    a.button-link.transparent(href='/personal/maritalStatus') Cancel

--- a/views/personal/maritalStatus-edit.pug
+++ b/views/personal/maritalStatus-edit.pug
@@ -17,20 +17,20 @@ block content
                 p Marital Status
             .radios
                 .radios__item
+                    input.radios__input(id="maritalStatusSingle" name="maritalStatus" type="radio" value="Single" checked=(data && data.personal.maritalStatus.toLowerCase()=='single') aria-describedby=(errors ? 'maritalStatus_error' : false))
+                    label.radios__label(for="maritalStatusSingle") Single
+                .radios__item
                     input.radios__input(id="maritalStatusMarried" name="maritalStatus" type="radio" value="Married" checked=(data && data.personal.maritalStatus.toLowerCase()=='married' || !data) aria-describedby=(errors ? 'maritalStatus_error' : false))
                     label.radios__label(for="maritalStatusMarried") Married or common-law
-                .radios__item
-                    input.radios__input(id="maritalStatusWidowed" name="maritalStatus" type="radio" value="Widowed" checked=(data && data.personal.maritalStatus.toLowerCase()=='widowed') aria-describedby=(errors ? 'maritalStatus_error' : false))
-                    label.radios__label(for="maritalStatusWidowed") Widowed
-                .radios__item
-                    input.radios__input(id="maritalStatusDivorced" name="maritalStatus" type="radio" value="Divorced" checked=(data && data.personal.maritalStatus.toLowerCase()=='divorced') aria-describedby=(errors ? 'maritalStatus_error' : false))
-                    label.radios__label(for="maritalStatusDivorced") Divorced
                 .radios__item
                     input.radios__input(id="maritalStatusSeparated" name="maritalStatus" type="radio" value="Separated" checked=(data && data.personal.maritalStatus.toLowerCase()=='separated') aria-describedby=(errors ? 'maritalStatus_error' : false))
                     label.radios__label(for="maritalStatusSeparated") Separated
                 .radios__item
-                    input.radios__input(id="maritalStatusSingle" name="maritalStatus" type="radio" value="Single" checked=(data && data.personal.maritalStatus.toLowerCase()=='single') aria-describedby=(errors ? 'maritalStatus_error' : false))
-                    label.radios__label(for="maritalStatusSingle") Single
+                    input.radios__input(id="maritalStatusDivorced" name="maritalStatus" type="radio" value="Divorced" checked=(data && data.personal.maritalStatus.toLowerCase()=='divorced') aria-describedby=(errors ? 'maritalStatus_error' : false))
+                    label.radios__label(for="maritalStatusDivorced") Divorced
+                .radios__item
+                    input.radios__input(id="maritalStatusWidowed" name="maritalStatus" type="radio" value="Widowed" checked=(data && data.personal.maritalStatus.toLowerCase()=='widowed') aria-describedby=(errors ? 'maritalStatus_error' : false))
+                    label.radios__label(for="maritalStatusWidowed") Widowed
             if errors
               span.validation-message #{__(errors.maritalStatus.msg)}
     div
@@ -38,7 +38,7 @@ block content
         <summary><span>Help with editing marital status</span></summary>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
 
-    input#redirect(name='redirect', type='hidden', value='personal/maritalStatus')
+    input#redirect(name='redirect', type='hidden', value='/personal/maritalStatus')
 
     .buttons
       .buttons--left

--- a/views/personal/maritalStatus-edit.pug
+++ b/views/personal/maritalStatus-edit.pug
@@ -1,0 +1,41 @@
+extends ../base
+
+block variables
+  -var title = 'Change your Marital Status'
+
+block content
+
+  h1 #{title}
+
+  div
+    p Please choose the correct status from the options listed below.
+
+  div
+    fieldset
+        legend
+            p Marital Status
+        .radios
+            .radios__item
+                input.radios__input(id="maritalStatusMarried" name="maritalStatus" type="radio" value="Married or common-law")
+                label.radios__label(for="maritalStatusMarried") Married or common-law
+            .radios__item
+                input.radios__input(id="maritalStatusWidowed" name="maritalStatus" type="radio" value="Widowed")
+                label.radios__label(for="maritalStatusWidowed") Widowed
+            .radios__item
+                input.radios__input(id="maritalStatusDivorced" name="maritalStatus" type="radio" value="Divorced")
+                label.radios__label(for="maritalStatusDivorced") Divorced
+            .radios__item
+                input.radios__input(id="maritalStatusSeparated" name="maritalStatus" type="radio" value="Separated")
+                label.radios__label(for="maritalStatusSeparated") Separated
+            .radios__item
+                input.radios__input(id="maritalStatusSingle" name="maritalStatus" type="radio" value="Single")
+                label.radios__label(for="maritalStatusSingle") Single
+
+  div
+    details.
+      <summary><span>Help with editing marital status</span></summary>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+
+  .buttons-row
+    a.button-link(href='#') Change Marital Status
+    a.button-link.transparent(href='#') Cancel

--- a/views/personal/maritalStatus.pug
+++ b/views/personal/maritalStatus.pug
@@ -1,0 +1,31 @@
+extends ../base
+
+block variables
+  -var title = 'Confirm your Marital Status'
+
+block content
+
+  h1 #{title}
+
+  div
+    p You can find the marital status we have on file below. Click confirm if this is correct or change it. Having your accurate marital status on file is important for you to properly file your taxes and get your benefits.
+
+  div
+    table.pure-table
+      thead
+        tr
+          th Marital Status
+      tbody
+        tr
+          td
+            div married
+
+  div
+    details.
+      <summary><span>Help with marital status</span></summary>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+
+  .buttons-row
+    a.button-link(href='#') Confirm
+    a.button-link(href='#') Change Marital Status
+    a.button-link.transparent(href='#') Cancel

--- a/views/personal/maritalStatus.pug
+++ b/views/personal/maritalStatus.pug
@@ -21,7 +21,7 @@ block content
             if data && data.personal.maritalStatus
               div #{data.personal.maritalStatus}
             else
-              div N/A
+              div Married
 
   div
     details.

--- a/views/personal/maritalStatus.pug
+++ b/views/personal/maritalStatus.pug
@@ -18,7 +18,10 @@ block content
       tbody
         tr
           td
-            div married
+            if data && data.personal.maritalStatus
+              div #{data.personal.maritalStatus}
+            else
+              div N/A
 
   div
     details.
@@ -27,5 +30,5 @@ block content
 
   .buttons-row
     a.button-link(href='#') Confirm
-    a.button-link(href='#') Change Marital Status
+    a.button-link(href='/personal/maritalStatus/edit') Change Marital Status
     a.button-link.transparent(href='#') Cancel

--- a/views/personal/maritalStatus.pug
+++ b/views/personal/maritalStatus.pug
@@ -18,7 +18,7 @@ block content
       tbody
         tr
           td
-            if data && data.personal.maritalStatus
+            if data && data.personal && data.personal.maritalStatus !== ''
               div #{data.personal.maritalStatus}
             else
               div Married


### PR DESCRIPTION
### Confirm + Edit Marital Status
I went with a pattern of `personal/[personalDetail]/edit` for the edit pages (so `personal/maritalStatus/edit`). Happy to change it if the team thinks we should structure it otherwise!

It doesn't currently pull in from the "API", but it's set up to receive those values.

Added a css "benefits-form" class, because I found I was fighting pure-form for the radio-buttons, but let me know if this is no good!

Edit:
- added focus styles to radio buttons
- added basic validation to the marital status page (this will still need to be update once we have the full user flow)
- moved validateRedirect to utils, to use as middleware

### More Edits:
- Add no-console rule to eslint (Disabled that rule for bin/www since we want console.logs there)
- Updated schema for maritalStatus
- Updated error code for maritalStatus to not say “below”
- Tidied up postSin
- Added some passing of maritalStatus in maritalStatus routes
- Added a few more tests for maritalStatus pages
- Re-ordered radio items

![image](https://user-images.githubusercontent.com/6607541/60846829-a704c580-a1ae-11e9-9b5e-47a1256b87c4.png)

![image](https://user-images.githubusercontent.com/6607541/60846851-bbe15900-a1ae-11e9-89ec-c635839dea87.png)
