### PR TITLE
Remove pure forms classes

### DIFF
--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -1,4 +1,4 @@
-form.pure-form.pure-form-stacked {
+form.cra-form {
   margin-top: $space-xl;
   max-width: 300px;
 
@@ -17,23 +17,27 @@ form.pure-form.pure-form-stacked {
   }
 }
 
-form.pure-form.pure-form-stacked {
+form.cra-form {
   > div:not(:last-of-type) {
     margin-bottom: $space-lg;
   }
 
-  .pure-form-message {
+  .cra-form-message {
+    display: block;
+    color: $color-grey-dark;
     padding: 0;
   }
 
   label,
-  label + span {
+  label + span,
+  input {
     margin: 0 0 $space-xs 0;
     font-size: inherit;
   }
 
   label {
     font-weight: 700;
+    display: block;
   }
 
   input {
@@ -41,16 +45,13 @@ form.pure-form.pure-form-stacked {
     font-size: 1em;
     font-weight: 400;
     width: 100%;
+    margin-top: 0;
     border-radius: 0;
-    -webkit-appearance: none;
-    vertical-align: top;
-  }
-
-  input {
+    display: block;
     height: 40px;
     border: 2px solid $color-black;
-    margin-top: 0;
     padding: $space-xxs;
+    -webkit-appearance: none;
 
     &.has-error {
       border: 2px solid $color-red;

--- a/public/scss/_variables.scss
+++ b/public/scss/_variables.scss
@@ -9,6 +9,7 @@ $color-red: #af3c43;
 $color-red-light: #f3e9e8;
 $color-purple: #7834bc;
 $color-grey-light: #cbcbcb;
+$color-grey-dark: #666666;
 
 // spacing units
 

--- a/public/styles.scss
+++ b/public/styles.scss
@@ -1,7 +1,6 @@
 /* Base styling from pure.css: https://purecss.io/ */
 @import '../node_modules/purecss/build/base';
 @import '../node_modules/purecss/build/buttons-core';
-@import '../node_modules/purecss/build/forms';
 @import '../node_modules/purecss/build/tables';
 
 /* Utilities */

--- a/views/login/code.pug
+++ b/views/login/code.pug
@@ -11,10 +11,10 @@ block content
     p Your personal access code is the 8 character code found in your notification letter.
 
   div
-    form.pure-form.pure-form-stacked(method='post')
+    form.cra-form(method='post')
       div
         label(for='code') Personal access code
-        span.pure-form-message For Example: QWER1234
+        span.cra-form-message For Example: QWER1234
         input.w-3-4#code(class={['has-error']: errors && errors.code} name='code', type='text', value=data.code, autocomplete='off' aria-describedby=(errors && errors.code ? 'code_error' : false))
         if errors
           span.validation-message #{__(errors.code.msg)}

--- a/views/login/sin.pug
+++ b/views/login/sin.pug
@@ -11,10 +11,10 @@ block content
 
   p Please enter your Social Insurance Number (SIN) in the field below.
 
-  form.pure-form.pure-form-stacked(method='post')
+  form.cra-form(method='post')
     div
       label(for='sin') Social Insurance Number
-      span.pure-form-message For Example: 123 456 789
+      span.cra-form-message For Example: 123 456 789
       input.w-3-4#sin(class={['has-error']: errors && errors.code} name='sin', type='text', value=data.code, autocomplete='off' aria-describedby=(errors && errors.code ? 'code_error' : false))
       if errors
         span.validation-message #{errors.code.msg}


### PR DESCRIPTION
Since @katedee mentioned it in #18, and since removing pure grids back in #13, it makes sense to take out the [`.pure-forms` CSS classes](https://purecss.io/forms/).

They were useful in getting some stuff working super fast, but in building the address page, I'm starting to fight against them as well. Added some more CSS where needed to keep our forms (ie, `/login/code` and `/login/sin`) looking the same as earlier, and then removed the "forms" import from the main file.

This PR has no functional changes and (should) have no visible changes either. 