### PR TITLE
fixup/Nunavut not NunavutNunavut + Add colon

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -47,7 +47,7 @@
   "Download your Notice of Assessment": "Download your Notice of Assessment",
   "Do you have questions?": "Do you have questions?",
   "Now that your return is filed, you should be all set for the year.": "Now that your return is filed, you should be all set for the year.",
-  "However, if you still have further questions, there are several ways to get help.": "However, if you still have further questions, there are several ways to get help.",
+  "However, if you still have further questions, there are several ways to get help:": "However, if you still have further questions, there are several ways to get help:",
   "Speak to someone at your nearest tax clinic": "Speak to someone at your nearest tax clinic",
   "Go online to": "Go online to",
   "find a free tax clinic in your area": "find a free tax clinic in your area",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -47,7 +47,7 @@
   "Download your Notice of Assessment": "Télécharger mon avis de cotisation",
   "Do you have questions?": "Avez-vous des questions?",
   "Now that your return is filed, you should be all set for the year.": "Maintenant que vous avez produit votre déclaration de revenus, tout est en ordre pour l’année.",
-  "However, if you still have further questions, there are several ways to get help.": "Si toutefois vous avez des questions, plusieurs choix s’offrent à vous.",
+  "However, if you still have further questions, there are several ways to get help:": "Si toutefois vous avez des questions, plusieurs choix s’offrent à vous :",
   "Speak to someone at your nearest tax clinic": "Parlez à une personne dans une clinique d’impôts près de chez vous",
   "Go online to": "Trouvez, sur Internet,",
   "find a free tax clinic in your area": "une clinique d’impôts gratuits dans votre région",

--- a/views/confirmation/confirmation.pug
+++ b/views/confirmation/confirmation.pug
@@ -33,7 +33,7 @@ block content
     h3 #{__('Do you have questions?')}
 
     p #{__('Now that your return is filed, you should be all set for the year.')}
-    p #{__('However, if you still have further questions, there are several ways to get help.')}
+    p #{__('However, if you still have further questions, there are several ways to get help:')}
     ul
       li #{__('Speak to someone at your nearest tax clinic')}
       li #{__('Go online to')} <a href="https://apps.cra-arc.gc.ca/ebci/oecv/external/prot/cli_srch_01_ld.action" target="_blank">#{__('find a free tax clinic in your area')}</a>

--- a/views/personal/address-edit.pug
+++ b/views/personal/address-edit.pug
@@ -45,7 +45,7 @@ block content
           option(value='Newfoundland And Labrador' selected=province =='Newfoundland And Labrador') #{__('Newfoundland and Labrador')}
           option(value='Northwest Territories' selected=province =='Northwest Territories') #{__('Northwest Territories')}
           option(value='Nova Scotia' selected=province =='Nova Scotia') #{__('Nova Scotia')}
-          option(value='Nunavut' selected=province =='Nunavut') #{__('Nunavut')}Nunavut
+          option(value='Nunavut' selected=province =='Nunavut') #{__('Nunavut')}
           option(value='Ontario' selected=province == 'Ontario') #{__('Ontario')}
           option(value='Prince Edward Island' selected=province =='Prince Edward Island') #{__('Prince Edward Island')}
           option(value='Quebec'  selected=province =='Quebec') #{__('Quebec')}


### PR DESCRIPTION
Made a few mistakesmistakes but luckily @rossferg is on the case.

- "Nunavut" not "NunavutNunavut" on the change address dropdown: resolves #95 
- Put a colon before the bullet list on the confirmation page: resolves #99  