### PR TITLE
Task/Change mailing address to Ontario

### DIFF
--- a/api/user.json
+++ b/api/user.json
@@ -9,12 +9,12 @@
     "sin": "847339283",
     "dateOfBirth": "1909/03/22",
     "address": {
-      "aptNumber": "",
-      "streetNumber": "375",
-      "streetName": "Rue Deschambault",
-      "postalCode": "R2H 0J9",
-      "city": "Winnipeg",
-      "province": "Manitoba"
+      "aptNumber": "Unit 202",
+      "streetNumber": "303",
+      "streetName": "Blake Blvd.",
+      "postalCode": "K2R 3Z9",
+      "city": "Ottawa",
+      "province": "Ontario"
     },
     "maritalStatus": "Single",
     "disability": false

--- a/locales/en.json
+++ b/locales/en.json
@@ -103,7 +103,7 @@
   "Optional": "Optional",
   "City": "City",
   "Postal Code": "Postal Code",
-  "For Example: R2H 0J9": "For Example: R2H 0J9",
+  "For Example: K2R 3Z9": "For Example: K2R 3Z9",
   "Province": "Province",
   "Change mailing address": "Change mailing address",
   "Deduct your RRSP contributions": "Deduct your RRSP contributions",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -104,7 +104,7 @@
   "Optional": "Facultatif",
   "City": "Ville",
   "Postal Code": "Code postal",
-  "For Example: R2H 0J9": "Exemple : R2H 0J9",
+  "For Example: K2R 3Z9": "Exemple : K2R 3Z9",
   "Province": "Province",
   "Change mailing address": "Modifier mon adresse postale",
   "Change Marital Status": "Modifier mon état matrimonial",

--- a/utils/index.spec.js
+++ b/utils/index.spec.js
@@ -45,7 +45,7 @@ describe('Test hasData function', () => {
   })
 
   test('returns false for empty string', () => {
-    expect(hasData(user, 'personal.address.aptNumber')).toBe(false)
+    expect(hasData({ obj: { string: '' } }, 'obj.string')).toBe(false)
   })
 
   test('returns true for disabilityClaim', () => {

--- a/views/personal/address-edit.pug
+++ b/views/personal/address-edit.pug
@@ -29,7 +29,7 @@ block content
 
       +textInput('City', 'w-1-2')(class='w-3-4', value=city name='city')
 
-      +textInput('Postal Code', ['w-1-2'], 'For Example: R2H 0J9')(class='w-3-4' name='postalCode' value=postalCode)
+      +textInput('Postal Code', ['w-1-2'], 'For Example: K2R 3Z9')(class='w-3-4' name='postalCode' value=postalCode)
 
       .w-1-2(class={['has-error']: errors && errors.province})
         label(for='province') #{__('Province')}


### PR DESCRIPTION
Updated the example user's mailing address to be in Ontario. I also updated the hint text on the "personal/address/edit" page, the locales files, and a test that expected `aptNumber` to be empty.