### PR TITLE
bump header size for node

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "node": ">=10.15"
   },
   "scripts": {
-    "dev": "nodemon ./bin/www",
+    "dev": "nodemon --max-http-header-size=40000 ./bin/www",
     "lint": "node_modules/eslint/bin/eslint.js config routes bin/www app.js",
-    "start": "node ./bin/www",
+    "start": "node --max-http-header-size=40000 ./bin/www",
     "test": "node node_modules/jest/bin/jest.js"
   },
   "dependencies": {


### PR DESCRIPTION
Previously we were getting either a generic `400` error every once in awhile, or on my end, the more specific `431` error.

Node before had a default header size allowance of 80kb, but [changed it to 8kb](https://github.com/nodejs/node/issues/24731). This was causing issues for our app, and forcing us to clear cache regularly. For our purposes now, I've bumped that limit up to 40kb.