### PR TITLE
Cross browser focus styles

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -280,5 +280,8 @@
   "The income we have on file does not match your records": "The income we have on file does not match your records",
   "If your records don’t match the income information displayed earlier, or you believe it to be incorrect, you shouldn’t use this service to file your taxes.": "If your records don’t match the income information displayed earlier, or you believe it to be incorrect, you shouldn’t use this service to file your taxes.",
   "Go back": "Go back",
-  "Is this your name?": "Is this your name?"
+  "Is this your name?": "Is this your name?",
+  "Keep your notification letter with you. You need information on that letter to use this service.": "Keep your notification letter with you. You need information on that letter to use this service.",
+  "For Example: A5G98S4K1": "For Example: A5G98S4K1",
+  "Your access code was validated!": "Your access code was validated!"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -268,5 +268,6 @@
   "Net Ontario tax (428)": "Impôt net de l’Ontario (428)",
   "RRSP (208)": "REER (208)",
   "A benefit signup prototype by the Canadian Digital Service": "Un prototype d’inscription à des avantages fiscaux du Service numérique canadien",
-  "This site will change as we test ideas.": "Ce site évoluera au fur et à mesure que nous testons des idées."
+  "This site will change as we test ideas.": "Ce site évoluera au fur et à mesure que nous testons des idées.",
+  "Keep your notification letter with you. You need information on that letter to use this service.": "Keep your notification letter with you. You need information on that letter to use this service."
 }

--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -2,8 +2,17 @@
   box-sizing: border-box;
 }
 
-*:focus {
-  @include focus();
+a[href],
+area[href],
+input,
+select
+textarea,
+button,
+iframe,
+[tabindex],
+[contentEditable=true]
+{
+  &:not([disabled]):focus { @include focus(); }
 }
 
 body {


### PR DESCRIPTION
## This PR consists of the following:

### Fixing focus styles for firefox and ie11 browsers
| Before |
|--------|
|   ![ie11](https://user-images.githubusercontent.com/30609058/62175258-f1d7b000-b30a-11e9-8c96-0c80c9f2e6c1.gif)     |  

### Breakdown
- Turns out ie11 and ff handle focus styles differently than chrome does
- Some css styles have been applied to account for this
- Source: [stackoverflow thread](https://stackoverflow.com/questions/1599660/which-html-elements-can-receive-focus)