### PR TITLE
Feature/Error checking middleware to reduce boilerplate code

### DIFF
--- a/formSchemas.js
+++ b/formSchemas.js
@@ -88,6 +88,11 @@ const validBirthDateLengths = {
   errorMessage: 'errors.login.dateOfBirth.format',
   validate: value => {
     const birthDateSplit = value.split('/')
+
+    if (birthDateSplit.length !== 3) {
+      return false
+    }
+
     return (
       birthDateSplit[0].length === 4 &&
       birthDateSplit[1].length === 2 &&

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -1,5 +1,5 @@
 const { validationResult, checkSchema } = require('express-validator')
-const { errorArray2ErrorObject, validateRedirect } = require('./../../utils')
+const { errorArray2ErrorObject, validateRedirect, checkErrors } = require('./../../utils')
 const { loginSchema, sinSchema, birthSchema } = require('./../../formSchemas.js')
 const API = require('../../api')
 
@@ -11,13 +11,25 @@ module.exports = function(app) {
 
   // SIN
   app.get('/login/sin', (req, res) => res.render('login/sin', { data: req.session }))
-  app.post('/login/sin', validateRedirect, checkSchema(sinSchema), postSIN)
+  app.post(
+    '/login/sin',
+    validateRedirect,
+    checkSchema(sinSchema),
+    checkErrors('login/sin'),
+    postSIN,
+  )
 
   // Date of Birth
   app.get('/login/dateOfBirth', (req, res) =>
     res.render('login/dateOfBirth', { data: req.session || {} }),
   )
-  app.post('/login/dateOfBirth', validateRedirect, checkSchema(birthSchema), postDoB)
+  app.post(
+    '/login/dateOfBirth',
+    validateRedirect,
+    checkSchema(birthSchema),
+    checkErrors('login/dateOfBirth'),
+    postDoB,
+  )
 
   // Success page
   app.get('/login/success', (req, res) => res.render('login/success', { data: req.session }))
@@ -47,32 +59,11 @@ const postLoginCode = (req, res) => {
 }
 
 const postSIN = (req, res) => {
-  const errors = validationResult(req)
-
-  if (!errors.isEmpty()) {
-    return res.status(422).render('login/sin', {
-      // the value the user entered never replaces the actual user SIN
-      data: req.session,
-      body: Object.assign({}, req.body),
-      errors: errorArray2ErrorObject(errors),
-    })
-  }
-
   //Success, we can redirect to the next page
   return res.redirect(req.body.redirect)
 }
 
 const postDoB = (req, res) => {
-  const errors = validationResult(req)
-
-  if (!errors.isEmpty()) {
-    return res.status(422).render('login/dateOfBirth', {
-      data: req.session,
-      body: Object.assign({}, req.body),
-      errors: errorArray2ErrorObject(errors),
-    })
-  }
-
   //Success, we can redirect to the next page
   return res.redirect(req.body.redirect)
 }

--- a/routes/personal/personal.controller.js
+++ b/routes/personal/personal.controller.js
@@ -1,6 +1,6 @@
-const { validationResult, checkSchema } = require('express-validator')
-const { errorArray2ErrorObject, validateRedirect } = require('./../../utils')
-const { maritalStatusSchema, residenceSchema, addressSchema } = require('./../../formSchemas.js')
+const { checkSchema } = require('express-validator')
+const { validateRedirect, checkErrors } = require('./../../utils')
+const { maritalStatusSchema, addressSchema, residenceSchema } = require('./../../formSchemas.js')
 
 module.exports = function(app) {
   app.get('/personal/name', (req, res) => res.render('personal/name', { data: req.session }))
@@ -9,13 +9,20 @@ module.exports = function(app) {
   app.get('/personal/address/edit', (req, res) =>
     res.render('personal/address-edit', { data: req.session }),
   )
-  app.post('/personal/address/edit', validateRedirect, checkSchema(addressSchema), postAddress)
+  app.post(
+    '/personal/address/edit',
+    validateRedirect,
+    checkSchema(addressSchema),
+    checkErrors('personal/address-edit'),
+    postAddress,
+  )
 
   app.get('/personal/residence', (req, res) => res.render('personal/residence'))
   app.post(
     '/personal/residence',
     validateRedirect,
     checkSchema(residenceSchema),
+    checkErrors('personal/residence'),
     postResidence,
   )
 
@@ -29,21 +36,12 @@ module.exports = function(app) {
     '/personal/maritalStatus/edit',
     validateRedirect,
     checkSchema(maritalStatusSchema),
+    checkErrors('personal/maritalStatus-edit'),
     postMaritalStatus,
   )
 }
 
 const postAddress = (req, res) => {
-  const errors = validationResult(req)
-
-  if (!errors.isEmpty()) {
-    return res.status(422).render('personal/address-edit', {
-      data: req.session,
-      body: Object.assign({}, req.body),
-      errors: errorArray2ErrorObject(errors),
-    })
-  }
-
   // copy all posted parameters, but remove the redirect
   let addressData = Object.assign({}, req.body)
   delete addressData.redirect
@@ -54,33 +52,16 @@ const postAddress = (req, res) => {
 }
 
 const postMaritalStatus = (req, res) => {
-  const errors = validationResult(req)
-
-  if (!errors.isEmpty()) {
-    return res.status(422).render('personal/maritalStatus-edit', {
-      data: req.session,
-      errors: errorArray2ErrorObject(errors),
-    })
-  }
-
   req.session.personal.maritalStatus = req.body.maritalStatus
 
   return res.redirect(req.body.redirect)
 }
 
 const postResidence = (req, res) => {
-  const errors = validationResult(req)
-
-  if (!errors.isEmpty()) {
-    return res.status(422).render('personal/residence', {
-      data: { residence: req.body.residence } || {},
-      errors: errorArray2ErrorObject(errors),
-    })
+  if (req.body.residence !== 'Yes') {
+    /* TODO: Point this at the offboarding page */
+    return res.redirect('/start')
   }
 
-  if (req.body.residence !== 'Yes') {
-    return res.redirect('/start')
-  } 
-
-  return res.redirect(req.body.redirect)  
+  return res.redirect(req.body.redirect)
 }


### PR DESCRIPTION
@katedee, what do you think? 

## Reduce boilerplate by putting error checking in middleware

Since most of our error checks are pretty similar, I built out a middleware that runs through the error check. If it finds an error, it 

- returns a `422` status
- passes in the session as `data`
- passes in any request parameters as `body`
- passes in the errors as `errors`

## Add extra check to birthdate format validation

Found a wee bug and added a check.

Previously, if the value was coming back like "1909", then the birthdate array wouldn't have a 2nd or 3rd entry, and then calling `birthDateSplit[1].length` would return the error message "can't call length on undefined".
