### PR TITLE
Feature/Use user data + make sure it's always there

### DIFF
--- a/api/user.json
+++ b/api/user.json
@@ -6,7 +6,7 @@
     "firstName": "Gabrielle",
     "lastName": "Roy",
     "sin": "111222333",
-    "dob": "1909/03/22",
+    "dateOfBirth": "1909/03/22",
     "address": {
       "aptNumber": "",
       "streetNumber": "375",
@@ -26,7 +26,7 @@
     "firstName": "Marcel",
     "lastName": "Carbotte",
     "sin": "222333444",
-    "dob": "1914/02/09",
+    "dateOfBirth": "1914/02/09",
     "disability": false,
     "netIncome": "$1,000.00"
   },
@@ -34,7 +34,7 @@
     {
       "firstName": "Bernadette",
       "lastName": "Roy",
-      "dob": "1948/09/25",
+      "dateOfBirth": "1948/09/25",
       "disability": false,
       "netIncome": "0",
       "relationship": "child"
@@ -42,7 +42,7 @@
     {
       "firstName": "Clémence",
       "lastName": "Roy",
-      "dob": "1949/10/16",
+      "dateOfBirth": "1949/10/16",
       "disability": false,
       "netIncome": "0",
       "relationship": "child"

--- a/app.js
+++ b/app.js
@@ -13,7 +13,7 @@ const express = require('express'),
   path = require('path'),
   cookieSession = require('cookie-session'),
   cookieSessionConfig = require('./config/cookieSession.config'),
-  { SINFilter, hasData } = require('./utils')
+  { SINFilter, hasData, checkPublic } = require('./utils')
 
 // initialize application.
 var app = express()
@@ -60,6 +60,8 @@ app.use(express.static(path.join(__dirname, 'public')))
 app.use(helmet())
 // gzip response body compression.
 app.use(compression())
+
+app.use(checkPublic)
 
 // Adding values/functions to app.locals means we can access them in our templates
 app.locals.GITHUB_SHA = process.env.GITHUB_SHA || null

--- a/formSchemas.js
+++ b/formSchemas.js
@@ -153,7 +153,7 @@ const isMatchingDoB = {
       return true
     }
 
-    return value === req.session.personal.dob
+    return value === req.session.personal.dateOfBirth
   },
 }
 

--- a/routes/deductions/deductions.controller.js
+++ b/routes/deductions/deductions.controller.js
@@ -27,14 +27,17 @@ const postRRSP = (req, res) => {
     })
   }
 
-  /* TODO: SAVE THIS TO THE SESSION */
   const rrspClaim = req.body.rrspClaim
 
   if (rrspClaim === 'Yes') {
+    req.session.deductions.rrspClaim = true
+
     // It's fine not having this in the form itself (like the other redirect value)
     // because these two pages are hardcoded together
     return res.redirect('/deductions/rrsp/amount')
   }
+
+  req.session.deductions.rrspClaim = false
 
   //Success, we can redirect to the next page
   return res.redirect(req.body.redirect)
@@ -50,7 +53,7 @@ const postRRSPAmount = (req, res) => {
     })
   }
 
-  /* TODO: SAVE THIS TO THE SESSION */
+  req.session.deductions.rrspAmount = req.body.rrspAmount
 
   //Success, we can redirect to the next page
   return res.redirect(req.body.redirect)

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -50,7 +50,8 @@ const postSIN = (req, res) => {
   if (!errors.isEmpty()) {
     return res.status(422).render('login/sin', {
       // the value the user entered never replaces the actual user SIN
-      data: { ...req.session, ...{ sin: req.body.sin } } || {},
+      data: req.session,
+      body: Object.assign({}, req.body),
       errors: errorArray2ErrorObject(errors),
     })
   }

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -8,14 +8,16 @@ module.exports = function(app) {
   app.get('/login', (req, res) => res.redirect('/login/code'))
   app.get('/login/code', (req, res) => res.render('login/code', { data: req.session || {} }))
   app.post('/login/code', validateRedirect, checkSchema(loginSchema), postLoginCode)
-  app.get('/login/success', (req, res) => res.render('login/success', { data: req.session || {} }))
+  app.get('/login/success', (req, res) => res.render('login/success', { data: req.session }))
 
   //SIN
-  app.get('/login/sin', (req, res) => res.render('login/sin', { data: req.session || {} }))
+  app.get('/login/sin', (req, res) => res.render('login/sin', { data: req.session }))
   app.post('/login/sin', validateRedirect, checkSchema(sinSchema), postSIN)
 
   //Date of Birth
-  app.get('/login/dateOfBirth', (req, res) => res.render('login/dateOfBirth', { data: req.session || {} }))
+  app.get('/login/dateOfBirth', (req, res) =>
+    res.render('login/dateOfBirth', { data: req.session || {} }),
+  )
   app.post('/login/dateOfBirth', validateRedirect, checkSchema(birthSchema), postDoB)
 }
 
@@ -47,6 +49,7 @@ const postSIN = (req, res) => {
 
   if (!errors.isEmpty()) {
     return res.status(422).render('login/sin', {
+      // the value the user entered never replaces the actual user SIN
       data: { ...req.session, ...{ sin: req.body.sin } } || {},
       errors: errorArray2ErrorObject(errors),
     })

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -8,17 +8,19 @@ module.exports = function(app) {
   app.get('/login', (req, res) => res.redirect('/login/code'))
   app.get('/login/code', (req, res) => res.render('login/code', { data: req.session || {} }))
   app.post('/login/code', validateRedirect, checkSchema(loginSchema), postLoginCode)
-  app.get('/login/success', (req, res) => res.render('login/success', { data: req.session }))
 
-  //SIN
+  // SIN
   app.get('/login/sin', (req, res) => res.render('login/sin', { data: req.session }))
   app.post('/login/sin', validateRedirect, checkSchema(sinSchema), postSIN)
 
-  //Date of Birth
+  // Date of Birth
   app.get('/login/dateOfBirth', (req, res) =>
     res.render('login/dateOfBirth', { data: req.session || {} }),
   )
   app.post('/login/dateOfBirth', validateRedirect, checkSchema(birthSchema), postDoB)
+
+  // Success page
+  app.get('/login/success', (req, res) => res.render('login/success', { data: req.session }))
 }
 
 const postLoginCode = (req, res) => {
@@ -65,7 +67,8 @@ const postDoB = (req, res) => {
 
   if (!errors.isEmpty()) {
     return res.status(422).render('login/dateOfBirth', {
-      data: { ...req.session, ...{ dob: req.body.dateOfBirth } } || {},
+      data: req.session,
+      body: Object.assign({}, req.body),
       errors: errorArray2ErrorObject(errors),
     })
   }

--- a/routes/personal/personal.controller.js
+++ b/routes/personal/personal.controller.js
@@ -3,7 +3,7 @@ const { errorArray2ErrorObject, validateRedirect } = require('./../../utils')
 const { maritalStatusSchema, addressSchema } = require('./../../formSchemas.js')
 
 module.exports = function(app) {
-  app.get('/personal/name', (req, res) => res.render('personal/name'))
+  app.get('/personal/name', (req, res) => res.render('personal/name', { data: req.session }))
 
   app.get('/personal/address', getAddress)
   app.get('/personal/address/edit', getAddressEdit)

--- a/routes/personal/personal.controller.js
+++ b/routes/personal/personal.controller.js
@@ -30,7 +30,8 @@ const postAddress = (req, res) => {
 
   if (!errors.isEmpty()) {
     return res.status(422).render('personal/address-edit', {
-      data: { ...req.session, ...{ address: req.body } },
+      data: req.session,
+      body: Object.assign({}, req.body),
       errors: errorArray2ErrorObject(errors),
     })
   }

--- a/routes/personal/personal.controller.js
+++ b/routes/personal/personal.controller.js
@@ -33,7 +33,11 @@ const postAddress = (req, res) => {
     })
   }
 
-  req.session.personal.address = req.body
+  // copy all posted parameters, but remove the redirect
+  let addressData = Object.assign({}, req.body)
+  delete addressData.redirect
+
+  req.session.personal.address = addressData
 
   return res.redirect(req.body.redirect)
 }

--- a/routes/personal/personal.controller.js
+++ b/routes/personal/personal.controller.js
@@ -5,7 +5,7 @@ const { maritalStatusSchema, addressSchema } = require('./../../formSchemas.js')
 module.exports = function(app) {
   app.get('/personal/name', (req, res) => res.render('personal/name', { data: req.session }))
 
-  app.get('/personal/address', getAddress)
+  app.get('/personal/address', (req, res) => res.render('personal/address', { data: req.session }))
   app.get('/personal/address/edit', getAddressEdit)
   app.post('/personal/address/edit', validateRedirect, checkSchema(addressSchema), postAddress)
 
@@ -21,29 +21,7 @@ module.exports = function(app) {
   )
 }
 
-/* this is placeholder data until we get the real user info in here */
-const fakeAddress = {
-  aptNumber: '',
-  streetNumber: '375',
-  streetName: 'Rue Deschambault',
-  postalCode: 'R2H 0J9',
-  city: 'Winnipeg',
-  province: 'Manitoba',
-}
-
-const getAddress = (req, res) => {
-  // if no req.session.address, preload the fake address
-  // otherwise, keep the address that's in the session
-  req.session.address = req.session && req.session.address ? req.session.address : fakeAddress
-
-  return res.render('personal/address', { data: req.session })
-}
-
 const getAddressEdit = (req, res) => {
-  // if no req.session.address, preload the fake address
-  // otherwise, keep the address that's in the session
-  req.session.address = req.session && req.session.address ? req.session.address : fakeAddress
-
   return res.render('personal/address-edit', { data: req.session })
 }
 

--- a/routes/personal/personal.controller.js
+++ b/routes/personal/personal.controller.js
@@ -6,7 +6,9 @@ module.exports = function(app) {
   app.get('/personal/name', (req, res) => res.render('personal/name', { data: req.session }))
 
   app.get('/personal/address', (req, res) => res.render('personal/address', { data: req.session }))
-  app.get('/personal/address/edit', getAddressEdit)
+  app.get('/personal/address/edit', (req, res) =>
+    res.render('personal/address-edit', { data: req.session }),
+  )
   app.post('/personal/address/edit', validateRedirect, checkSchema(addressSchema), postAddress)
 
   app.get('/personal/maritalStatus', (req, res) =>
@@ -21,10 +23,6 @@ module.exports = function(app) {
   )
 }
 
-const getAddressEdit = (req, res) => {
-  return res.render('personal/address-edit', { data: req.session })
-}
-
 const postAddress = (req, res) => {
   const errors = validationResult(req)
 
@@ -35,7 +33,7 @@ const postAddress = (req, res) => {
     })
   }
 
-  req.session.address = req.body
+  req.session.personal.address = req.body
 
   return res.redirect(req.body.redirect)
 }

--- a/routes/personal/personal.controller.js
+++ b/routes/personal/personal.controller.js
@@ -14,7 +14,9 @@ module.exports = function(app) {
   app.get('/personal/maritalStatus', (req, res) =>
     res.render('personal/maritalStatus', { data: req.session }),
   )
-  app.get('/personal/maritalStatus/edit', (req, res) => res.render('personal/maritalStatus-edit'))
+  app.get('/personal/maritalStatus/edit', (req, res) =>
+    res.render('personal/maritalStatus-edit', { data: req.session }),
+  )
   app.post(
     '/personal/maritalStatus/edit',
     validateRedirect,
@@ -45,17 +47,14 @@ const postAddress = (req, res) => {
 const postMaritalStatus = (req, res) => {
   const errors = validationResult(req)
 
-  let maritalStatus = req.body.maritalStatus || null
-  req.session.personal = {
-    maritalStatus: maritalStatus,
-  }
-
   if (!errors.isEmpty()) {
     return res.status(422).render('personal/maritalStatus-edit', {
-      data: { maritalStatus: req.body.maritalStatus } || {},
+      data: req.session,
       errors: errorArray2ErrorObject(errors),
     })
   }
+
+  req.session.personal.maritalStatus = req.body.maritalStatus
 
   return res.redirect(req.body.redirect)
 }

--- a/routes/personal/personal.controller.js
+++ b/routes/personal/personal.controller.js
@@ -12,7 +12,7 @@ module.exports = function(app) {
   app.post('/personal/address/edit', validateRedirect, checkSchema(addressSchema), postAddress)
 
   app.get('/personal/maritalStatus', (req, res) =>
-    res.render('personal/maritalStatus', { data: req.session || {} }),
+    res.render('personal/maritalStatus', { data: req.session }),
   )
   app.get('/personal/maritalStatus/edit', (req, res) => res.render('personal/maritalStatus-edit'))
   app.post(

--- a/utils/index.js
+++ b/utils/index.js
@@ -83,8 +83,13 @@ const SINFilter = text => {
  */
 const hasData = (obj, key) => {
   return key.split('.').every(x => {
-    // eslint-disable-next-line no-prototype-builtins
-    if (typeof obj != 'object' || obj === null || !obj.hasOwnProperty(x) || obj[x] === null) {
+    if (
+      typeof obj != 'object' ||
+      obj === null ||
+      !obj.hasOwnProperty(x) || // eslint-disable-line no-prototype-builtins
+      obj[x] === null ||
+      obj[x] === ''
+    ) {
       return false
     }
     obj = obj[x]

--- a/utils/index.js
+++ b/utils/index.js
@@ -50,25 +50,25 @@ const SINFilter = text => {
 }
 
 /**
- * 
  * @param {Object} obj the obj we're passing, most often 'data'
  * @param {String} key the key we're trying to access, passed as a string, not including the obj ref itself
  * ex. if we're trying to get to data.personal.maritalStatus
  * pass as hasData(data, 'personal.maritalStatus')
  */
 const hasData = (obj, key) => {
-  return key.split('.').every((x) => {
-      if(typeof obj != 'object' || obj === null || !obj.hasOwnProperty(x) || obj[x] === null) {
-        return false;
-      }
-      obj = obj[x];
-      return true;
-  });
+  return key.split('.').every(x => {
+    // eslint-disable-next-line no-prototype-builtins
+    if (typeof obj != 'object' || obj === null || !obj.hasOwnProperty(x) || obj[x] === null) {
+      return false
+    }
+    obj = obj[x]
+    return true
+  })
 }
 
 module.exports = {
   errorArray2ErrorObject,
   validateRedirect,
   SINFilter,
-  hasData
+  hasData,
 }

--- a/utils/index.spec.js
+++ b/utils/index.spec.js
@@ -44,6 +44,10 @@ describe('Test hasData function', () => {
     expect(hasData({}, 'personal.address.city')).toBe(false)
   })
 
+  test('returns false for empty string', () => {
+    expect(hasData(user, 'personal.address.aptNumber')).toBe(false)
+  })
+
   test('returns true for disabilityClaim', () => {
     expect(hasData(user, 'deductions.disabilityClaim')).toBe(false)
   })

--- a/views/login/dateOfBirth.pug
+++ b/views/login/dateOfBirth.pug
@@ -17,7 +17,7 @@ block content
     form.cra-form(method='post')
       div(class={['has-error']: errors && errors.dateOfBirth})
         label(for='dateOfBirth') Date of Birth
-        span.cra-form-message For Example: #{data.personal.dob}
+        span.cra-form-message For Example: #{data.personal.dateOfBirth}
         if errors
           +validationMessage(errors.dateOfBirth.msg, 'dateOfBirth')
         input.w-3-4#dateOfBirth(name='dateOfBirth', type='text', value=dateOfBirth, autocomplete='off' aria-describedby=(errors && errors.dateOfBirth ? 'dateOfBirth-error' : false))

--- a/views/login/dateOfBirth.pug
+++ b/views/login/dateOfBirth.pug
@@ -2,13 +2,14 @@ extends ../base
 
 block variables
   -var title = 'Enter your date of birth'
+  -var dateOfBirth = hasData(body, 'dateOfBirth') ? body.dateOfBirth : ''
 
 block content
 
   h1 #{title}
 
   div
-    p Thanks! We just need one more piece of information to authenticate you. 
+    p Thanks! We just need one more piece of information to authenticate you.
 
     p Please enter your date of birth in the field below.
 
@@ -16,20 +17,17 @@ block content
     form.cra-form(method='post')
       div(class={['has-error']: errors && errors.dateOfBirth})
         label(for='dateOfBirth') Date of Birth
-        if hasData(data, 'personal.dob')
-            span.cra-form-message For Example: #{data.personal.dob}
-        else
-            span.cra-form-message For Example: 2018/04/02
+        span.cra-form-message For Example: #{data.personal.dob}
         if errors
-            +validationMessage(errors.dateOfBirth.msg, 'dateOfBirth')
-        input.w-3-4#dateOfBirth(name='dateOfBirth', type='text', value=data.dob, autocomplete='off' aria-describedby=(errors && errors.dateOfBirth ? 'dateOfBirth-error' : false))
+          +validationMessage(errors.dateOfBirth.msg, 'dateOfBirth')
+        input.w-3-4#dateOfBirth(name='dateOfBirth', type='text', value=dateOfBirth, autocomplete='off' aria-describedby=(errors && errors.dateOfBirth ? 'dateOfBirth-error' : false))
 
       div
         details.
           <summary><span>Help with date of birth</span></summary>
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
 
-      input#redirect(name='redirect', type='hidden', value='/login/success')
+      input#redirect(name='redirect', type='hidden', value='/personal/name')
 
       .buttons
         .buttons--left

--- a/views/login/sin.pug
+++ b/views/login/sin.pug
@@ -18,10 +18,7 @@ block content
   form.cra-form(method='post')
     div(class={['has-error']: errors && errors.sin})
       label(for='sin') Social Insurance Number
-      if data.personal
-        span.cra-form-message For Example: #{SINFilter(data.personal.sin)}
-      else
-        span.cra-form-message For Example: 123 456 789
+      span.cra-form-message For Example: #{SINFilter(data.personal.sin)}
       if errors
         +validationMessage(errors.sin.msg, 'sin')
       input.w-3-4#sin(name='sin', type='text', value=sin, autocomplete='off' aria-describedby=(errors && errors.sin ? 'sin-error' : false))

--- a/views/login/sin.pug
+++ b/views/login/sin.pug
@@ -2,6 +2,7 @@ extends ../base
 
 block variables
   -var title = 'Enter your Social Insurance Number (SIN)'
+  -var sin = hasData(body, 'sin') ? body.sin : ''
 
 block content
 
@@ -23,7 +24,7 @@ block content
         span.cra-form-message For Example: 123 456 789
       if errors
         +validationMessage(errors.sin.msg, 'sin')
-      input.w-3-4#sin(name='sin', type='text', value=data.sin, autocomplete='off' aria-describedby=(errors && errors.sin ? 'sin-error' : false))
+      input.w-3-4#sin(name='sin', type='text', value=sin, autocomplete='off' aria-describedby=(errors && errors.sin ? 'sin-error' : false))
 
     div
       details.

--- a/views/personal/address-edit.pug
+++ b/views/personal/address-edit.pug
@@ -2,12 +2,12 @@ extends ../base
 
 block variables
   -var title = 'Change your mailing address'
-  -var aptNumber = hasData(data, 'personal.address.aptNumber') ? data.personal.address.aptNumber : ''
-  -var streetNumber = hasData(data, 'personal.address.streetNumber') ? data.personal.address.streetNumber : ''
-  -var streetName = hasData(data, 'personal.address.streetName') ? data.personal.address.streetName : ''
-  -var city = hasData(data, 'personal.address.city') ? data.personal.address.city : ''
-  -var postalCode = hasData(data, 'personal.address.postalCode') ? data.personal.address.postalCode : ''
-  -var province = hasData(data, 'personal.address.province') ? data.personal.address.province : ''
+  -var aptNumber = hasData(body, 'aptNumber') ? body.aptNumber : hasData(data, 'personal.address.aptNumber') ? data.personal.address.aptNumber : ''
+  -var streetNumber = hasData(body, 'streetNumber') ? body.streetNumber : hasData(data, 'personal.address.streetNumber') ? data.personal.address.streetNumber : ''
+  -var streetName = hasData(body, 'streetName') ? body.streetName : hasData(data, 'personal.address.streetName') ? data.personal.address.streetName : ''
+  -var city = hasData(body, 'city') ? body.city : hasData(data, 'personal.address.city') ? data.personal.address.city : ''
+  -var postalCode = hasData(body, 'postalCode') ? body.postalCode : hasData(data, 'personal.address.postalCode') ? data.personal.address.postalCode : ''
+  -var province = hasData(body, 'province') ? body.province : hasData(data, 'personal.address.province') ? data.personal.address.province : ''
 
 block content
 

--- a/views/personal/address-edit.pug
+++ b/views/personal/address-edit.pug
@@ -2,12 +2,12 @@ extends ../base
 
 block variables
   -var title = 'Change your mailing address'
-  -var aptNumber = hasData(data, 'address.aptNumber') ? data.address.aptNumber : ''
-  -var streetNumber = hasData(data, 'address.streetNumber') ? data.address.streetNumber : ''
-  -var streetName = hasData(data, 'address.streetName') ? data.address.streetName : ''
-  -var city = hasData(data, 'address.city') ? data.address.city : ''
-  -var postalCode = hasData(data, 'address.postalCode') ? data.address.postalCode : ''
-  -var province = hasData(data, 'address.province') ? data.address.province : ''
+  -var aptNumber = hasData(data, 'personal.address.aptNumber') ? data.personal.address.aptNumber : ''
+  -var streetNumber = hasData(data, 'personal.address.streetNumber') ? data.personal.address.streetNumber : ''
+  -var streetName = hasData(data, 'personal.address.streetName') ? data.personal.address.streetName : ''
+  -var city = hasData(data, 'personal.address.city') ? data.personal.address.city : ''
+  -var postalCode = hasData(data, 'personal.address.postalCode') ? data.personal.address.postalCode : ''
+  -var province = hasData(data, 'personal.address.province') ? data.personal.address.province : ''
 
 block content
 

--- a/views/personal/address-edit.pug
+++ b/views/personal/address-edit.pug
@@ -81,4 +81,4 @@ block content
         .buttons--left
           button(type='submit') Change mailing address
         .buttons--right
-          a.button-link.transparent.full-width(href='/clear') Cancel
+          a.button-link.transparent.full-width(href='/personal/address') Cancel

--- a/views/personal/address.pug
+++ b/views/personal/address.pug
@@ -19,12 +19,12 @@ block content
         tr
           td
             .address
-              if data.address.aptNumber
-                div #{data.address.aptNumber}-#{data.address.streetNumber} #{data.address.streetName}
+              if hasData(data, 'personal.address.aptNumber')
+                div #{data.personal.address.aptNumber}-#{data.personal.address.streetNumber} #{data.personal.address.streetName}
               else
-                div #{data.address.streetNumber} #{data.address.streetName}
-              div #{data.address.city}, #{data.address.province}
-              div #{data.address.postalCode}
+                div #{data.personal.address.streetNumber} #{data.personal.address.streetName}
+              div #{data.personal.address.city}, #{data.personal.address.province}
+              div #{data.personal.address.postalCode}
 
   div
     details.
@@ -32,7 +32,7 @@ block content
       <p>Your mailing address can be different than your current residence. What’s important is that you will receive letters sent to this address.</p>
 
   .buttons-row
-    a.button-link(href='#') Confirm
+    a.button-link(href='/personal/maritalStatus') Confirm
     a.button-link(href='/personal/address/edit') Change address
-    a.button-link.transparent(href='#') Cancel
+    a.button-link.transparent(href='/clear') Cancel
 

--- a/views/personal/address.pug
+++ b/views/personal/address.pug
@@ -32,7 +32,7 @@ block content
       <p>Your mailing address can be different than your current residence. What’s important is that you will receive letters sent to this address.</p>
 
   .buttons-row
-    a.button-link(href='/personal/maritalStatus') Confirm
+    a.button-link(href='/deductions/rrsp') Confirm
     a.button-link(href='/personal/address/edit') Change address
     a.button-link.transparent(href='/clear') Cancel
 

--- a/views/personal/maritalStatus-edit.pug
+++ b/views/personal/maritalStatus-edit.pug
@@ -2,6 +2,7 @@ extends ../base
 
 block variables
   -var title = 'Change your marital status'
+  -var maritalStatus = data.personal.maritalStatus
 
 block content
 
@@ -18,19 +19,19 @@ block content
                 if errors
                   +validationMessage(errors.maritalStatus.msg, 'maritalStatus')
                 .radios__item
-                    input.radios__input(id="maritalStatusSingle" name="maritalStatus" type="radio" value="Single" checked=(data && data.personal.maritalStatus.toLowerCase()=='single') aria-describedby=(errors ? 'maritalStatus-error' : false))
+                    input.radios__input(id="maritalStatusSingle" name="maritalStatus" type="radio" value="Single" checked=(maritalStatus.toLowerCase()=='single') aria-describedby=(errors ? 'maritalStatus-error' : false))
                     label.radios__label(for="maritalStatusSingle") Single
                 .radios__item
-                    input.radios__input(id="maritalStatusMarried" name="maritalStatus" type="radio" value="Married" checked=(data && data.personal.maritalStatus.toLowerCase()=='married' || !data) aria-describedby=(errors ? 'maritalStatus-error' : false))
+                    input.radios__input(id="maritalStatusMarried" name="maritalStatus" type="radio" value="Married" checked=(maritalStatus.toLowerCase()=='married' || !data) aria-describedby=(errors ? 'maritalStatus-error' : false))
                     label.radios__label(for="maritalStatusMarried") Married or common-law
                 .radios__item
-                    input.radios__input(id="maritalStatusSeparated" name="maritalStatus" type="radio" value="Separated" checked=(data && data.personal.maritalStatus.toLowerCase()=='separated') aria-describedby=(errors ? 'maritalStatus-error' : false))
+                    input.radios__input(id="maritalStatusSeparated" name="maritalStatus" type="radio" value="Separated" checked=(maritalStatus.toLowerCase()=='separated') aria-describedby=(errors ? 'maritalStatus-error' : false))
                     label.radios__label(for="maritalStatusSeparated") Separated
                 .radios__item
-                    input.radios__input(id="maritalStatusDivorced" name="maritalStatus" type="radio" value="Divorced" checked=(data && data.personal.maritalStatus.toLowerCase()=='divorced') aria-describedby=(errors ? 'maritalStatus-error' : false))
+                    input.radios__input(id="maritalStatusDivorced" name="maritalStatus" type="radio" value="Divorced" checked=(maritalStatus.toLowerCase()=='divorced') aria-describedby=(errors ? 'maritalStatus-error' : false))
                     label.radios__label(for="maritalStatusDivorced") Divorced
                 .radios__item
-                    input.radios__input(id="maritalStatusWidowed" name="maritalStatus" type="radio" value="Widowed" checked=(data && data.personal.maritalStatus.toLowerCase()=='widowed') aria-describedby=(errors ? 'maritalStatus-error' : false))
+                    input.radios__input(id="maritalStatusWidowed" name="maritalStatus" type="radio" value="Widowed" checked=(maritalStatus.toLowerCase()=='widowed') aria-describedby=(errors ? 'maritalStatus-error' : false))
                     label.radios__label(for="maritalStatusWidowed") Widowed
 
     div

--- a/views/personal/maritalStatus.pug
+++ b/views/personal/maritalStatus.pug
@@ -18,10 +18,7 @@ block content
       tbody
         tr
           td
-            if hasData(data, 'personal.maritalStatus')
-              div #{data.personal.maritalStatus}
-            else
-              div Married
+            div #{data.personal.maritalStatus}
 
   div
     details.
@@ -31,4 +28,4 @@ block content
   .buttons-row
     a.button-link(href='#') Confirm
     a.button-link(href='/personal/maritalStatus/edit') Change Marital Status
-    a.button-link.transparent(href='#') Cancel
+    a.button-link.transparent(href='/clear') Cancel

--- a/views/personal/name.pug
+++ b/views/personal/name.pug
@@ -20,7 +20,7 @@ block content
       tbody
         tr
           td
-            div Gabrielle Roy
+            div #{data.personal.firstName} #{data.personal.lastName}
 
   div
     details.
@@ -29,6 +29,6 @@ block content
       <p>Once updated, you can proceed to use this service.</p>
 
   .buttons-row
-    a.button-link(href='#') Confirm
-    a.button-link.transparent(href='#') Cancel
+    a.button-link(href='/personal/address') Confirm
+    a.button-link.transparent(href='/clear') Cancel
 


### PR DESCRIPTION
This is a pretty important one.

**TL;DR**

- Created a new middleware to inject user data into the session for all pages after "/login/code"
- Linked (nearly) all the finished pages together that we've built
- Created a new "body" key in the couple places where we pass user data back into the template

More below, but the point of adding this middleware is that we don't have to fake out data for our pages when we're building them.


##  Add checkPublic middleware to the app

Since we need user data to be in the app for most pages, and since we're rapidly devving, testing, and demoing pages, we should guarantee that we have user data in the session for all the non-public paths.

Once this is handling real user data, we can change this middleware to redirect everyone to the start page if they try to manually go to a URL but haven't signed in. But for right now, it's more useful for us to make sure the session is there rather than locking people out of the app.

A knock-on effect of this is that we can remove a bunch of "if hasData" checks from our templates now and going forward. 

##  Add user-submitted address parameters to the page under the "body" key

Basically the problem is:

- we want to keep the original user address around
- but we want to be able to preserve the value the user typed in instead of just losing it

So by passing it in as "body", we can do both.

The "if" check for setting variables at the beginning of the file
will do:

- use `body[key]` if exists, and isn't null or empty string
- use `data[key]` if exists, and isn't null or empty string
- use ""

It looks really gnarly but I think it's actually a Big Improvement ™.

Also sent the `sin` and `dateOfBirth` back as a "body" key.