### PR TITLE
Task/Fix <details> element on IE11

### DIFF
--- a/public/js/details-element-polyfill.js
+++ b/public/js/details-element-polyfill.js
@@ -1,0 +1,203 @@
+/*
+Details Element Polyfill 2.3.1
+Copyright © 2019 Javan Makhmali
+ */
+(function() {
+  "use strict";
+  var element = document.createElement("details");
+  element.innerHTML = "<summary>a</summary>b";
+  element.setAttribute("style", "position: absolute; left: -9999px");
+  var support = {
+    open: "open" in element && elementExpands(),
+    toggle: "ontoggle" in element
+  };
+  function elementExpands() {
+    (document.body || document.documentElement).appendChild(element);
+    var closedHeight = element.offsetHeight;
+    element.open = true;
+    var openedHeight = element.offsetHeight;
+    element.parentNode.removeChild(element);
+    return closedHeight != openedHeight;
+  }
+  var styles = '\ndetails, summary {\n  display: block;\n}\ndetails:not([open]) > *:not(summary) {\n  display: none;\n}\nsummary::before {\n  content: "►";\n  padding-right: 0.3rem;\n  font-size: 0.6rem;\n  cursor: default;\n}\n[open] > summary::before {\n  content: "▼";\n}\n';
+  var _ref = [], forEach = _ref.forEach, slice = _ref.slice;
+  if (!support.open) {
+    polyfillStyles();
+    polyfillProperties();
+    polyfillToggle();
+    polyfillAccessibility();
+  }
+  if (support.open && !support.toggle) {
+    polyfillToggleEvent();
+  }
+  function polyfillStyles() {
+    document.head.insertAdjacentHTML("afterbegin", "<style>" + styles + "</style>");
+  }
+  function polyfillProperties() {
+    var prototype = document.createElement("details").constructor.prototype;
+    var setAttribute = prototype.setAttribute, removeAttribute = prototype.removeAttribute;
+    var open = Object.getOwnPropertyDescriptor(prototype, "open");
+    Object.defineProperties(prototype, {
+      open: {
+        get: function get() {
+          if (this.tagName == "DETAILS") {
+            return this.hasAttribute("open");
+          } else {
+            if (open && open.get) {
+              return open.get.call(this);
+            }
+          }
+        },
+        set: function set(value) {
+          if (this.tagName == "DETAILS") {
+            return value ? this.setAttribute("open", "") : this.removeAttribute("open");
+          } else {
+            if (open && open.set) {
+              return open.set.call(this, value);
+            }
+          }
+        }
+      },
+      setAttribute: {
+        value: function value(name, _value) {
+          var _this = this;
+          var call = function call() {
+            return setAttribute.call(_this, name, _value);
+          };
+          if (name == "open" && this.tagName == "DETAILS") {
+            var wasOpen = this.hasAttribute("open");
+            var result = call();
+            if (!wasOpen) {
+              var summary = this.querySelector("summary");
+              if (summary) summary.setAttribute("aria-expanded", true);
+              triggerToggle(this);
+            }
+            return result;
+          }
+          return call();
+        }
+      },
+      removeAttribute: {
+        value: function value(name) {
+          var _this2 = this;
+          var call = function call() {
+            return removeAttribute.call(_this2, name);
+          };
+          if (name == "open" && this.tagName == "DETAILS") {
+            var wasOpen = this.hasAttribute("open");
+            var result = call();
+            if (wasOpen) {
+              var summary = this.querySelector("summary");
+              if (summary) summary.setAttribute("aria-expanded", false);
+              triggerToggle(this);
+            }
+            return result;
+          }
+          return call();
+        }
+      }
+    });
+  }
+  function polyfillToggle() {
+    onTogglingTrigger(function(element) {
+      element.hasAttribute("open") ? element.removeAttribute("open") : element.setAttribute("open", "");
+    });
+  }
+  function polyfillToggleEvent() {
+    if (window.MutationObserver) {
+      new MutationObserver(function(mutations) {
+        forEach.call(mutations, function(mutation) {
+          var target = mutation.target, attributeName = mutation.attributeName;
+          if (target.tagName == "DETAILS" && attributeName == "open") {
+            triggerToggle(target);
+          }
+        });
+      }).observe(document.documentElement, {
+        attributes: true,
+        subtree: true
+      });
+    } else {
+      onTogglingTrigger(function(element) {
+        var wasOpen = element.getAttribute("open");
+        setTimeout(function() {
+          var isOpen = element.getAttribute("open");
+          if (wasOpen != isOpen) {
+            triggerToggle(element);
+          }
+        }, 1);
+      });
+    }
+  }
+  function polyfillAccessibility() {
+    setAccessibilityAttributes(document);
+    if (window.MutationObserver) {
+      new MutationObserver(function(mutations) {
+        forEach.call(mutations, function(mutation) {
+          forEach.call(mutation.addedNodes, setAccessibilityAttributes);
+        });
+      }).observe(document.documentElement, {
+        subtree: true,
+        childList: true
+      });
+    } else {
+      document.addEventListener("DOMNodeInserted", function(event) {
+        setAccessibilityAttributes(event.target);
+      });
+    }
+  }
+  function setAccessibilityAttributes(root) {
+    findElementsWithTagName(root, "SUMMARY").forEach(function(summary) {
+      var details = findClosestElementWithTagName(summary, "DETAILS");
+      summary.setAttribute("aria-expanded", details.hasAttribute("open"));
+      if (!summary.hasAttribute("tabindex")) summary.setAttribute("tabindex", "0");
+      if (!summary.hasAttribute("role")) summary.setAttribute("role", "button");
+    });
+  }
+  function eventIsSignificant(event) {
+    return !(event.defaultPrevented || event.ctrlKey || event.metaKey || event.shiftKey || event.target.isContentEditable);
+  }
+  function onTogglingTrigger(callback) {
+    addEventListener("click", function(event) {
+      if (eventIsSignificant(event)) {
+        if (event.which <= 1) {
+          var element = findClosestElementWithTagName(event.target, "SUMMARY");
+          if (element && element.parentNode && element.parentNode.tagName == "DETAILS") {
+            callback(element.parentNode);
+          }
+        }
+      }
+    }, false);
+    addEventListener("keydown", function(event) {
+      if (eventIsSignificant(event)) {
+        if (event.keyCode == 13 || event.keyCode == 32) {
+          var element = findClosestElementWithTagName(event.target, "SUMMARY");
+          if (element && element.parentNode && element.parentNode.tagName == "DETAILS") {
+            callback(element.parentNode);
+            event.preventDefault();
+          }
+        }
+      }
+    }, false);
+  }
+  function triggerToggle(element) {
+    var event = document.createEvent("Event");
+    event.initEvent("toggle", false, false);
+    element.dispatchEvent(event);
+  }
+  function findElementsWithTagName(root, tagName) {
+    return (root.tagName == tagName ? [ root ] : []).concat(typeof root.getElementsByTagName == "function" ? slice.call(root.getElementsByTagName(tagName)) : []);
+  }
+  function findClosestElementWithTagName(element, tagName) {
+    if (typeof element.closest == "function") {
+      return element.closest(tagName);
+    } else {
+      while (element) {
+        if (element.tagName == tagName) {
+          return element;
+        } else {
+          element = element.parentNode;
+        }
+      }
+    }
+  }
+})();

--- a/public/scss/components/_details.scss
+++ b/public/scss/components/_details.scss
@@ -1,5 +1,6 @@
 details {
   margin-bottom: $space-lg;
+  list-style-type: none;
 
   summary {
     color: $color-blue-dark;

--- a/public/scss/components/_details.scss
+++ b/public/scss/components/_details.scss
@@ -9,7 +9,7 @@ details {
     display: list-item;
 
     &:focus {
-      outline: 0;
+      outline: 0 !important;
 
       > span {
         @include focus($outlineOffset: 2px);

--- a/views/_includes/script.pug
+++ b/views/_includes/script.pug
@@ -7,5 +7,5 @@ script.
   }
 
 script.
-  if (typeof Promise !== "function")
+  if (typeof Promise !== "function" && document.querySelector('details') !== null)
   document.write('<script src="//unpkg.com/details-element-polyfill@2.3.1/dist/details-element-polyfill.js"><\/script>');

--- a/views/_includes/script.pug
+++ b/views/_includes/script.pug
@@ -8,4 +8,4 @@ script.
 
 script.
   if (typeof Promise !== "function" && document.querySelector('details') !== null)
-  document.write('<script src="//unpkg.com/details-element-polyfill@2.3.1/dist/details-element-polyfill.js"><\/script>');
+  document.write('<script src="/js/details-element-polyfill.js"><\/script>');

--- a/views/_includes/script.pug
+++ b/views/_includes/script.pug
@@ -5,3 +5,7 @@ script.
       if (e.keyCode == 32) { e.target.click() }
     })
   }
+
+script.
+  if (typeof Promise !== "function")
+  document.write('<script src="//unpkg.com/details-element-polyfill@2.3.1/dist/details-element-polyfill.js"><\/script>');


### PR DESCRIPTION
Copy+pasted in a polyfill into our /public folder and conditionally including it on pages with a `details` element in older browsers (eg, in IE11).

So there's a few decisions in here.

## Adding a polyfill

`<details>` elements don't work in IE11, but they're a nice semantic solution for what we want to do: conditionally display information.

The easy way to fix this without a lot of finagling is to include a polyfill. I've picked the `details-element-polyfill` on npm because it's the most popular one.

## Not using a CDN

After humming and hawing, using a CDN might cause weird problems because @ayoajila has been telling me there are weird proxy issues going on trying to run the app on his laptop.

Using a CDN also means that our container isn't self-contained anymore if it relies on an external request.

So, I just copied the polyfill lock, stock into a `/js` directory. I doubt it gets updated very often and if we need to update it we can just copy in the latest version.

I figured we don't really need to include this in our package.json as a dependency. (what do you think @katedee?)

## Using a conditional statement with `document.write()`

There are more ways to do this that are discussed at length in this this other article: https://philipwalton.com/articles/loading-polyfills-only-when-needed/

However, this was cheap, easy, and it works, so I didn't want to overdo it.

Source:
- https://stackoverflow.com/questions/45509701/elegant-way-to-include-es6-promise-for-ie

## Screenshots

| before | after |
|--------|-------|
|   ![ie114](https://user-images.githubusercontent.com/2454380/62226880-e4f9a180-b388-11e9-97f9-64e439f03ac7.gif)   | ![ie113](https://user-images.githubusercontent.com/2454380/62226881-e4f9a180-b388-11e9-8c3d-2cc49c2e2e41.gif)  |



