### PR TITLE
Feature/offramp page

### DIFF
--- a/app.js
+++ b/app.js
@@ -77,6 +77,7 @@ require('./routes/dependants/dependants.controller')(app)
 require('./routes/partner/partner.controller')(app)
 require('./routes/financial/financial.controller')(app)
 require('./routes/confirmation/confirmation.controller')(app)
+require('./routes/offramp/offramp.controller')(app)
 
 // clear session
 app.get('/clear', (req, res) => {

--- a/public/scss/_variables.scss
+++ b/public/scss/_variables.scss
@@ -2,6 +2,8 @@
 
 $color-blue-dark: #284162;
 $color-blue-light: #335075;
+$color-banner-blue: #4B98B2;
+$color-banner-blue-light: #DFF8FD;
 $color-yellow: #ffbf47;
 $color-white: #ffffff;
 $color-black: #000000;

--- a/public/scss/components/_banners.scss
+++ b/public/scss/components/_banners.scss
@@ -4,6 +4,16 @@
     padding: $space-md;
     padding-left: $space-xxl;
 
+    p {
+        &:nth-child(2) {
+            margin-top: 0;
+        }
+
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+
     &__icon {
         width: 25px;
         height: 25px;

--- a/public/scss/components/_banners.scss
+++ b/public/scss/components/_banners.scss
@@ -1,0 +1,31 @@
+.banner {
+    width: 100%;
+    position: relative;
+    padding: $space-md;
+    padding-left: $space-xxl;
+
+    &__icon {
+        width: 25px;
+        height: 25px;
+        display: inline-block;
+        border-radius: 50%;
+        text-align: center;
+        font-size: 16px;
+        font-weight: 700;
+        color: $color-white;
+        line-height: 1;
+        padding-top: 4px;
+        position: absolute;
+        top: 20px;
+        left: 20px;
+    }
+
+    &--blue {
+        background: $color-banner-blue-light;
+        border-left: 5px solid $color-banner-blue;
+
+        &__icon {
+            background: $color-banner-blue;
+        }
+    }
+}

--- a/public/styles.scss
+++ b/public/styles.scss
@@ -18,3 +18,4 @@
 @import './scss/components/_footer';
 @import './scss/components/_header';
 @import './scss/components/_radios';
+@import './scss/components/_banners';

--- a/routes/offramp/offramp.controller.js
+++ b/routes/offramp/offramp.controller.js
@@ -1,5 +1,5 @@
 module.exports = function(app) {
-    app.get('/offramp', (req, res) =>
-      res.render('offramp/offramp', { data: req.session }),
-    )
+  app.get('/offramp', (req, res) =>
+    res.render('offramp/offramp', { data: req.session }),
+  )
 }

--- a/routes/offramp/offramp.controller.js
+++ b/routes/offramp/offramp.controller.js
@@ -1,0 +1,5 @@
+module.exports = function(app) {
+    app.get('/offramp', (req, res) =>
+      res.render('offramp/offramp', { data: req.session }),
+    )
+}

--- a/routes/offramp/offramp.spec.js
+++ b/routes/offramp/offramp.spec.js
@@ -1,0 +1,9 @@
+const request = require('supertest')
+const app = require('../../app.js')
+
+describe('Test /offramp response', () => {
+  test('it returns a 200 response for /offramp', async () => {
+    const response = await request(app).get('/offramp')
+    expect(response.statusCode).toBe(200)
+  })
+})

--- a/routes/personal/personal.controller.js
+++ b/routes/personal/personal.controller.js
@@ -59,8 +59,7 @@ const postMaritalStatus = (req, res) => {
 
 const postResidence = (req, res) => {
   if (req.body.residence !== 'Yes') {
-    /* TODO: Point this at the offboarding page */
-    return res.redirect('/start')
+    return res.redirect('/offramp')
   }
 
   return res.redirect(req.body.redirect)

--- a/routes/personal/personal.spec.js
+++ b/routes/personal/personal.spec.js
@@ -77,7 +77,7 @@ describe('Test /personal responses', () => {
     test('it returns a 302 when selecting NO', async () => {
       const response = await request(app)
         .post('/personal/residence')
-        .send({ redirect: '/', residence: 'No' })
+        .send({ redirect: '/offramp', residence: 'No' })
       expect(response.statusCode).toBe(302)
     })
 

--- a/views/_includes/banner.pug
+++ b/views/_includes/banner.pug
@@ -1,4 +1,4 @@
-mixin blueBanner(text, variant, spanChar)
+mixin banner(text, variant, spanChar)
   div(class="banner banner--" + variant +"")
     span(class="banner__icon banner--"+ variant +"__icon" aria-hidden="true")= spanChar || 'i'
     != text

--- a/views/_includes/banner.pug
+++ b/views/_includes/banner.pug
@@ -1,0 +1,4 @@
+mixin blueBanner(text, variant, spanChar)
+  div(class="banner banner--" + variant +"")
+    span(class="banner__icon banner--"+ variant +"__icon" aria-hidden="true")= spanChar 
+    != text

--- a/views/_includes/banner.pug
+++ b/views/_includes/banner.pug
@@ -1,4 +1,4 @@
 mixin blueBanner(text, variant, spanChar)
   div(class="banner banner--" + variant +"")
-    span(class="banner__icon banner--"+ variant +"__icon" aria-hidden="true")= spanChar 
+    span(class="banner__icon banner--"+ variant +"__icon" aria-hidden="true")= spanChar || 'i'
     != text

--- a/views/_includes/bannerBlue.pug
+++ b/views/_includes/bannerBlue.pug
@@ -1,4 +1,0 @@
-mixin blueBanner(text)
-  div.banner.banner--blue
-    span.banner__icon.banner--blue__icon(aria-hidden="true") i
-    != text

--- a/views/_includes/bannerBlue.pug
+++ b/views/_includes/bannerBlue.pug
@@ -1,0 +1,4 @@
+mixin blueBanner(text)
+  div.banner.banner--blue
+    span.banner__icon.banner--blue__icon(aria-hidden="true") i
+    != text

--- a/views/offramp/offramp.pug
+++ b/views/offramp/offramp.pug
@@ -7,11 +7,12 @@ block variables
 block content
 
   h1 #{title}
-  +blueBanner('Your tax return is too complex to be filed using this service. Nothing about your taxes is incorrect – see below for further instructions on how to complete your tax return.', 'blue')
+  +banner('<p>Your tax return is too complex to be filed using this service. Nothing about your taxes is incorrect – see below for further instructions on how to complete your tax return.</p>', 'blue')
   div
     p To finish filing your taxes for the current tax year (filing for 2018), you will need to do one of the following:
     ul
       li Use the paper form enclosed in the Claim Tax Benefits package you received in the mail
-      li Contact CRA at (123) 456-7890 for help
-      li File your taxes with another free service, listed here: #[a(href="#") Ways to file your taxes]
+      li #[a(href="https://www.canada.ca/en/revenue-agency/services/tax/individuals/community-volunteer-income-tax-program.html") Visit a community tax clinic near you] to have a volunteer help you submit your taxes.
+      li Contact CRA at #[a(href="tel:123-456-7890") (123) 456-7890] for help
+      li File your taxes with another #[a(href="https://www.canada.ca/en/revenue-agency/services/e-services/e-services-individuals/netfile-overview/certified-software-netfile-program.html") NETFILE-compliant online service certified by the CRA]
 

--- a/views/offramp/offramp.pug
+++ b/views/offramp/offramp.pug
@@ -7,7 +7,7 @@ block variables
 block content
 
   h1 #{title}
-  +blueBanner('Your tax return is too complex to be filed using this service. Nothing about your taxes is incorrect – see below for further instructions on how to complete your tax return.', 'blue', 'i')
+  +blueBanner('Your tax return is too complex to be filed using this service. Nothing about your taxes is incorrect – see below for further instructions on how to complete your tax return.', 'blue')
   div
     p To finish filing your taxes for the current tax year (filing for 2018), you will need to do one of the following:
     ul

--- a/views/offramp/offramp.pug
+++ b/views/offramp/offramp.pug
@@ -1,5 +1,5 @@
 extends ../base
-include ../_includes/bannerBlue
+include ../_includes/banner
 
 block variables
   -var title = 'Your taxes can’t be completed using this service'
@@ -7,7 +7,7 @@ block variables
 block content
 
   h1 #{title}
-  +blueBanner('Your tax return is too complex to be filed using this service. Nothing about your taxes is incorrect – see below for further instructions on how to complete your tax return.')
+  +blueBanner('Your tax return is too complex to be filed using this service. Nothing about your taxes is incorrect – see below for further instructions on how to complete your tax return.', 'blue', 'i')
   div
     p To finish filing your taxes for the current tax year (filing for 2018), you will need to do one of the following:
     ul

--- a/views/offramp/offramp.pug
+++ b/views/offramp/offramp.pug
@@ -1,0 +1,17 @@
+extends ../base
+include ../_includes/bannerBlue
+
+block variables
+  -var title = 'Your taxes can’t be completed using this service'
+
+block content
+
+  h1 #{title}
+  +blueBanner('Your tax return is too complex to be filed using this service. Nothing about your taxes is incorrect – see below for further instructions on how to complete your tax return.')
+  div
+    p To finish filing your taxes for the current tax year (filing for 2018), you will need to do one of the following:
+    ul
+      li Use the paper form enclosed in the Claim Tax Benefits package you received in the mail
+      li Contact CRA at (123) 456-7890 for help
+      li File your taxes with another free service, listed here: #[a(href="#") Ways to file your taxes]
+


### PR DESCRIPTION
### TL;DR:
- added offramp page
- added a banner include/mixin for some banners in the app
- updated "no" on postResidence to point to the offramp page
- just a basic test that the page loads

Offramp is in its own directory, because I can see us using this outside of just the personal controller. If you feel that it does not belong in its own folder, we can change this.

Still calling it offramp, this can change depending on what we decide to name it.

Banner include/mixin - we only have the blue one on the app right now (and it needs to be added to a bunch of places), but I allowed for colour variant in case it does change up.


![image](https://user-images.githubusercontent.com/6607541/61305297-952baf80-a7b8-11e9-8b1f-cbc374903a7a.png)
