### PR TITLE
Task/Change maritalStatus to Single

### DIFF
--- a/api/user.json
+++ b/api/user.json
@@ -16,7 +16,7 @@
       "city": "Winnipeg",
       "province": "Manitoba"
     },
-    "maritalStatus": "Married",
+    "maritalStatus": "Single",
     "disability": false
   },
   "financial": {
@@ -68,14 +68,7 @@
     "totalTax": 4782.00,
     "taxableAmount": "$1,000.00"
   },
-  "partner": {
-    "firstName": "Marcel",
-    "lastName": "Carbotte",
-    "sin": "222333444",
-    "dateOfBirth": "1914/02/09",
-    "disability": false,
-    "netIncome": "$1,000.00"
-  },
+  "partner": null,
   "dependents": [
     {
       "firstName": "Bernadette",

--- a/routes/personal/personal.spec.js
+++ b/routes/personal/personal.spec.js
@@ -26,13 +26,7 @@ describe('Test /personal responses', () => {
     test('it has Married selected by default', async () => {
       const response = await request(app).get('/personal/maritalStatus')
       const $ = cheerio.load(response.text)
-      expect($('td div').text()).toEqual('Married')
-    })
-
-    test('it defaults to Married being checked for /personal/maritalStatus/edit path', async () => {
-      const response = await request(app).get('/personal/maritalStatus/edit')
-      const $ = cheerio.load(response.text)
-      expect($('#maritalStatusMarried').attr('checked')).toEqual('checked')
+      expect($('td div').text()).toEqual('Single')
     })
 
     test('it checks the stored marital status by default for /personal/maritalStatus/edit path', async () => {


### PR DESCRIPTION
Changing this meant:

- removing the partner entry in the json blob
- removing a "default" test since we don't have a default anymore
- changing the "married" test to "single"