### PR TITLE
Task/Add trillium student residence page

### DIFF
--- a/api/user.json
+++ b/api/user.json
@@ -68,7 +68,7 @@
     "seniorHomeownerClaim": null,
     "trilliumRentAmount": 0,
     "trilliumPropertyTaxAmount": 0,
-    "trilliumStudentResidenceAmount": 0,
+    "trilliumStudentResidence": null,
     "trilliumEnergyAmount": 0,
     "trilliumLongTermCareAmount": 0
   }

--- a/formSchemas.js
+++ b/formSchemas.js
@@ -9,6 +9,15 @@ const currencySchema = (errorMessageString = 'errors.currency') => {
   }
 }
 
+const yesNoSchema = (errorMessageString = 'errors.yesNo') => {
+  return {
+    isIn: {
+      errorMessage: errorMessageString,
+      options: [['Yes', 'No']],
+    },
+  }
+}
+
 /**
  * Runs an array of validators over a value
  * this is a workaround I found to allow multiple custom validators
@@ -261,12 +270,7 @@ const addressSchema = {
 }
 
 const rrspSchema = {
-  rrspClaim: {
-    isIn: {
-      errorMessage: 'errors.rrspClaim',
-      options: [['Yes', 'No']],
-    },
-  },
+  rrspClaim: yesNoSchema(),
 }
 
 const rrspAmountSchema = {
@@ -274,12 +278,7 @@ const rrspAmountSchema = {
 }
 
 const donationsSchema = {
-  donationsClaim: {
-    isIn: {
-      errorMessage: 'errors.donationsClaim',
-      options: [['Yes', 'No']],
-    },
-  },
+  donationsClaim: yesNoSchema(),
 }
 
 const donationsAmountSchema = {
@@ -287,12 +286,7 @@ const donationsAmountSchema = {
 }
 
 const residenceSchema = {
-  residence: {
-    isIn: {
-      errorMessage: 'errors.residence',
-      options: [['Yes', 'No']],
-    },
-  },
+  residence: yesNoSchema(),
 }
 
 const authSchema = {
@@ -308,12 +302,7 @@ const trilliumPropertyTaxAmountSchema = {
 }
 
 const trilliumStudentResidenceSchema = {
-  trilliumStudentResidence: {
-    isIn: {
-      errorMessage: 'errors.yesNo',
-      options: [['Yes', 'No']],
-    },
-  },
+  trilliumStudentResidence: yesNoSchema(),
 }
 
 const trilliumEnergyAmountSchema = {

--- a/formSchemas.js
+++ b/formSchemas.js
@@ -307,6 +307,15 @@ const trilliumPropertyTaxAmountSchema = {
   trilliumPropertyTaxAmount: currencySchema(),
 }
 
+const trilliumStudentResidenceSchema = {
+  trilliumStudentResidence: {
+    isIn: {
+      errorMessage: 'errors.yesNo',
+      options: [['Yes', 'No']],
+    },
+  },
+}
+
 const trilliumEnergyAmountSchema = {
   trilliumEnergyAmount: currencySchema(),
 }
@@ -339,6 +348,7 @@ module.exports = {
   trilliumPropertyTaxAmountSchema,
   trilliumEnergyAmountSchema,
   trilliumlongTermCareAmountSchema,
+  trilliumStudentResidenceSchema,
   reviewSchema,
   authSchema,
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -20,6 +20,7 @@
   "errors.address.province": "Please select a valid province",
   "errors.rrspClaim": "You must select one of the options",
   "errors.currency": "Enter a dollar amount higher than 0, like 120.00",
+  "errors.yesNo": "You must select one of the options",
   "errors.address.province.province": "errors.address.province.province",
   "errors.residence": "You must select one of the options",
   "errors.donationsClaim": "You must select one of the options",
@@ -163,5 +164,7 @@
   "Please enter the total amount paid for accommodation in a public long-term care home in 2018.": "Please enter the total amount paid for accommodation in a public long-term care home in 2018.",
   "Accommodation costs in 2018": "Accommodation costs in 2018",
   "For example: R2H 0J9": "For example: R2H 0J9",
-  "Submit my return": "Submit my return"
+  "Submit my return": "Submit my return",
+  "Designated student residence": "Designated student residence",
+  "Did you live in a designated student residence in 2018?": "Did you live in a designated student residence in 2018?"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -20,6 +20,7 @@
   "errors.address.province": "Please select a valid province",
   "errors.rrspClaim": "You must select one of the options",
   "errors.currency": "Enter a dollar amount higher than 0, like 120.00",
+  "errors.yesNo": "You must select one of the options",
   "errors.address.province.province": "errors.address.province.province",
   "errors.residence": "You must select one of the options",
   "errors.donationsClaim": "You must select one of the options",
@@ -156,5 +157,7 @@
   "if this doesn’t apply to you or if you don’t have the receipts to verify this information later.": "if this doesn’t apply to you or if you don’t have the receipts to verify this information later.",
   "Accommodation costs in 2018": "Accommodation costs in 2018",
   "Review your estimated benefits": "Review your estimated benefits",
-  "Submit my return": "Submit my return"
+  "Submit my return": "Submit my return",
+  "Designated student residence": "Designated student residence",
+  "Did you live in a designated student residence in 2018?": "Did you live in a designated student residence in 2018?"
 }

--- a/routes/deductions/deductions.controller.js
+++ b/routes/deductions/deductions.controller.js
@@ -7,6 +7,7 @@ const {
   donationsAmountSchema,
   trilliumRentAmountSchema,
   trilliumPropertyTaxAmountSchema,
+  trilliumStudentResidenceSchema,
   trilliumEnergyAmountSchema,
   trilliumlongTermCareAmountSchema,
 } = require('./../../formSchemas.js')
@@ -77,6 +78,17 @@ module.exports = function(app) {
     checkSchema(trilliumPropertyTaxAmountSchema),
     checkErrors('deductions/trillium-propertyTax-amount'),
     postTrilliumPropertyTaxAmount,
+  )
+
+  app.get('/trillium/studentResidence', (req, res) =>
+    res.render('deductions/trillium-studentResidence', { data: req.session }),
+  )
+  app.post(
+    '/trillium/studentResidence',
+    validateRedirect,
+    checkSchema(trilliumStudentResidenceSchema),
+    checkErrors('deductions/trillium-studentResidence'),
+    postTrilliumStudentResidence,
   )
 
   app.get('/trillium/energy/amount', (req, res) =>
@@ -166,6 +178,13 @@ const postTrilliumPropertyTaxAmount = (req, res) => {
   req.session.deductions.trilliumPropertyTaxAmount = req.body.trilliumPropertyTaxAmount
 
   //Success, we can redirect to the next page
+  return res.redirect(req.body.redirect)
+}
+
+const postTrilliumStudentResidence = (req, res) => {
+  req.session.deductions.trilliumStudentResidence =
+    req.body.trilliumStudentResidence === 'Yes' ? true : false
+
   return res.redirect(req.body.redirect)
 }
 

--- a/routes/deductions/deductions.spec.js
+++ b/routes/deductions/deductions.spec.js
@@ -3,28 +3,6 @@ const app = require('../../app.js')
 
 describe('Test /deductions responses', () => {
   describe('Test /deductions/rrsp responses', () => {
-    test('it returns a 200 response for /deductions/rrsp', async () => {
-      const response = await request(app).get('/deductions/rrsp')
-      expect(response.statusCode).toBe(200)
-    })
-
-    test('it returns a 422 response for no posted value', async () => {
-      const response = await request(app)
-        .post('/deductions/rrsp')
-        .send({ redirect: '/' })
-      expect(response.statusCode).toBe(422)
-    })
-
-    const badRRSPClaims = ['', null, false, 0, 'dinosaur', 'yes']
-    badRRSPClaims.map(rrspClaim => {
-      test(`it returns a 422 for a bad posted value: "${rrspClaim}"`, async () => {
-        const response = await request(app)
-          .post('/deductions/rrsp')
-          .send({ rrspClaim, redirect: '/' })
-        expect(response.statusCode).toBe(422)
-      })
-    })
-
     test('it redirects to the edit page when posting "Yes"', async () => {
       const response = await request(app)
         .post('/deductions/rrsp')
@@ -44,28 +22,6 @@ describe('Test /deductions responses', () => {
 
   //Start of Charitable donation section
   describe('Test /deductions/donations responses', () => {
-    test('it returns a 200 response for /deductions/donations', async () => {
-      const response = await request(app).get('/deductions/donations')
-      expect(response.statusCode).toBe(200)
-    })
-
-    test('it returns a 422 response for no posted value', async () => {
-      const response = await request(app)
-        .post('/deductions/donations')
-        .send({ redirect: '/' })
-      expect(response.statusCode).toBe(422)
-    })
-
-    const badDonationsClaims = ['', null, false, 0, 'dinosaur', 'yes']
-    badDonationsClaims.map(donationsClaim => {
-      test(`it returns a 422 for a bad posted value: "${donationsClaim}"`, async () => {
-        const response = await request(app)
-          .post('/deductions/donations')
-          .send({ donationsClaim, redirect: '/' })
-        expect(response.statusCode).toBe(422)
-      })
-    })
-
     test('it redirects to the edit page when posting "Yes"', async () => {
       const response = await request(app)
         .post('/deductions/donations')
@@ -80,6 +36,68 @@ describe('Test /deductions responses', () => {
         .send({ donationsClaim: 'No', redirect: '/' })
       expect(response.statusCode).toBe(302)
       expect(response.headers.location).toEqual('/')
+    })
+  })
+
+  // Start of the trillium student residence section
+  describe('Test /trillium/studentResidence responses', () => {
+    test('it redirects to the posted redirect url when posting "Yes"', async () => {
+      const response = await request(app)
+        .post('/trillium/studentResidence')
+        .send({ trilliumStudentResidence: 'Yes', redirect: '/' })
+      expect(response.statusCode).toBe(302)
+      expect(response.headers.location).toEqual('/')
+    })
+
+    test('it redirects to the posted redirect url when posting "No"', async () => {
+      const response = await request(app)
+        .post('/trillium/studentResidence')
+        .send({ trilliumStudentResidence: 'No', redirect: '/' })
+      expect(response.statusCode).toBe(302)
+      expect(response.headers.location).toEqual('/')
+    })
+  })
+
+  describe('Test /deductions/* yesNo responses', () => {
+    const yesNoResponses = [
+      {
+        url: '/deductions/rrsp',
+        key: 'rrspClaim',
+      },
+      {
+        url: '/deductions/donations',
+        key: 'donationsClaim',
+      },
+      {
+        url: '/trillium/studentResidence',
+        key: 'trilliumStudentResidence',
+      },
+    ]
+
+    yesNoResponses.map(yesNoResponse => {
+      describe(`Test ${yesNoResponse.url} responses`, () => {
+        test('it returns a 200 response', async () => {
+          const response = await request(app).get(yesNoResponse.url)
+          expect(response.statusCode).toBe(200)
+        })
+
+        test('it returns a 422 response for no posted value', async () => {
+          const response = await request(app)
+            .post(yesNoResponse.url)
+            .send({ redirect: '/' })
+          expect(response.statusCode).toBe(422)
+        })
+
+        const badValues = ['', null, false, 0, 'dinosaur', 'yes']
+        badValues.map(badValue => {
+          test(`it returns a 422 for a bad posted value: "${badValue}"`, async () => {
+            const response = await request(app)
+              .post(yesNoResponse.url)
+              .send({ [yesNoResponse.key]: badValue, redirect: '/' })
+            expect(response.statusCode).toBe(422)
+          })
+        })
+      })
     })
   })
 

--- a/views/deductions/trillium-propertyTax-amount.pug
+++ b/views/deductions/trillium-propertyTax-amount.pug
@@ -16,6 +16,6 @@ block content
   form.cra-form(method='post')
     +textInput('Total property tax in 2018')(class='w-1-2 input-with-unit' name='trilliumPropertyTaxAmount' placeholder='0.00' aria-labelledby='trilliumPropertyTaxAmount__unit trilliumPropertyTaxAmount__label' value=trilliumPropertyTaxAmount)
 
-    input#redirect(name='redirect', type='hidden', value='/trillium/energy/amount')
+    input#redirect(name='redirect', type='hidden', value='/trillium/studentResidence')
 
     +formButtons('Continue')

--- a/views/deductions/trillium-studentResidence.pug
+++ b/views/deductions/trillium-studentResidence.pug
@@ -1,0 +1,17 @@
+extends ../base
+include ../_includes/yesNoRadios
+
+block variables
+  -var title = 'Designated student residence'
+  -var trilliumStudentResidence = !hasData(data, 'deductions.trilliumStudentResidence') ? null : data.deductions.trilliumStudentResidence === true ? 'Yes' : 'No'
+
+block content
+
+  h1 #{__(title)}
+
+  form.cra-form(method='post')
+    +yesNoRadios('trilliumStudentResidence', trilliumStudentResidence, 'Did you live in a designated student residence in 2018?', errors)
+
+    input#redirect(name='redirect', type='hidden', value='/trillium/energy/amount')
+
+    +formButtons()


### PR DESCRIPTION
This is the last page of the 5 trillium pages, the student residence page.

It's pretty simple and does the job, but it looks pretty barren and unfortunately our form CSS crunches all the words up on the side of the page.

It's worked so far, but it's not good at all for this page in particular. There's also sometimes that the button text is a bit squished, so I was planning to look at those two things in particular after user testing and see if we can't add a class or two to fix our problems.

@katedee, if you approve then I'll merge and ask Brian on Monday about if we want to fix this before usability testing.

### Screenshots

|  as designed | as built   |
|---|---|
| <img width="1516" alt="Screen Shot 2019-07-19 at 6 17 01 PM" src="https://user-images.githubusercontent.com/2454380/61568659-1a7dc100-aa52-11e9-9f84-4281e49a46ae.png">  |  ![image](https://user-images.githubusercontent.com/2454380/61568656-1356b300-aa52-11e9-8317-b37bb5ff2e22.png) |




