### PR TITLE
Add French translation to <meta> description

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -269,5 +269,6 @@
   "Detailed breakdown of tax refund": "Detailed breakdown of tax refund",
   "Medical Expenses (330)": "Medical Expenses (330)",
   "Net Ontario tax (428)": "Net Ontario tax (428)",
-  "RRSP (208)": "RRSP (208)"
+  "RRSP (208)": "RRSP (208)",
+  "A benefit signup prototype by the Canadian Digital Service": "A benefit signup prototype by the Canadian Digital Service"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -266,5 +266,6 @@
   "Detailed breakdown of tax refund": "Répartition détaillée du remboursement d’impôt",
   "Medical Expenses (330)": "Frais médicaux (330)",
   "Net Ontario tax (428)": "Impôt net de l’Ontario (428)",
-  "RRSP (208)": "REER (208)"
+  "RRSP (208)": "REER (208)",
+  "A benefit signup prototype by the Canadian Digital Service": "Un prototype d’inscription à des avantages fiscaux du Service numérique canadien"
 }

--- a/views/base.pug
+++ b/views/base.pug
@@ -9,7 +9,7 @@ html(lang=getLocale() === 'fr' ? 'fr' : 'en')
     // Required meta tags
     meta(charset='utf-8')
     meta(name='viewport', content='width=device-width, initial-scale=1, shrink-to-fit=no')
-    meta(name='description' content='[WIP] A benefit signup prototype by the Canadian Digital Service')
+    meta(name='description' content=`[ALPHA] ${__('A benefit signup prototype by the Canadian Digital Service')}`)
     if GITHUB_SHA
       meta(name='keywords' content=`GITHUB_SHA=${GITHUB_SHA}`)
     link(rel='shortcut icon' href='/favicon.png' type='image/x-icon' sizes='32x32')


### PR DESCRIPTION
When we share the link around, some sites (Facebook, Slack, etc), will grab the meta description in the header as a preview.

Currently, our meta description isn't translated into French, so this translates it.

## Screenshots

| before | after |
|--------|-------|
|   ![image](https://user-images.githubusercontent.com/2454380/61813275-4c58a400-ae13-11e9-98ab-a270fc136ba2.png)    |  ![image](https://user-images.githubusercontent.com/2454380/61813319-68f4dc00-ae13-11e9-8a89-d0eb9e9aec28.png)    |

