### PR TITLE
[WIP] Feature/Sin looks at user's actual social insurance number

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,8 @@ const express = require('express'),
   sassMiddleware = require('node-sass-middleware'),
   path = require('path'),
   cookieSession = require('cookie-session'),
-  cookieSessionConfig = require('./config/cookieSession.config')
+  cookieSessionConfig = require('./config/cookieSession.config'),
+  { SINFilter } = require('./utils')
 
 // initialize application.
 var app = express()
@@ -59,8 +60,9 @@ app.use(helmet())
 // gzip response body compression.
 app.use(compression())
 
-// Adding GITHUB_SHA to locals so that we can access it in our templates
+// Adding values/functions to app.locals means we can access them in our templates
 app.locals.GITHUB_SHA = process.env.GITHUB_SHA || null
+app.locals.SINFilter = SINFilter
 
 // configure routes
 require('./routes/start/start.controller')(app)

--- a/formSchemas.js
+++ b/formSchemas.js
@@ -36,6 +36,17 @@ const sinSchema = {
     isInt: {
       errorMessage: 'errors.login.numericSIN',
     },
+    custom: {
+      options: (value, { req }) => {
+        /* If there is no session, always return true */
+        if (!req.session || !req.session.personal) {
+          return true
+        }
+
+        return value === req.session.personal.sin
+      },
+      errorMessage: 'errors.login.sin',
+    },
   },
 }
 

--- a/formSchemas.js
+++ b/formSchemas.js
@@ -18,8 +18,9 @@ const loginSchema = {
       options: [API.getMatches()],
       errorMessage: 'errors.login.code',
     },
-  }
+  },
 }
+
 const sinSchema = {
   sin: {
     customSanitizer: {
@@ -43,9 +44,9 @@ const maritalStatusSchema = {
   maritalStatus: {
     isIn: {
       errorMessage: 'errors.maritalStatus.maritalStatus',
-      options: [['Married','Widowed','Divorced','Separated','Single']]
-    }
-  }
+      options: [['Married', 'Widowed', 'Divorced', 'Separated', 'Single']],
+    },
+  },
 }
 
 module.exports = {

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,12 +1,12 @@
 {
-	"This service is to claim tax benefits online.": "This service is to claim tax benefits online.",
-	"Claim tax benefits": "Claim tax benefits",
-	"Please correct the errors on the page": "Please correct the errors on the page",
-	"errors.login.length": "Access code must be 8 characters",
-	"errors.login.alphanumeric": "Access code should only contain letters and numbers",
-	"errors.login.code": "Access code not recognized",
-	"errors.login.numericSIN": "Your SIN should only be numbers",
-	"errors.login.lengthSIN": "Your SIN should have 9 numbers",
-	"errors.maritalStatus.maritalStatus": "You must select one of the options",
-	"Invalid value": "Invalid value"
+  "This service is to claim tax benefits online.": "This service is to claim tax benefits online.",
+  "Claim tax benefits": "Claim tax benefits",
+  "Please correct the errors on the page": "Please correct the errors on the page",
+  "errors.login.length": "Access code must be 8 characters",
+  "errors.login.alphanumeric": "Access code should only contain letters and numbers",
+  "errors.login.code": "Access code not recognized",
+  "errors.login.numericSIN": "Your SIN should only be numbers",
+  "errors.login.lengthSIN": "Your SIN should have 9 numbers",
+  "errors.maritalStatus.maritalStatus": "You must select one of the options",
+  "errors.login.sin": "SIN does not match access code"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -7,5 +7,6 @@
   "errors.login.code": "Access code not recognized",
   "errors.login.numericSIN": "Votre numéro d'assurance sociale devrait être composer de 9 chiffres",
   "errors.login.lengthSIN": "Your SIN should have 9 numbers",
-  "errors.maritalStatus.maritalStatus": "You must select one of the options"
+  "errors.maritalStatus.maritalStatus": "You must select one of the options",
+  "errors.login.sin": "SIN does not match access code"
 }

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -39,7 +39,6 @@ const postLoginCode = (req, res) => {
 }
 
 const postSIN = (req, res) => {
-
   //If sin is not set, set it to null
   let sin = req.body.sin || null
   req.session.sin = sin
@@ -47,9 +46,6 @@ const postSIN = (req, res) => {
   const errors = validationResult(req)
 
   if (!errors.isEmpty()) {
-    // clear session
-    req.session = null
-
     return res.status(422).render('login/sin', {
       data: { sin: req.body.sin } || {},
       errors: errorArray2ErrorObject(errors),

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -43,7 +43,7 @@ const postSIN = (req, res) => {
 
   if (!errors.isEmpty()) {
     return res.status(422).render('login/sin', {
-      data: { sin: req.body.sin } || {},
+      data: { ...req.session, ...{ sin: req.body.sin } } || {},
       errors: errorArray2ErrorObject(errors),
     })
   }

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -1,4 +1,4 @@
-const { body, validationResult, checkSchema } = require('express-validator')
+const { validationResult, checkSchema } = require('express-validator')
 const { errorArray2ErrorObject, validateRedirect } = require('./../../utils.js')
 const { loginSchema, sinSchema } = require('./../../formSchemas.js')
 const API = require('../../api')
@@ -12,18 +12,7 @@ module.exports = function(app) {
 
   //SIN
   app.get('/login/sin', (req, res) => res.render('login/sin', { data: req.session || {} }))
-  app.post(
-    '/login/sin',
-    validateRedirect,
-    checkSchema(sinSchema),
-    body('sin').custom((value, { req }) => {
-      if (value !== req.session.personal.sin) {
-        throw new Error('SIN does not match access code')
-      }
-      return true
-    }),
-    postSIN,
-  )
+  app.post('/login/sin', validateRedirect, checkSchema(sinSchema), postSIN)
 }
 
 const postLoginCode = (req, res) => {
@@ -50,10 +39,6 @@ const postLoginCode = (req, res) => {
 }
 
 const postSIN = (req, res) => {
-  //If sin is not set, set it to null
-  let sin = req.body.sin || null
-  req.session.sin = sin
-
   const errors = validationResult(req)
 
   if (!errors.isEmpty()) {

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -1,4 +1,4 @@
-const { validationResult, checkSchema } = require('express-validator')
+const { body, validationResult, checkSchema } = require('express-validator')
 const { errorArray2ErrorObject, validateRedirect } = require('./../../utils.js')
 const { loginSchema, sinSchema } = require('./../../formSchemas.js')
 const API = require('../../api')
@@ -12,7 +12,18 @@ module.exports = function(app) {
 
   //SIN
   app.get('/login/sin', (req, res) => res.render('login/sin', { data: req.session || {} }))
-  app.post('/login/sin', validateRedirect, checkSchema(sinSchema), postSIN)
+  app.post(
+    '/login/sin',
+    validateRedirect,
+    checkSchema(sinSchema),
+    body('sin').custom((value, { req }) => {
+      if (value !== req.session.personal.sin) {
+        throw new Error('SIN does not match access code')
+      }
+      return true
+    }),
+    postSIN,
+  )
 }
 
 const postLoginCode = (req, res) => {

--- a/utils.js
+++ b/utils.js
@@ -25,14 +25,32 @@ const errorArray2ErrorObject = (errors = []) => {
 //Note that this is not the only error validation, see routes defined above.
 const validateRedirect = (req, res, next) => {
   let redirect = req.body.redirect || null
-  
+
   if (!redirect) {
     throw new Error(`[POST ${req.path}] 'redirect' parameter missing`)
   }
   return next()
 }
 
+/* Pug filters */
+/**
+ * Accepts a string (assumed to be a SIN)
+ * If it is 9 characters long 9, this function returns a string with
+ * a space inserted after the 3rd character and the 6th character
+ *
+ * ie, "111222333" => "111 222 333"
+ *
+ * @param string text a 9-character string assumed to be a social insurance number
+ */
+const SINFilter = text => {
+  if (text.length === 9) {
+    text = text.slice(0, 3) + ' ' + text.slice(3, 6) + ' ' + text.slice(6)
+  }
+  return text
+}
+
 module.exports = {
   errorArray2ErrorObject,
-  validateRedirect
+  validateRedirect,
+  SINFilter,
 }

--- a/views/login/sin.pug
+++ b/views/login/sin.pug
@@ -7,6 +7,9 @@ block content
 
   h1 #{title}
 
+  if data.personal
+    h2 Thanks, #{data.personal.firstName} #{data.personal.lastName}!
+
   p Now that we have your personal code, we need some additional information in order to verify that it’s you.
 
   p Please enter your Social Insurance Number (SIN) in the field below.
@@ -14,7 +17,11 @@ block content
   form.cra-form(method='post')
     div
       label(for='sin') Social Insurance Number
-      span.cra-form-message For Example: 123 456 789
+      if data.personal
+        span.cra-form-message For Example: #{SINFilter(data.personal.sin)}
+      else
+        span.cra-form-message For Example: 123 456 789
+
       input.w-3-4#sin(class={['has-error']: errors && errors.sin} name='sin', type='text', value=data.sin, autocomplete='off' aria-describedby=(errors && errors.sin ? 'sin_error' : false))
       if errors
         span.validation-message #{__(errors.sin.msg)}


### PR DESCRIPTION
Part of the "login" flow means checking the SIN against the actual SIN of the user trying to sign in, not just validating it has the correct format.

Added logic such that:

- if there _is_ a user session, check that the SIN is the correct one
- if there _isn’t_ a user session, just validate the format

I think probably we want to KO the second case at some point soon, but for now we still let people see the SIN page without a real access code, and it will still send them to the success page.

### I also updated updated the SIN page with user's name and SIN in the hint text

Since we're going to be (eventually) creating different user journeys through the application, asking someone demoing the service to enter a correct

- access code
- SIN
- date of birth

is a pretty big lift, even though that's how the app works.

To make it easier, I updated the hint text so that it shows the correct value for the current user.

This is just a "dev" feature, so we will revert to static hint text once we have a live service.

## gif

![sin](https://user-images.githubusercontent.com/2454380/61060701-f45c7f00-a3c8-11e9-8636-bcb15dcfd47a.gif)
