### PR TITLE
Feature/Add auth page before editing personal information

### DIFF
--- a/api/user.json
+++ b/api/user.json
@@ -1,6 +1,7 @@
 {
   "login": {
-    "code": "QWER1234"
+    "code": "QWER1234",
+    "auth": false
   },
   "personal": {
     "firstName": "Gabrielle",

--- a/formSchemas.js
+++ b/formSchemas.js
@@ -273,7 +273,16 @@ const residenceSchema = {
   residence: {
     isIn: {
       errorMessage: 'errors.residence',
-      options: [[ 'Yes' , 'No' ]],
+      options: [['Yes', 'No']],
+    },
+  },
+}
+
+const authSchema = {
+  auth: {
+    isCurrency: {
+      errorMessage: 'errors.auth',
+      options: { allow_negatives: false },
     },
   },
 }
@@ -287,4 +296,5 @@ module.exports = {
   birthSchema,
   rrspSchema,
   rrspAmountSchema,
+  authSchema,
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -26,5 +26,6 @@
   "errors.rrspClaim": "You must select one of the options",
   "errors.rrspAmount": "Enter a dollar amount higher than 0, like 120.00",
   "errors.address.province.province": "errors.address.province.province",
-  "errors.residence": "You must select one of the options"
+  "errors.residence": "You must select one of the options",
+  "errors.auth": "Enter a dollar amount higher than 0, like 120.00"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -24,5 +24,6 @@
   "errors.address.postalCode.format": "Postal code is incorrect format",
   "errors.address.province": "Please select a valid province",
   "errors.rrspClaim": "You must select one of the options",
-  "errors.rrspAmount": "Enter a dollar amount higher than 0, like 120.00"
+  "errors.rrspAmount": "Enter a dollar amount higher than 0, like 120.00",
+  "errors.auth": "Enter a dollar amount higher than 0, like 120.00"
 }

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -88,5 +88,10 @@ const postAuth = (req, res) => {
   // set "auth" to true
   req.session.login.auth = true
 
-  return res.redirect(decodeURIComponent(req.query.redirect))
+  let redirect = decodeURIComponent(req.query.redirect)
+  if (!redirect.startsWith('/')) {
+    throw new Error(`[POST ${req.path}] can only redirect to relative URLs`)
+  }
+
+  return res.redirect(redirect)
 }

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -1,6 +1,6 @@
 const { validationResult, checkSchema } = require('express-validator')
 const { errorArray2ErrorObject, validateRedirect, checkErrors } = require('./../../utils')
-const { loginSchema, sinSchema, birthSchema } = require('./../../formSchemas.js')
+const { loginSchema, sinSchema, birthSchema, authSchema } = require('./../../formSchemas.js')
 const API = require('../../api')
 
 module.exports = function(app) {
@@ -21,7 +21,7 @@ module.exports = function(app) {
 
   // Date of Birth
   app.get('/login/dateOfBirth', (req, res) =>
-    res.render('login/dateOfBirth', { data: req.session || {} }),
+    res.render('login/dateOfBirth', { data: req.session }),
   )
   app.post(
     '/login/dateOfBirth',
@@ -32,7 +32,8 @@ module.exports = function(app) {
   )
 
   // Auth page
-  app.get('/login/auth', (req, res) => res.render('login/auth', { data: { redirect: '/start' } }))
+  app.get('/login/auth', getAuth)
+  app.post('/login/auth', checkSchema(authSchema), checkErrors('login/auth'), postAuth)
 
   // Success page
   app.get('/login/success', (req, res) => res.render('login/success', { data: req.session }))
@@ -69,4 +70,23 @@ const postSIN = (req, res) => {
 const postDoB = (req, res) => {
   //Success, we can redirect to the next page
   return res.redirect(req.body.redirect)
+}
+
+const getAuth = (req, res) => {
+  if (!req.query.redirect) {
+    return res.redirect('/start')
+  }
+
+  return res.render('login/auth', { data: req.session })
+}
+
+const postAuth = (req, res) => {
+  if (!req.query.redirect) {
+    return res.redirect('/start')
+  }
+
+  // set "auth" to true
+  req.session.login.auth = true
+
+  return res.redirect(decodeURIComponent(req.query.redirect))
 }

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -31,6 +31,9 @@ module.exports = function(app) {
     postDoB,
   )
 
+  // Auth page
+  app.get('/login/auth', (req, res) => res.render('login/auth', { data: { redirect: '/start' } }))
+
   // Success page
   app.get('/login/success', (req, res) => res.render('login/success', { data: req.session }))
 }

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -213,10 +213,12 @@ describe('Test /login responses', () => {
     const month = currentDate.getMonth()
     const day = currentDate.getDate()
 
-    const dateToString = (dateInput) => {
-      const add0 = (s) => { return (s < 10) ? '0' + s : s }
-      const d= new Date(dateInput)
-      return [d.getFullYear(),add0(d.getMonth()+1), add0(d.getDate())].join('/')
+    const dateToString = dateInput => {
+      const add0 = s => {
+        return s < 10 ? '0' + s : s
+      }
+      const d = new Date(dateInput)
+      return [d.getFullYear(), add0(d.getMonth() + 1), add0(d.getDate())].join('/')
     }
 
     const fewMonthsAgo = dateToString(new Date(year, month - 3, day))
@@ -334,10 +336,10 @@ describe('Test /login responses', () => {
       const response = await authSession
         .post('/login/code')
         .send({ code: 'QWER1234', redirect: '/login/sin' })
-        .then( () => {
+        .then(() => {
           return authSession
             .post('/login/sin')
-            .send({ code: 'QWER1234', sin:'111222333', redirect: '/login/dateOfBirth' })
+            .send({ code: 'QWER1234', sin: '111222333', redirect: '/login/dateOfBirth' })
         })
       expect(response.statusCode).toBe(302)
     })
@@ -354,6 +356,13 @@ describe('Test /login responses', () => {
         .post('/login/dateOfBirth')
         .send({ dateOfBirth: '1909/03/22', redirect: '/login/success' })
       expect(response.statusCode).toBe(302)
+    })
+  })
+
+  describe('Test /login/auth responses', () => {
+    test('it returns a 200 response for /login/auth', async () => {
+      const response = await request(app).get('/login/auth')
+      expect(response.statusCode).toBe(200)
     })
   })
 })

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -360,8 +360,14 @@ describe('Test /login responses', () => {
   })
 
   describe('Test /login/auth responses', () => {
-    test('it returns a 200 response for /login/auth', async () => {
+    test('it returns a 302 response to the start page when no "redirect" query parameter', async () => {
       const response = await request(app).get('/login/auth')
+      expect(response.statusCode).toBe(302)
+      expect(response.headers.location).toEqual('/start')
+    })
+
+    test('it returns a 200 response when containing a "redirect" query parameter', async () => {
+      const response = await request(app).get('/login/auth?redirect=%2Fstart')
       expect(response.statusCode).toBe(200)
     })
   })

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -367,8 +367,42 @@ describe('Test /login responses', () => {
     })
 
     test('it returns a 200 response when containing a "redirect" query parameter', async () => {
-      const response = await request(app).get('/login/auth?redirect=%2Fstart')
+      const response = await request(app).get('/login/auth?redirect=%2Furl')
       expect(response.statusCode).toBe(200)
+    })
+
+    test('it returns a 422 response for no posted value', async () => {
+      const response = await request(app).post('/login/auth')
+      expect(response.statusCode).toBe(422)
+    })
+
+    const badAuths = ['', null, 'dinosaur', '10.0', '10.000', '-10', '.1']
+    badAuths.map(auth => {
+      test(`it returns a 422 for a bad posted value: "${auth}"`, async () => {
+        const response = await request(app)
+          .post('/login/auth')
+          .send({ auth })
+        expect(response.statusCode).toBe(422)
+      })
+    })
+
+    const goodAuths = ['0', '10', '10.00', '.10']
+    goodAuths.map(auth => {
+      test(`it returns a 302 for a good posted value: "${auth}"`, async () => {
+        const response = await request(app)
+          .post('/login/auth?redirect=%2Furl')
+          .send({ auth })
+        expect(response.statusCode).toBe(302)
+        expect(response.headers.location).toEqual('/url')
+      })
+    })
+
+    test('it returns a 302 response to the start page when posting a good value but no "redirect" query parameter', async () => {
+      const response = await request(app)
+        .post('/login/auth')
+        .send({ auth: '10.00' })
+      expect(response.statusCode).toBe(302)
+      expect(response.headers.location).toEqual('/start')
     })
   })
 })

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -404,5 +404,18 @@ describe('Test /login responses', () => {
       expect(response.statusCode).toBe(302)
       expect(response.headers.location).toEqual('/start')
     })
+
+    const badRedirects = ['https%3A%2F%2Fevilcompany.com', 'evilcompany.com']
+    badRedirects.map(redirect => {
+      test(`it throws a 500 error for a non-relative "redirect" query parameter link: "${redirect}"`, async () => {
+        const response = await request(app)
+          .post(`/login/auth?redirect=${redirect}`)
+          .send({ auth: '10.00' })
+        expect(response.statusCode).toBe(500)
+        expect(response.text).toMatch(
+          'Error: [POST /login/auth] can only redirect to relative URLs',
+        )
+      })
+    })
   })
 })

--- a/routes/personal/personal.controller.js
+++ b/routes/personal/personal.controller.js
@@ -1,16 +1,17 @@
 const { checkSchema } = require('express-validator')
-const { validateRedirect, checkErrors } = require('./../../utils')
+const { validateRedirect, checkErrors, doAuth } = require('./../../utils')
 const { maritalStatusSchema, addressSchema, residenceSchema } = require('./../../formSchemas.js')
 
 module.exports = function(app) {
   app.get('/personal/name', (req, res) => res.render('personal/name', { data: req.session }))
 
   app.get('/personal/address', (req, res) => res.render('personal/address', { data: req.session }))
-  app.get('/personal/address/edit', (req, res) =>
+  app.get('/personal/address/edit', doAuth, (req, res) =>
     res.render('personal/address-edit', { data: req.session }),
   )
   app.post(
     '/personal/address/edit',
+    doAuth,
     validateRedirect,
     checkSchema(addressSchema),
     checkErrors('personal/address-edit'),
@@ -29,11 +30,12 @@ module.exports = function(app) {
   app.get('/personal/maritalStatus', (req, res) =>
     res.render('personal/maritalStatus', { data: req.session }),
   )
-  app.get('/personal/maritalStatus/edit', (req, res) =>
+  app.get('/personal/maritalStatus/edit', doAuth, (req, res) =>
     res.render('personal/maritalStatus-edit', { data: req.session }),
   )
   app.post(
     '/personal/maritalStatus/edit',
+    doAuth,
     validateRedirect,
     checkSchema(maritalStatusSchema),
     checkErrors('personal/maritalStatus-edit'),

--- a/utils/index.js
+++ b/utils/index.js
@@ -49,6 +49,36 @@ const checkPublic = function(req, res, next) {
 }
 
 /**
+ * This request middleware is used to add an "auth" step to some of our pages
+ *
+ * If we are visiting one of our edit pages, we want to ask users
+ * another question before we let them edit their info.
+ *
+ * This means that we want to show the /login/auth page the first time, but not afterwards
+ *
+ * We don't want to show the /login/auth page if
+ *
+ * - we're running tests
+ * - we have already set "auth" to true
+ *
+ * Otherwise, we redirect to the /login/auth page and put the redirect query in the URL
+ */
+const doAuth = function(req, res, next) {
+  // if running tests, do nothing
+  if (process.env.NODE_ENV === 'test') {
+    return next()
+  }
+
+  // go to original url if "auth" is truthy
+  const { login: { auth = null } = {} } = req.session
+  if (auth) {
+    return next()
+  }
+
+  return res.redirect(`/login/auth?redirect=${encodeURIComponent(req.path)}`)
+}
+
+/**
  * Middleware function that runs our error validation
  *
  * Since returning our errors is looking like a lot of boilerplate code, this function:
@@ -140,6 +170,7 @@ module.exports = {
   errorArray2ErrorObject,
   validateRedirect,
   checkErrors,
+  doAuth,
   SINFilter,
   hasData,
   checkPublic,

--- a/views/login/auth.pug
+++ b/views/login/auth.pug
@@ -1,0 +1,32 @@
+extends ../base
+
+block variables
+  -var title = 'Confirm your most recent benefit payment'
+
+block content
+
+  h1 #{title}
+
+  div
+    p Before we can update your information, we need to ask a further question to verify your identity.
+
+    p Please enter the most recent benefit payment you received. If it matches our records, you will be able to update your information on the next page.
+
+  form.cra-form(method='post')
+    div(class={['has-error']: errors && errors.auth})
+      label#auth__label(for='auth') Enter your most recent benefit payment
+      if errors
+        +validationMessage(errors.auth.msg, 'auth')
+      span#auth__unit.input-with-unit__unit(for='auth') $
+      input.w-1-2.input-with-unit#auth(name='auth', type='text', placeholder="0.00", autocomplete='off' aria-describedby=(errors && errors.auth ? 'auth-error' : false) aria-labelledby="auth__label auth__unit")
+
+    div
+      details.
+        <summary><span>Help with knowledge based question</span></summary>
+        <p>This is necessary to protect your information from unscrupulous individuals.</p>
+
+    .buttons
+      .buttons--left
+        button(type='submit') Continue
+      .buttons--right
+        a.button-link.transparent.full-width(href='/clear') Cancel


### PR DESCRIPTION
## Add another authentication step before changing name or address

One of the things we discussed with the authentication team at CRA was that we would use a layered security approach where we ask people another knowledge based question when they want to make a big change to their info, like changing an address or marital status. 

Adding some middleware that achieves this behaviour.

Expected behaviour

- if someone clicks "change address" or "change marital status", they see the /login/auth page
- they have to give any number, but not random characters and not empty
- once they answer, they can change address / name
- next time they want to edit something, they don't see the screen

Note: since it doesn't matter what their expected benefit is, I don't have any check for a precise number. I just wanted to show a flow in which you have to answer an additional question.

## Use query parameter to redirect

Since the auth page has to redirect to another page that we don't know ahead of time (all of our other redirects are hardcoded), I put the redirect URL as a query parameter. None of our other pages work like this, and at this point, I don't think any of them will have to. The auth page is unique. 

So that we can't be used for phishing people (it's a long shot, but you know), I also added a check that the redirect query parameter must start with a slash (ie, a relative link: `/start` or `/personal/address/edit`), which means we can't use absolute links like `https://google.com` in there.

## gif

![auth](https://user-images.githubusercontent.com/2454380/61297433-3e1ede00-a7aa-11e9-8eda-f2a2d5c3b2d5.gif)
