### PR TITLE
Tweaks to residence page

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -183,6 +183,7 @@
 	"Saskatchewan": "Saskatchewan",
 	"Yukon": "Yukon",
 	"Non Resident": "Non Resident",
+	"Province or Territory of Residence": "Province or Territory of Residence",
 	"Political contributions": "Political contributions",
 	"Did you make any political contributions during the current tax year (filing for 2018)?": "Did you make any political contributions during the current tax year (filing for 2018)?",
 	"Deduct political contributions?": "Deduct political contributions?",

--- a/locales/en.json
+++ b/locales/en.json
@@ -191,7 +191,7 @@
 	"Please enter your political contributions into the fields below.": "Please enter your political contributions into the fields below.",
 	"Total federal contributions": "Total federal contributions",
 	"Total provincial contributions": "Total provincial contributions",
-	"errors.politicalAmount": "errors.politicalAmount"
+	"errors.politicalAmount": "errors.politicalAmount",
 	"Here’s what CRA knows about your income for the current tax year (filing for 2018). Additional claims and deductions can be made afterwards.": "Here’s what CRA knows about your income for the current tax year (filing for 2018). Additional claims and deductions can be made afterwards.",
 	"Total income earned in 2018": "Total income earned in 2018",
 	"Detailed breakdown of income earned in 2018": "Detailed breakdown of income earned in 2018",

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -39,7 +39,7 @@ form.cra-form.cra-form--lg {
 
 form.cra-form {
   > div:not(:last-of-type) {
-    margin-bottom: $space-md;
+    margin-bottom: $space-xl;
   }
 
   div *:last-child {

--- a/views/personal/residence.pug
+++ b/views/personal/residence.pug
@@ -13,12 +13,11 @@ block content
 
   form.cra-form(method='post')
     div(class={['has-error']: errors && errors.residence})
-      label.requiredField(for='residence')
-        | Province or Territory of Residence
-        if errors
+      label.resLabel(for='residence', name="residence-label") 
+        span #{__('Province or Territory of Residence')}
+      if errors
           +validationMessage(errors.residence.msg, 'residence')
-        select(name='residence', aria-describedby=(errors && errors.residence ? 'residence-error' : false))
-          option(disabled='', selected='selected', value='')  ---- Select your province of residence ----
+      select(name='residence', aria-describedby=(errors && errors.residence ? 'residence-error' : false))
           option(value='Alberta') #{__('Alberta')}
           option(value='British Columbia') #{__('British Columbia')}
           option(value='Manitoba') #{__('Manitoba')}
@@ -27,7 +26,7 @@ block content
           option(value='Northwest Territories') #{__('Northwest Territories')}
           option(value='Nova Scotia') #{__('Nova Scotia')} 
           option(value='Nunavut') #{__('Nunavut')} 
-          option(value='Ontario') #{__('Ontario')} 
+          option(value='Ontario', selected='selected') #{__('Ontario')} 
           option(value='Prince Edward Island') #{__('Prince Edward Island')} 
           option(value='Quebec') #{__('Quebec')} 
           option(value='Saskatchewan') #{__('Saskatchewan')} 

--- a/views/personal/residence.pug
+++ b/views/personal/residence.pug
@@ -13,7 +13,7 @@ block content
 
   form.cra-form(method='post')
     div(class={['has-error']: errors && errors.residence})
-      label.resLabel(for='residence', name="residence-label") #{__('Province or Territory of Residence')}
+      label(for='residence', name="residence-label") #{__('Province or Territory of Residence')}
       if errors
           +validationMessage(errors.residence.msg, 'residence')
       select(name='residence', aria-describedby=(errors && errors.residence ? 'residence-error' : false))

--- a/views/personal/residence.pug
+++ b/views/personal/residence.pug
@@ -13,8 +13,7 @@ block content
 
   form.cra-form(method='post')
     div(class={['has-error']: errors && errors.residence})
-      label.resLabel(for='residence', name="residence-label") 
-        span #{__('Province or Territory of Residence')}
+      label.resLabel(for='residence', name="residence-label") #{__('Province or Territory of Residence')}
       if errors
           +validationMessage(errors.residence.msg, 'residence')
       select(name='residence', aria-describedby=(errors && errors.residence ? 'residence-error' : false))


### PR DESCRIPTION
## This PR consists of the following:

### PR Review changes to residence page (Paul's feedback)
| Before | After |
|--------|-------|
|    ![Residencetweaks-before](https://user-images.githubusercontent.com/30609058/61660843-cd3f6080-ac98-11e9-9bad-0954eecc90b4.gif)    |    ![Residencetweaks](https://user-images.githubusercontent.com/30609058/61660737-8d787900-ac98-11e9-99ff-a10bae18ac02.gif)   |

### Breakdown:
- default the selection box to Ontario
- removed “select your province option”
- changed margins back to xl under select, didn't realise it affected others that would look weird (may revisit this later)
- fixed indent issue on label, the select and label were being grouped
- added #{__(‘Province or Territory of Residence’)} to the label
