### PR TITLE
Alpha Banner

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -270,5 +270,6 @@
   "Medical Expenses (330)": "Medical Expenses (330)",
   "Net Ontario tax (428)": "Net Ontario tax (428)",
   "RRSP (208)": "RRSP (208)",
-  "A benefit signup prototype by the Canadian Digital Service": "A benefit signup prototype by the Canadian Digital Service"
+  "A benefit signup prototype by the Canadian Digital Service": "A benefit signup prototype by the Canadian Digital Service",
+  "This site will change as we test ideas.": "This site will change as we test ideas."
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -267,5 +267,6 @@
   "Medical Expenses (330)": "Frais médicaux (330)",
   "Net Ontario tax (428)": "Impôt net de l’Ontario (428)",
   "RRSP (208)": "REER (208)",
-  "A benefit signup prototype by the Canadian Digital Service": "Un prototype d’inscription à des avantages fiscaux du Service numérique canadien"
+  "A benefit signup prototype by the Canadian Digital Service": "Un prototype d’inscription à des avantages fiscaux du Service numérique canadien",
+  "This site will change as we test ideas.": "Ce site évoluera au fur et à mesure que nous testons des idées."
 }

--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -76,6 +76,50 @@ li:not(:last-of-type) {
   @extend %page-container;
 }
 
+.fip-container {
+  flex-direction: row;
+  justify-content: space-between;
+  display: flex;
+
+  @include sm {
+    justify-content: space-between;
+  }
+}
+
+.phase-banner {
+  background: #F4F4F4;
+}
+
+.phase-banner {
+  div {
+  @extend %page-container;
+  display: flex;
+  align-items: center;
+  padding-top: $space-sm;
+  padding-bottom: $space-sm;
+  margin-bottom: $space-md;
+  }
+
+  span {
+    font-size: 0.5em;
+
+    @include sm {
+      font-size: 0.7em;
+    }
+  }
+
+  span:first-of-type {
+    border: 2px $color-black solid;
+    padding: 1px 8px;
+    letter-spacing: 1px;
+    margin-right: $space-md;
+  }
+
+  span a {
+    color: $color-black;
+  }
+}
+
 .pure-table {
   width: 100%;
 

--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -80,7 +80,7 @@ li:not(:last-of-type) {
   flex-direction: column;
   display: flex;
 
-  @include xs {
+  @include sm {
     justify-content: space-between;
     flex-direction: row;
   }
@@ -110,9 +110,13 @@ li:not(:last-of-type) {
 
   span:first-of-type {
     border: 2px $color-black solid;
-    padding: 1px 8px;
+    padding: 1px 5px;
     letter-spacing: 1px;
     margin-right: $space-md;
+
+    @include sm {
+      padding: 1px 7px;
+    }
   }
 
   span a {

--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -76,62 +76,6 @@ li:not(:last-of-type) {
   @extend %page-container;
 }
 
-.fip-container {
-  flex-direction: column;
-  display: flex;
-
-  @include sm {
-    justify-content: space-between;
-    flex-direction: row;
-  }
-}
-
-.phase-banner {
-  background: #F4F4F4;
-}
-
-.phase-banner {
-  div {
-  @extend %page-container;
-  display: flex;
-  align-items: flex-start;
-  padding-top: $space-sm;
-  padding-bottom: $space-sm;
-  margin-bottom: $space-md;
-
-  @include sm {
-    align-items: center;
-  }
-  }
-
-  span {
-    font-size: 0.5em;
-
-    @include sm {
-      font-size: 0.7em;
-    }
-  }
-
-  span:first-of-type {
-    border: 2px $color-black solid;
-    padding: 1px 5px;
-    letter-spacing: 1px;
-    margin-right: 1.7em;
-
-    @include sm {
-      padding: 1px 7px;
-    }
-  }
-
-  span:last-of-type {
-    margin-top: 3px;    
-    
-    @include sm {
-      margin-top: 0px;
-    }
-  }
-}
-
 .pure-table {
   width: 100%;
 

--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -77,12 +77,12 @@ li:not(:last-of-type) {
 }
 
 .fip-container {
-  flex-direction: row;
-  justify-content: space-between;
+  flex-direction: column;
   display: flex;
 
-  @include sm {
+  @include xs {
     justify-content: space-between;
+    flex-direction: row;
   }
 }
 

--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -94,10 +94,14 @@ li:not(:last-of-type) {
   div {
   @extend %page-container;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   padding-top: $space-sm;
   padding-bottom: $space-sm;
   margin-bottom: $space-md;
+
+  @include sm {
+    align-items: center;
+  }
   }
 
   span {
@@ -112,15 +116,19 @@ li:not(:last-of-type) {
     border: 2px $color-black solid;
     padding: 1px 5px;
     letter-spacing: 1px;
-    margin-right: $space-md;
+    margin-right: 1.7em;
 
     @include sm {
       padding: 1px 7px;
     }
   }
 
-  span a {
-    color: $color-black;
+  span:last-of-type {
+    margin-top: 3px;    
+    
+    @include sm {
+      margin-top: 0px;
+    }
   }
 }
 

--- a/public/scss/components/_fip.scss
+++ b/public/scss/components/_fip.scss
@@ -1,0 +1,9 @@
+.fip-container {
+  flex-direction: column;
+  display: flex;
+
+  @include sm {
+    justify-content: space-between;
+    flex-direction: row;
+  }
+}

--- a/public/scss/components/_header.scss
+++ b/public/scss/components/_header.scss
@@ -1,14 +1,19 @@
 header {
-  padding: $space-xs 0 0 0;
+  padding: 0 0 0 0;
+
+  button {
+    padding: 0;
+  }
 
   @include sm {
-    padding: $space-lg 0 $space-xl 0;
+    padding: 0 0 $space-xl 0;
+    text-align: right;
   }
 
   .language-link {
-    text-align: right;
-    font-size: 0.85em;
+    text-align: left;
     margin-bottom: $space-sm;
+    font-size: 0.6em;
 
     h2 {
       @include visuallyHidden();
@@ -23,16 +28,20 @@ header {
 
     @include sm {
       margin-bottom: 0;
+      font-size: 0.85em;
     }
   }
 
   .canada-flag {
     width: 272px;
+    margin-bottom: $space-sm;
+
     @include xs {
-      width: 282px;
+      width: 220px;
     }
     @include sm {
       width: 360px;
+      margin-bottom: 0;
     }
   }
 }

--- a/public/scss/components/_header.scss
+++ b/public/scss/components/_header.scss
@@ -6,14 +6,14 @@ header {
   }
 
   @include sm {
-    padding: 0 0 $space-xl 0;
+    padding-bottom: $space-xl;
     text-align: right;
   }
 
   .language-link {
     text-align: left;
     margin-bottom: $space-sm;
-    font-size: 0.6em;
+    font-size: 0.85em;
 
     h2 {
       @include visuallyHidden();
@@ -28,7 +28,6 @@ header {
 
     @include sm {
       margin-bottom: 0;
-      font-size: 0.85em;
     }
   }
 

--- a/public/scss/components/_header.scss
+++ b/public/scss/components/_header.scss
@@ -36,9 +36,6 @@ header {
     width: 272px;
     margin-bottom: $space-sm;
 
-    @include xs {
-      width: 220px;
-    }
     @include sm {
       width: 360px;
       margin-bottom: 0;

--- a/public/scss/components/_phase-banner.scss
+++ b/public/scss/components/_phase-banner.scss
@@ -1,0 +1,45 @@
+.phase-banner {
+  background: #F4F4F4;
+}
+
+.phase-banner {
+  div {
+  @extend %page-container;
+  display: flex;
+  align-items: flex-start;
+  padding-top: $space-sm;
+  padding-bottom: $space-sm;
+  margin-bottom: $space-md;
+
+  @include sm {
+    align-items: center;
+    }
+  }
+
+  span {
+    font-size: 0.5em;
+
+    @include sm {
+      font-size: 0.7em;
+    }
+  }
+
+  span:first-of-type {
+    border: 2px $color-black solid;
+    padding: 1px 5px;
+    letter-spacing: 1px;
+    margin-right: 1.7em;
+
+    @include sm {
+      padding: 1px 7px;
+    }
+  }
+
+  span:last-of-type {
+    margin-top: 3px;    
+    
+    @include sm {
+      margin-top: 0px;
+    }
+  }
+}

--- a/public/styles.scss
+++ b/public/styles.scss
@@ -20,3 +20,5 @@
 @import './scss/components/_multiple-choice';
 @import './scss/components/_banners';
 @import './scss/components/_breakdown-table';
+@import './scss/components/_fip';
+@import './scss/components/_phase-banner';

--- a/views/_includes/fip.pug
+++ b/views/_includes/fip.pug
@@ -1,0 +1,9 @@
+.page--container
+  //- can also potentially put these as strings in our locales file
+  .fip-container
+    .canada-flag
+      if getLocale() == 'fr'
+        img(src='/img/sig-blk-fr.svg', alt='Gouvernement du Canada')
+      else
+        img(src='/img/sig-blk-en.svg', alt='Government of Canada')
+    include languageLink

--- a/views/_includes/phaseBanner.pug
+++ b/views/_includes/phaseBanner.pug
@@ -1,0 +1,4 @@
+.phase-banner
+  div
+    span ALPHA
+    span #{__('This site will change as we test ideas.')}

--- a/views/base.pug
+++ b/views/base.pug
@@ -28,15 +28,21 @@ html(lang=getLocale() === 'fr' ? 'fr' : 'en')
   body
     .container
       header
+        .phase-banner
+          div
+            span ALPHA
+            span This is a new service – your 
+              a(href='#') #{__('feedback')} 
+              | will help us to improve it.
         .page--container
-          include _includes/languageLink
           //- can also potentially put these as strings in our locales file
-          .canada-flag
-            if getLocale() == 'fr'
-              img(src='/img/sig-blk-fr.svg', alt='Gouvernement du Canada')
-            else
-              img(src='/img/sig-blk-en.svg', alt='Government of Canada')
-
+          .fip-container
+            .canada-flag
+              if getLocale() == 'fr'
+                img(src='/img/sig-blk-fr.svg', alt='Gouvernement du Canada')
+              else
+                img(src='/img/sig-blk-en.svg', alt='Government of Canada')
+            include _includes/languageLink
       main
         if errors
           include _includes/errorList.pug

--- a/views/base.pug
+++ b/views/base.pug
@@ -31,9 +31,7 @@ html(lang=getLocale() === 'fr' ? 'fr' : 'en')
         .phase-banner
           div
             span ALPHA
-            span This is a new service – your 
-              a(href='#') #{__('feedback')} 
-              | will help us to improve it.
+            span This site will change as we test ideas.
         .page--container
           //- can also potentially put these as strings in our locales file
           .fip-container

--- a/views/base.pug
+++ b/views/base.pug
@@ -31,7 +31,7 @@ html(lang=getLocale() === 'fr' ? 'fr' : 'en')
         .phase-banner
           div
             span ALPHA
-            span This site will change as we test ideas.
+            span #{__('This site will change as we test ideas.')}
         .page--container
           //- can also potentially put these as strings in our locales file
           .fip-container

--- a/views/base.pug
+++ b/views/base.pug
@@ -28,19 +28,8 @@ html(lang=getLocale() === 'fr' ? 'fr' : 'en')
   body
     .container
       header
-        .phase-banner
-          div
-            span ALPHA
-            span #{__('This site will change as we test ideas.')}
-        .page--container
-          //- can also potentially put these as strings in our locales file
-          .fip-container
-            .canada-flag
-              if getLocale() == 'fr'
-                img(src='/img/sig-blk-fr.svg', alt='Gouvernement du Canada')
-              else
-                img(src='/img/sig-blk-en.svg', alt='Government of Canada')
-            include _includes/languageLink
+        include _includes/phaseBanner
+        include _includes/fip
       main
         if errors
           include _includes/errorList.pug


### PR DESCRIPTION
## This PR consists of the following:

### 1) Creating an Alpha Banner component that is a part of the `base.pug` layout

| Desktop | 
|---------|
| <img width="1338" alt="Screen Shot 2019-07-24 at 13 57 49" src="https://user-images.githubusercontent.com/30609058/61816843-2afbb600-ae1b-11e9-8e6f-792b22791c66.png">    | 

| Mobile |
|--------|
| <img width="327" alt="Screen Shot 2019-07-24 at 13 58 18" src="https://user-images.githubusercontent.com/30609058/61816842-2afbb600-ae1b-11e9-9e8a-97b01e60edc3.png">    |

#### Breakdown
- Designing alpha banner component
- Converting design to html 
- Mobile queries
- French translations
- Css styling

### 2) Aligning french toggle with fip

| Before | After |
|--------|-------|
|   <img width="1012" alt="Screen Shot 2019-07-24 at 14 03 01" src="https://user-images.githubusercontent.com/30609058/61817117-c8ef8080-ae1b-11e9-88ec-2b43c9d9ccfd.png">     |   <img width="645" alt="Screen Shot 2019-07-24 at 14 02 17" src="https://user-images.githubusercontent.com/30609058/61817074-aa898500-ae1b-11e9-8b6d-dc2958b242d0.png">    |

#### Breakdown
- Grouping fip and french toggle into same container
- Applying flexbox properties for alignment
- Mobile queries (`flex: row` on desktop >>> `flex:column` on mobile)

### [Trello Card: Add "Alpha" Branding to app"](https://trello.com/c/A2xnSdW7)

