### PR TITLE
Task/Bump session expiry time to an hour

### DIFF
--- a/config/cookieSession.config.js
+++ b/config/cookieSession.config.js
@@ -2,20 +2,19 @@
  configuration for our cookie sessions
   - set a name for the session so that the cookie persists between server reloads
     - if a COOKIE_SECRET environment variable, use that as a secret name
-    - else use a timestamp that rotates every 20 minutes
-  - also set cookie expiry time to 20 minutes
+    - else use a timestamp that rotates every 60 minutes
+  - also set cookie expiry time to 60 minutes
   more docs here: https://expressjs.com/en/resources/middleware/cookie-session.html
 */
-const twentyMinutes = 1000 * 60 * 20
-const sessionName = `ctb-${process.env.COOKIE_SECRET ||
-  Math.floor(new Date().getTime() / twentyMinutes)}`
+const oneHour = 1000 * 60 * 60
+const sessionName = `ctb-${process.env.COOKIE_SECRET || Math.floor(new Date().getTime() / oneHour)}`
 
 const cookieSessionConfig = {
   name: sessionName,
   secret: sessionName,
   cookie: {
     httpOnly: true,
-    maxAge: twentyMinutes,
+    maxAge: oneHour,
     sameSite: true,
   },
 }


### PR DESCRIPTION
Since we're going to be testing with users this Wednesday, we don't want to be running tests where people enter info and then it all resets silently.

Setting the session expiry to one hour makes this far less likely to happen.