### PR TITLE
fix for income sources to pull from correct spot

### DIFF
--- a/views/financial/income.pug
+++ b/views/financial/income.pug
@@ -3,7 +3,7 @@ include ../_includes/yesNoRadios
 
 block variables
   -var title = __('Confirm your income information')
-  -var incomeSources = hasData(data, 'financial.incomeSources') ? data.financial.income : {}
+  -var incomeSources = hasData(data, 'financial.incomeSources') ? data.financial.incomeSources : {}
   -var taxes = hasData(data, 'financial.taxes') ? data.financial.taxes : {}
   -var totalIncome = hasData(data, 'financial.incomes.totalIncome') ? data.financial.incomes.totalIncome : 0
   -var totalTax = hasData(data, 'financial.totalTax') ? data.financial.totalTax : 0
@@ -17,7 +17,7 @@ block content
   div
     p #{__(`Here’s what CRA knows about your income for the current tax year (filing for ${year}). Additional claims and deductions can be made afterwards.`)}
 
-  if income
+  if incomeSources
     div
       table.breakdown-table
         thead


### PR DESCRIPTION
title says it all.

I messed up and forgot to update where incomeSources was pulling from with my own data changes. And since sometimes the stale data session sits around locally, I didn't see it take effect.