### PR TITLE
Task/text looks textier

### DIFF
--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -56,6 +56,7 @@ h4,
 h5,
 h6 {
   font-family: 'Lato', sans-serif;
+  line-height: 1.33;
 }
 
 %page-container {

--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -108,6 +108,7 @@ li:not(:last-of-type) {
 
 .pure-table {
   width: 100%;
+  margin-bottom: $space-sm;
 
   @include sm {
     width: 80%;

--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -22,12 +22,22 @@ body {
 }
 
 p,
+ol,
 ul {
   margin-top: 0;
   margin-bottom: $space-xs;
 
   @include xs {
     margin-bottom: $space-sm;
+  }
+}
+
+ol,
+ul {
+  padding-left: $space-md;
+
+  @include sm {
+    padding-left: $space-xl;
   }
 }
 

--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -95,6 +95,10 @@ main {
 
 li:not(:last-of-type) {
   padding-bottom: $space-xxs;
+
+  @include sm {
+    padding-bottom: 0;
+  }
 }
 
 .container {

--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -8,15 +8,27 @@
 
 body {
   margin: 0;
-  font-size: 1.3em;
+  font-size: 1.05em;
   font-family: 'Noto Sans', sans-serif;
   line-height: 1.65;
+
+  @include xs {
+    font-size: 1.2em;
+  }
+
+  @include sm {
+    font-size: 1.3em;
+  }
 }
 
 p,
 ul {
   margin-top: 0;
-  margin-bottom: $space-sm;
+  margin-bottom: $space-xs;
+
+  @include xs {
+    margin-bottom: $space-sm;
+  }
 }
 
 a {

--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -22,6 +22,7 @@ body {
 }
 
 p,
+.multiple-choice__item p,
 ol,
 ul {
   margin-top: 0;

--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -10,7 +10,13 @@ body {
   margin: 0;
   font-size: 1.3em;
   font-family: 'Noto Sans', sans-serif;
-  line-height: 1.33;
+  line-height: 1.65;
+}
+
+p,
+ul {
+  margin-top: 0;
+  margin-bottom: $space-sm;
 }
 
 a {

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -3,11 +3,16 @@ form.cra-form {
   max-width: 300px;
   width: 100%;
 
+  .d--ib {
+    margin-bottom: $space-xs;
+  }
+
   @include sm {
     max-width: 450px;
 
     .d--ib {
       display: inline-block;
+      margin-bottom: 0;
     }
 
     .w-3-4 {
@@ -48,7 +53,7 @@ form.cra-form {
 
   %form-element {
     display: block;
-    margin: 0 0 $space-xs 0;
+    margin: 0;
     font-size: inherit;
   }
 
@@ -92,7 +97,7 @@ form.cra-form {
     font-size: 1em;
     font-weight: 400;
     width: 100%;
-    margin-top: 0;
+    margin-top: 8px;
     border-radius: 0;
     display: block;
     height: 40px;

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -91,6 +91,10 @@ form.cra-form {
     color: $color-red;
   }
 
+  .multiple-choice .validation-message {
+    margin-bottom: $space-sm;
+  }
+
   input,
   select {
     font-family: sans-serif;
@@ -172,5 +176,9 @@ form.cra-form {
     * {
       margin: 0;
     }
+  }
+
+  .has-error &__legend {
+    margin-bottom: $space-xxs;
   }
 }

--- a/public/scss/_mixins.scss
+++ b/public/scss/_mixins.scss
@@ -51,9 +51,9 @@
     @content;
   }
 }
-/* ≥ 1280px */
+/* ≥ 1200px */
 @mixin xl {
-  @media screen and (min-width: 80em) {
+  @media screen and (min-width: 75em) {
     @content;
   }
 }

--- a/public/scss/components/_details.scss
+++ b/public/scss/components/_details.scss
@@ -23,11 +23,12 @@ details {
     & ~ * {
       margin-top: 0;
       margin-bottom: 0;
-      padding: $space-xxs $space-md;
+      padding: 0 0 $space-sm $space-md;
       border-left: 5px solid $color-grey-light;
 
       &:last-child {
         margin-bottom: $space-md;
+        padding-bottom: $space-xxs;
       }
     }
 

--- a/public/scss/components/_error-list.scss
+++ b/public/scss/components/_error-list.scss
@@ -5,6 +5,7 @@
 
   &__header {
     margin-top: $space-xs;
+    margin-bottom: $space-md;
   }
 
   margin-top: $space-sm;

--- a/public/scss/components/_fip.scss
+++ b/public/scss/components/_fip.scss
@@ -1,9 +1,0 @@
-.fip-container {
-  flex-direction: column;
-  display: flex;
-
-  @include sm {
-    justify-content: space-between;
-    flex-direction: row;
-  }
-}

--- a/public/scss/components/_header.scss
+++ b/public/scss/components/_header.scss
@@ -6,8 +6,18 @@ header {
   }
 
   @include sm {
-    padding-bottom: $space-xl;
+    padding-bottom: $space-lg;
     text-align: right;
+  }
+
+  .fip-container {
+    flex-direction: column;
+    display: flex;
+
+    @include sm {
+      justify-content: space-between;
+      flex-direction: row;
+    }
   }
 
   .language-link {

--- a/public/scss/components/_header.scss
+++ b/public/scss/components/_header.scss
@@ -13,7 +13,7 @@ header {
   .language-link {
     text-align: left;
     margin-bottom: $space-sm;
-    font-size: 0.85em;
+    font-size: 0.9em;
 
     h2 {
       @include visuallyHidden();

--- a/public/scss/components/_multiple-choice.scss
+++ b/public/scss/components/_multiple-choice.scss
@@ -116,17 +116,19 @@
     max-width: 600px;
     margin-left: -$multiple-choice-padding-left;
 
-    p {
-      &:first-child {
-        margin: 0;
-      }
-    }
-
     &__wrapper {
       margin-top: $space-md;
-      padding: $space-md;
+      padding: $space-xs;
       padding-left: $space-lg;
       border-left: 2px solid $color-grey-dark;
+    }
+  }
+
+  p {
+    font-size: 16px;
+
+    @include xs {
+      font-size: inherit;
     }
   }
 

--- a/public/scss/components/_phase-banner.scss
+++ b/public/scss/components/_phase-banner.scss
@@ -1,27 +1,23 @@
 .phase-banner {
-  background: #F4F4F4;
+  background: #f4f4f4;
 }
 
 .phase-banner {
   div {
-  @extend %page-container;
-  display: flex;
-  align-items: flex-start;
-  padding-top: $space-sm;
-  padding-bottom: $space-sm;
-  margin-bottom: $space-md;
+    @extend %page-container;
+    display: flex;
+    align-items: flex-start;
+    padding-top: $space-sm;
+    padding-bottom: $space-sm;
+    margin-bottom: $space-md;
 
-  @include sm {
-    align-items: center;
+    @include sm {
+      align-items: center;
     }
   }
 
   span {
-    font-size: 0.5em;
-
-    @include sm {
-      font-size: 0.7em;
-    }
+    font-size: 0.7em;
   }
 
   span:first-of-type {
@@ -36,8 +32,8 @@
   }
 
   span:last-of-type {
-    margin-top: 3px;    
-    
+    margin-top: 3px;
+
     @include sm {
       margin-top: 0px;
     }

--- a/public/scss/components/_phase-banner.scss
+++ b/public/scss/components/_phase-banner.scss
@@ -1,5 +1,6 @@
 .phase-banner {
   background: #f4f4f4;
+  line-height: 1.33;
 }
 
 .phase-banner {

--- a/public/styles.scss
+++ b/public/styles.scss
@@ -20,5 +20,4 @@
 @import './scss/components/_multiple-choice';
 @import './scss/components/_banners';
 @import './scss/components/_breakdown-table';
-@import './scss/components/_fip';
 @import './scss/components/_phase-banner';


### PR DESCRIPTION
This PR is mostly focused around that "make it look better on a phone" Trello cards. The really big things in here are adjusting the line height, changing all the font sizes, and putting bottom-spacing rules all over the place.

## Increasing the line height

I've been looking at CRA's content pages, and their line height for body content is actually super high at `1.66`. But whatever, it looks fairly nice and our body text is really cramped on smaller screens. It hasn't been a super obvious problem so far since most of our pages are fairly skimpy, but the start page, the confirmation page, and the offramp pages were way too compressed.

## Lowering font sizes

This one breaks with CRA's styling (they never lower the font size), but some of our titles are nuts with one word per line, and in general we have lots of scrolling to read things. It's 100% an improvement to put in smaller font sizes on smaller screens.

## App-wide bottom spacing

Adjusting [bottom spacing](https://csswizardry.com/2012/06/single-direction-margin-declarations/) on a case-by-case basis is pretty much the worst thing ever, so I've tried to create fairly generic rules where possible. If you see something that looks bad, we can change it, but for now I think this is an improvement.

## Screenshots

Most of the changes are fairly subtle on desktop but way more noticeable on mobile, so I mostly have mobile screenshots.

### start page (desktop)

| before | after |
|--------|-------|
|  low line spacing + lots of bottom padding  | high line spacing + less bottom padding     |
| <img width="1428" alt="Screen Shot 2019-07-29 at 11 51 00 AM" src="https://user-images.githubusercontent.com/2454380/62064756-8521c000-b1fb-11e9-8488-c26adbaca43f.png">   |  <img width="1428" alt="Screen Shot 2019-07-29 at 11 51 03 AM" src="https://user-images.githubusercontent.com/2454380/62064755-8521c000-b1fb-11e9-8a3a-f2e4294fc211.png"> |

### start page (mobile)

| before | after |
|--------|-------|
|   v big     |  more reasonable     |
|  ![claim-tax-benefits azurewebsites net_start](https://user-images.githubusercontent.com/2454380/62064617-3c6a0700-b1fb-11e9-86ff-e8e39f31f44c.png)   |  ![localhost_3005_start](https://user-images.githubusercontent.com/2454380/62064621-3e33ca80-b1fb-11e9-9e61-bbb76ccd9e61.png)   |


### address page

| before | after |
|--------|-------|
|   everything is super big + spacing between first two fields is effed     |  smaller + fixed spacing  |
|  ![claim-tax-benefits azurewebsites net_personal_address_edit](https://user-images.githubusercontent.com/2454380/62064531-0e84c280-b1fb-11e9-9458-9e196afa8293.png)  | ![localhost_3005_personal_address_edit](https://user-images.githubusercontent.com/2454380/62064537-10e71c80-b1fb-11e9-8224-9e3b74371289.png)   |

### error list items

| before | after |
|--------|-------|
| list items are massive + left spacing is too big   |   list items are good now   |
|  ![claim-tax-benefits azurewebsites net_personal_address_edit (1)](https://user-images.githubusercontent.com/2454380/62064229-640c9f80-b1fa-11e9-81f9-b8546371c0f5.png)  | ![localhost_3005_personal_address_edit (1)](https://user-images.githubusercontent.com/2454380/62064234-653dcc80-b1fa-11e9-8b1c-79464d8be9ce.png)  |

### confirmation page

| before | after |
|--------|-------|
| header (almost) gets cut off    |  header is comfortable  |
|  ![claim-tax-benefits azurewebsites net_confirmation](https://user-images.githubusercontent.com/2454380/62064139-3b84a580-b1fa-11e9-9574-759bf178ba86.png)    |  ![localhost_3005_confirmation](https://user-images.githubusercontent.com/2454380/62064136-3a537880-b1fa-11e9-811e-21842d0776b0.png)  |






