### PR TITLE
add banners to main page and sin page

### DIFF
--- a/public/scss/components/_banners.scss
+++ b/public/scss/components/_banners.scss
@@ -30,7 +30,7 @@
         left: 20px;
     }
 
-    &--blue {
+    &--blue, &--check {
         background: $color-banner-blue-light;
         border-left: 5px solid $color-banner-blue;
 
@@ -38,4 +38,15 @@
             background: $color-banner-blue;
         }
     }
+
+    &--check {
+        &__icon {
+            display: inline-block;
+            background-image: url("data:image/svg+xml,%3Csvg width='13px' height='11px' viewBox='0 0 13 11' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Cdesc%3Echeckmark%3C/desc%3E%3Cg id='Page-1' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd' stroke-linecap='square'%3E%3Cg id='1.3-Enter-SIN' transform='translate(-79.000000, -232.000000)' stroke='%23FFFFFF' stroke-width='2'%3E%3Cg id='Group-3' transform='translate(81.000000, 232.000000)'%3E%3Cpath d='M0,6.44810072 L3.16500985,8.84667626' id='Line-5'%3E%3C/path%3E%3Cpath d='M3.03186405,1.92361281 L9.77998686,8.5' id='Line-5' transform='translate(6.279987, 5.000000) rotate(84.000000) translate(-6.279987, -5.000000) '%3E%3C/path%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-position: center;
+        }
+    }
+
+
 }

--- a/views/_includes/banner.pug
+++ b/views/_includes/banner.pug
@@ -1,6 +1,6 @@
-mixin banner(variant, spanChar='i')
+mixin banner(variant)
   div(class="banner banner--" + variant +"")
-    span(class="banner__icon banner--"+ variant +"__icon" aria-hidden="true")= spanChar
+    span(class="banner__icon banner--"+ variant +"__icon" aria-hidden="true")= variant !== 'check' ? 'i' : null
     if block
       block
     else

--- a/views/_includes/banner.pug
+++ b/views/_includes/banner.pug
@@ -1,6 +1,6 @@
-mixin banner(variant, spanChar)
+mixin banner(variant, spanChar='i')
   div(class="banner banner--" + variant +"")
-    span(class="banner__icon banner--"+ variant +"__icon" aria-hidden="true")= spanChar || 'i'
+    span(class="banner__icon banner--"+ variant +"__icon" aria-hidden="true")= spanChar
     if block
       block
     else

--- a/views/login/sin.pug
+++ b/views/login/sin.pug
@@ -1,4 +1,5 @@
 extends ../base
+include ../_includes/banner
 
 block variables
   -var title = __('Enter your Social Insurance Number (SIN)')
@@ -7,6 +8,9 @@ block variables
 block content
 
   h1 #{title}
+
+  +banner('check', '')
+    p #{__('Your access code was validated!')}
 
   if data.personal
     h2 #{__('Thanks,')} #{data.personal.firstName} #{data.personal.lastName}!

--- a/views/login/sin.pug
+++ b/views/login/sin.pug
@@ -9,7 +9,7 @@ block content
 
   h1 #{title}
 
-  +banner('check', '')
+  +banner('check')
     p #{__('Your access code was validated!')}
 
   if data.personal

--- a/views/start/index.pug
+++ b/views/start/index.pug
@@ -1,8 +1,12 @@
 extends ../base
+include ../_includes/banner
 
 block content
 
   h1 #{__('Claim Tax Benefits')}
+
+  +banner('blue')
+    p #{__('Keep your notification letter with you. You need information on that letter to use this service.')}
 
   div
     p #{__('Welcome to the Canada Revenue Agency’s new')} <strong>#{__('Claim Tax Benefits')}</strong> #{__('service')}.


### PR DESCRIPTION
Add the previous banner to the other spots where it's present in the app (according to the latest sketch).
Had to add a check variant, for the one's where the circle contains a check mark inside.

![localhost_3005_start](https://user-images.githubusercontent.com/6607541/62074349-932e0b80-b210-11e9-968e-4fb7bc894bc2.png)
![localhost_3005_login_sin](https://user-images.githubusercontent.com/6607541/62074371-9fb26400-b210-11e9-980f-fc1444ddb5be.png)
