### PR TITLE
Fixup/Inputs need labels

### DIFF
--- a/views/_includes/input-text.pug
+++ b/views/_includes/input-text.pug
@@ -8,14 +8,14 @@ mixin textInput(label, divClasses, hintText)
     class=divClasses
   )
     label(
-      for!=attributes.name 
+      for!=attributes.name
       id!=attributes.name + '__label'
     ) #{__(label)}
     if hintText
       span.cra-form-message #{__(hintText)}
     if errors && errors[attributes.name]
       +validationMessage(
-        errors[attributes.name].msg, 
+        errors[attributes.name].msg,
         attributes.name
       )
     if attributes.class.includes('input-with-unit')
@@ -24,7 +24,7 @@ mixin textInput(label, divClasses, hintText)
       ) $
     input(
       autocomplete='off',
-      type='text', 
+      type='text',
+      id=(attributes.id || attributes.name)
       aria-describedby=(errors && errors[attributes.name] ? attributes.name + '-error' : false)
     )&attributes(attributes)
-      

--- a/views/personal/residence.pug
+++ b/views/personal/residence.pug
@@ -17,7 +17,7 @@ block content
       label(for='residence', name="residence-label") #{__('Province or Territory of Residence')}
       if errors
           +validationMessage(errors.residence.msg, 'residence')
-      select(name='residence', aria-describedby=(errors && errors.residence ? 'residence-error' : false))
+      select#residence(name='residence', aria-describedby=(errors && errors.residence ? 'residence-error' : false))
           option(value='Alberta') #{__('Alberta')}
           option(value='British Columbia') #{__('British Columbia')}
           option(value='Manitoba') #{__('Manitoba')}


### PR DESCRIPTION
Was doing an axe scan of our existing pages, and I noticed that there were a couple pages where we were getting the error message that labels weren't being associated with inputs.

- the /personal/residence page
- the /personal/address/edit page 

The reason that they weren't being associated was that our `<input>` elements had `name` attributes but no `id`.  

### manually add `id` to /personal/residence `<select>`

Super easy change.

### update the text-input mixin to set the `id` as the `name`

If an `id` is passed in explicitly, it will be used instead of the name value.


## Screenshot

<img width="1378" alt="Screen Shot 2019-07-23 at 3 09 04 PM" src="https://user-images.githubusercontent.com/2454380/61740377-7b600e80-ad5c-11e9-87ee-6811effc8821.png">
