### PR TITLE
Province of residence v2.0

### DIFF
--- a/formSchemas.js
+++ b/formSchemas.js
@@ -304,6 +304,7 @@ const residenceSchema = {
           'Quebec',
           'Saskatchewan',
           'Yukon',
+          'Non Resident',
         ],
       ],
     },

--- a/formSchemas.js
+++ b/formSchemas.js
@@ -286,7 +286,28 @@ const donationsAmountSchema = {
 }
 
 const residenceSchema = {
-  residence: yesNoSchema(),
+  residence: {
+    isIn: {
+      errorMessage: 'errors.residence',
+      options: [
+        [
+          'Alberta',
+          'British Columbia',
+          'Manitoba',
+          'New Brunswick',
+          'Newfoundland And Labrador',
+          'Northwest Territories',
+          'Nova Scotia',
+          'Nunavut',
+          'Ontario',
+          'Prince Edward Island',
+          'Quebec',
+          'Saskatchewan',
+          'Yukon',
+        ],
+      ],
+    },
+  },
 }
 
 const authSchema = {

--- a/locales/en.json
+++ b/locales/en.json
@@ -22,7 +22,7 @@
   "errors.currency": "Enter a dollar amount higher than 0, like 120.00",
   "errors.yesNo": "You must select one of the options",
   "errors.address.province.province": "errors.address.province.province",
-  "errors.residence": "You must select one of the options",
+  "errors.residence": "You must select a province or territory",
   "errors.donationsClaim": "You must select one of the options",
   "errors.review": "You must consent to submit your return",
   "This service is to claim tax benefits online.": "This service is to claim tax benefits online.",

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -39,7 +39,7 @@ form.cra-form.cra-form--lg {
 
 form.cra-form {
   > div:not(:last-of-type) {
-    margin-bottom: $space-xl;
+    margin-bottom: $space-md;
   }
 
   div *:last-child {

--- a/routes/personal/personal.controller.js
+++ b/routes/personal/personal.controller.js
@@ -60,7 +60,7 @@ const postMaritalStatus = (req, res) => {
 }
 
 const postResidence = (req, res) => {
-  if (req.body.residence !== 'Yes') {
+  if (req.body.residence !== 'Ontario') {
     return res.redirect('/offramp')
   }
 

--- a/routes/personal/personal.spec.js
+++ b/routes/personal/personal.spec.js
@@ -74,17 +74,17 @@ describe('Test /personal responses', () => {
       expect(response.statusCode).toBe(422)
     })
 
-    test('it returns a 302 when selecting NO', async () => {
+    test('it returns a 302 when selecting unsupported province', async () => {
       const response = await request(app)
         .post('/personal/residence')
-        .send({ redirect: '/offramp', residence: 'No' })
+        .send({ redirect: '/offramp', residence: 'Alberta' })
       expect(response.statusCode).toBe(302)
     })
 
-    test('it returns a 302 when selecting YES', async () => {
+    test('it returns a 302 when selecting Ontario', async () => {
       const response = await request(app)
         .post('/personal/residence')
-        .send({ redirect: '/personal/address', residence: 'Yes' })
+        .send({ redirect: '/personal/address', residence: 'Ontario' })
       expect(response.statusCode).toBe(302)
     })
   })

--- a/routes/personal/personal.spec.js
+++ b/routes/personal/personal.spec.js
@@ -78,6 +78,7 @@ describe('Test /personal responses', () => {
       const response = await request(app)
         .post('/personal/residence')
         .send({ redirect: '/offramp', residence: 'Alberta' })
+      expect(response.headers.location).toEqual('/offramp')
       expect(response.statusCode).toBe(302)
     })
 
@@ -85,6 +86,7 @@ describe('Test /personal responses', () => {
       const response = await request(app)
         .post('/personal/residence')
         .send({ redirect: '/personal/address', residence: 'Ontario' })
+      expect(response.headers.location).toEqual('/personal/address')
       expect(response.statusCode).toBe(302)
     })
   })

--- a/views/personal/residence.pug
+++ b/views/personal/residence.pug
@@ -1,38 +1,38 @@
 extends ../base
 
 block variables
-  -var title = 'Confirm you are an Ontario resident'
+  -var title = 'Confirm your province or territory of residence'
 
 block content
 
   h1 #{__(title)}
 
   div
-    p #{__('In order to be eligible for this service, your primary residence on December 31, 2018, must have been in Ontario.')}
+    p #{__('In order to be eligible for this service, your primary residence on December 31, 2018, must have been in Ontario. If you live outside of Ontario, we will provide you with alternative options in which you can complete your tax return.')}
 
 
   form.cra-form(method='post')
     div(class={['has-error']: errors && errors.residence})
-      label.provinceOfRes__label.requiredField(for='residence')
+      label.requiredField(for='residence')
         | Province or Territory of Residence
         if errors
           +validationMessage(errors.residence.msg, 'residence')
-        select.residence(name='residence', aria-describedby=(errors && errors.residence ? 'residence-error' : false))
-          option(disabled='', selected='selected', value='')  -- select a province --
-          option(value='Alberta') Alberta
-          option(value='British Columbia') British Columbia
-          option(value='Manitoba') Manitoba
-          option(value='New Brunswick') New Brunswick
-          option(value='Newfoundland And Labrador') Newfoundland and Labrador
-          option(value='Northwest Territories') Northwest Territories
-          option(value='Nova Scotia') Nova Scotia
-          option(value='Nunavut') Nunavut
-          option(value='Ontario') Ontario
-          option(value='Prince Edward Island') Prince Edward Island
-          option(value='Quebec') Quebec
-          option(value='Saskatchewan') Saskatchewan
-          option(value='Yukon') Yukon
-
+        select(name='residence', aria-describedby=(errors && errors.residence ? 'residence-error' : false))
+          option(disabled='', selected='selected', value='')  ---- Select your province of residence ----
+          option(value='Alberta') #{__('Alberta')}
+          option(value='British Columbia') #{__('British Columbia')}
+          option(value='Manitoba') #{__('Manitoba')}
+          option(value='New Brunswick') #{__('New Brunswick')}
+          option(value='Newfoundland And Labrador') #{__('Newfoundland and Labrador')}
+          option(value='Northwest Territories') #{__('Northwest Territories')}
+          option(value='Nova Scotia') #{__('Nova Scotia')} 
+          option(value='Nunavut') #{__('Nunavut')} 
+          option(value='Ontario') #{__('Ontario')} 
+          option(value='Prince Edward Island') #{__('Prince Edward Island')} 
+          option(value='Quebec') #{__('Quebec')} 
+          option(value='Saskatchewan') #{__('Saskatchewan')} 
+          option(value='Yukon') #{__('Yukon')}
+          option(value='Non Resident') #{__('Non Resident')}
     input#redirect(name='redirect', type='hidden', value='/personal/address')
 
     +formButtons()

--- a/views/personal/residence.pug
+++ b/views/personal/residence.pug
@@ -1,5 +1,4 @@
 extends ../base
-include ../_includes/yesNoRadios
 
 block variables
   -var title = 'Confirm you are an Ontario resident'
@@ -13,7 +12,26 @@ block content
 
 
   form.cra-form(method='post')
-    +yesNoRadios('residence', residence, 'Ontario resident on December 31, 2018?', errors)
+    div(class={['has-error']: errors && errors.residence})
+      label.provinceOfRes__label.requiredField(for='residence')
+        | Province or Territory of Residence
+        if errors
+          +validationMessage(errors.residence.msg, 'residence')
+        select.residence(name='residence', aria-describedby=(errors && errors.residence ? 'residence-error' : false))
+          option(disabled='', selected='selected', value='')  -- select a province --
+          option(value='Alberta') Alberta
+          option(value='British Columbia') British Columbia
+          option(value='Manitoba') Manitoba
+          option(value='New Brunswick') New Brunswick
+          option(value='Newfoundland And Labrador') Newfoundland and Labrador
+          option(value='Northwest Territories') Northwest Territories
+          option(value='Nova Scotia') Nova Scotia
+          option(value='Nunavut') Nunavut
+          option(value='Ontario') Ontario
+          option(value='Prince Edward Island') Prince Edward Island
+          option(value='Quebec') Quebec
+          option(value='Saskatchewan') Saskatchewan
+          option(value='Yukon') Yukon
 
     input#redirect(name='redirect', type='hidden', value='/personal/address')
 


### PR DESCRIPTION
## This PR consists of the following:

### Ontario Page >>> Province or Territory of Residence Page

| Before | After |
|--------|-------|
|   ![61225272-3d287680-a6ee-11e9-9e7a-045a6981cc59](https://user-images.githubusercontent.com/30609058/61651592-2cdf4100-ac84-11e9-8c08-823e0a9b235a.gif)     |   ![Residence2 0(after)](https://user-images.githubusercontent.com/30609058/61651489-f86b8500-ac83-11e9-8e78-af3497b4fca0.gif)  |

### Breakdown
- Reverted back to dropdown menu to handle new options (makes more sense than radios since we have over 10)
- Added new options to residence's form schema
- Updated error message
- Updated content
- Updated residence page tests
- Updated controller to handle new residence values
- Reduced margins between form and buttons on form pages

