### PR TITLE
Fix/mobile tables

### DIFF
--- a/public/scss/components/_breakdown-table.scss
+++ b/public/scss/components/_breakdown-table.scss
@@ -1,54 +1,3 @@
-// .breakdown-table {
-//   width: 80%;
-//   border-collapse: collapse;
-//   border-spacing: 0;
-//   empty-cells: show;
-//   border: none;
-//   margin-bottom: $space-xxl;
-
-//   td, th:not([class]) {
-//     padding: 10px 28px;
-//   }
-
-//   tr td:last-child,
-//   tr th.breakdown-table__heading:last-child  {
-//     text-align: right;
-//   }
-
-//   tr:not(:first-child) {
-//     border-left: 2px solid $color-grey-light;
-//   }
-
-//   .space-row {
-//     &:last-of-type td {
-//       padding-top: $space-xxl;
-//     }
-
-//     td {
-//       padding-top: $space-xl;
-//     }
-//   }
-
-//   &__heading {
-//     text-align: left;
-//     background: $color-grey-light;
-//     padding: 28px;
-//     font-size: 1.75rem;
-//     font-weight: 700;
-//   }
-
-//   &__subheading {
-//     text-align: left;
-//     font-weight: 400;
-//     padding: 10px 28px;
-//     padding-bottom: $space-md;
-//   }
-
-//   &__summary-row {
-//     font-weight: 700;
-//   }
-// }
-
 .breakdown-table {
   $table: &;
 
@@ -69,8 +18,12 @@
     text-align: left;
     background: $color-grey-light;
     padding: 28px;
-    font-size: 1.75rem;
+    font-size: 1em;
     font-weight: 700;
+
+    @include md {
+      font-size: 1.3em;
+    }
 
     span {
       width: 60%;
@@ -88,13 +41,22 @@
     font-weight: 400;
     padding: 10px 28px;
     padding-bottom: $space-md;
+    font-size: 0.9em;
+
+    @include md {
+      font-size: 1em;
+    }
   }
   
   &__row {
-    border-left: 2px solid $color-grey-light;
+    border-top: 1px solid $color-grey-light;
+    padding: 10px 28px;
 
     @include md {
+      padding: 0;
       display: table-row;
+      border-top: 0;
+      border-left: 2px solid $color-grey-light;
     }
 
     &--summary {
@@ -107,23 +69,28 @@
     margin: 0;
     word-wrap: break-word;
     overflow-wrap: break-word;
-    padding: 10px 28px;
+    font-size: 0.9em;
 
     @include md {
+      font-size: 1em;
       display: table-cell;
+      padding: 10px 28px;
     }
   }
 
   .key {
     margin-bottom: 5px;
+    font-weight: 700;
     @include md {
+      font-weight: 400;
       width: 60%;
     }
   }
+
   .value {
     white-space: pre-wrap;
-    text-align: right;
     @include md {
+      text-align: right;
       width: 40%;
     }
   }

--- a/public/scss/components/_breakdown-table.scss
+++ b/public/scss/components/_breakdown-table.scss
@@ -1,50 +1,131 @@
+// .breakdown-table {
+//   width: 80%;
+//   border-collapse: collapse;
+//   border-spacing: 0;
+//   empty-cells: show;
+//   border: none;
+//   margin-bottom: $space-xxl;
+
+//   td, th:not([class]) {
+//     padding: 10px 28px;
+//   }
+
+//   tr td:last-child,
+//   tr th.breakdown-table__heading:last-child  {
+//     text-align: right;
+//   }
+
+//   tr:not(:first-child) {
+//     border-left: 2px solid $color-grey-light;
+//   }
+
+//   .space-row {
+//     &:last-of-type td {
+//       padding-top: $space-xxl;
+//     }
+
+//     td {
+//       padding-top: $space-xl;
+//     }
+//   }
+
+//   &__heading {
+//     text-align: left;
+//     background: $color-grey-light;
+//     padding: 28px;
+//     font-size: 1.75rem;
+//     font-weight: 700;
+//   }
+
+//   &__subheading {
+//     text-align: left;
+//     font-weight: 400;
+//     padding: 10px 28px;
+//     padding-bottom: $space-md;
+//   }
+
+//   &__summary-row {
+//     font-weight: 700;
+//   }
+// }
+
 .breakdown-table {
-  width: 80%;
-  border-collapse: collapse;
-  border-spacing: 0;
-  empty-cells: show;
-  border: none;
-  margin-bottom: $space-xxl;
+  $table: &;
 
-  td, th:not([class]) {
-    padding: 10px 28px;
+  @include md {
+    max-width: 750px;
   }
 
-  tr td:last-child,
-  tr th.breakdown-table__heading:last-child  {
-    text-align: right;
-  }
-
-  tr:not(:first-child) {
-    border-left: 2px solid $color-grey-light;
-  }
-
-  .space-row {
-    &:last-of-type td {
-      padding-top: $space-xxl;
-    }
-
-    td {
-      padding-top: $space-xl;
+  &-data {
+    @include md {
+      border-collapse: collapse; 
+      display: table;
+      width: 100%;
+      table-layout: fixed;
     }
   }
 
-  &__heading {
+  h2#{$table}__heading {
     text-align: left;
     background: $color-grey-light;
     padding: 28px;
     font-size: 1.75rem;
     font-weight: 700;
+
+    span {
+      width: 60%;
+      display: inline-block;
+
+      &:last-child {
+        width: 39%;
+        text-align: right;
+      }
+    }
   }
 
-  &__subheading {
+  p#{$table}__subheading {
     text-align: left;
     font-weight: 400;
     padding: 10px 28px;
     padding-bottom: $space-md;
   }
+  
+  &__row {
+    border-left: 2px solid $color-grey-light;
 
-  &__summary-row {
-    font-weight: 700;
+    @include md {
+      display: table-row;
+    }
+
+    &--summary {
+      font-weight: 700;
+    }
   }
+
+  .key,
+  .value {
+    margin: 0;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    padding: 10px 28px;
+
+    @include md {
+      display: table-cell;
+    }
+  }
+
+  .key {
+    margin-bottom: 5px;
+    @include md {
+      width: 60%;
+    }
+  }
+  .value {
+    white-space: pre-wrap;
+    text-align: right;
+    @include md {
+      width: 40%;
+    }
+  }
+  
 }

--- a/public/scss/components/_breakdown-table.scss
+++ b/public/scss/components/_breakdown-table.scss
@@ -46,26 +46,26 @@
     @include md {
       font-size: 1em;
     }
-  }
-  
-  &__row {
-    border-top: 1px solid $color-grey-light;
-    padding: 10px 28px;
+  }  
+}
 
-    @include md {
-      padding: 0;
-      display: table-row;
-      border-top: 0;
-      border-left: 2px solid $color-grey-light;
-    }
+.breakdown-table__row {
+  border-top: 1px solid $color-grey-light;
+  padding: 10px 28px;
 
-    &--summary {
-      font-weight: 700;
-    }
+  @include md {
+    padding: 0;
+    display: table-row;
+    border-top: 0;
+    border-left: 2px solid $color-grey-light;
   }
 
-  .key,
-  .value {
+  &--summary {
+    font-weight: 700;
+  }
+
+  &-key,
+  &-value {
     margin: 0;
     word-wrap: break-word;
     overflow-wrap: break-word;
@@ -78,7 +78,7 @@
     }
   }
 
-  .key {
+  &-key {
     margin-bottom: 5px;
     font-weight: 700;
     @include md {
@@ -87,12 +87,11 @@
     }
   }
 
-  .value {
+  &-value {
     white-space: pre-wrap;
     @include md {
       text-align: right;
       width: 40%;
     }
   }
-  
 }

--- a/views/confirmation/review.pug
+++ b/views/confirmation/review.pug
@@ -22,43 +22,43 @@ block content
     p #{__('Take one final look before continuing. If something looks incorrect, please')} #[a(href="https://www.canada.ca/en/revenue-agency/corporate/contact-information/telephone-numbers.html") #{__('contact CRA')}] #{__('before filing.')}
 
   div
-    table.breakdown-table
-      thead
-        tr
-          th.breakdown-table__heading #{__('Your annual benefits')}
-          th.breakdown-table__heading $#{currencyFilter(totalBenefits)}
-      tbody
-        tr
-          th(colspan="2").breakdown-table__subheading #{__('Detailed breakdown of benefits')}
+    .breakdown-table
+      h2.breakdown-table__heading 
+        span #{__('Your annual benefits')}
+        span $#{currencyFilter(totalBenefits)}
+      
+      p.breakdown-table__subheading #{__('Detailed breakdown of benefits')}
+
+      .breakdown-table-data
         each val, index in benefits
           if index !== "totalBenefits"
-            tr
-              td #{__(`${index}`)}
-              td $#{currencyFilter(val)}
+            .breakdown-table__row
+              dt.breakdown-table__row-key #{__(`${index}`)}
+              dd.breakdown-table__row-value $#{currencyFilter(val)}
 
-        tr.breakdown-table__summary-row
-          td #{__('Total Benefits')}
-          td $#{currencyFilter(totalBenefits)}
+        .breakdown-table__row.breakdown-table__row--summary
+          dt.breakdown-table__row-key #{__('Total Benefits')}
+          dd.breakdown-table__row-value $#{currencyFilter(totalBenefits)}
 
   div
-    table.breakdown-table
-      thead
-        tr
-          th.breakdown-table__heading #{__('Your projected refund')}
-          th.breakdown-table__heading +$#{currencyFilter(totalRefund.amount)}
-      tbody
-        tr
-          th(colspan="2").breakdown-table__subheading #{__('Detailed breakdown of tax refund')}
+    .breakdown-table
+      h2.breakdown-table__heading 
+        span #{__('Your projected refund')}
+        span +$#{currencyFilter(totalRefund.amount)}
+      
+      p.breakdown-table__subheading #{__('Detailed breakdown of tax refund')}
+
+      .breakdown-table-data
         each refundLine in refundLines
           -var lineNumber = refundLine.multiLine ? refundLine.multiLine : refundLine.line
-          tr(
+          .breakdown-table__row(
             class={
-              ['breakdown-table__summary-row space-row']: refundLine.name === "Total Refund",
+              ['breakdown-table__row--summary space-row']: refundLine.name === "Total Refund",
               ['space-row']: count === 5 || count === 6 || count === 7 || count === 9
             }
           )
-            td #{__(`${refundLine.name} (${lineNumber})`)}
-            td $#{currencyFilter(refundLine.amount)}
+            dt.breakdown-table__row-key #{__(`${refundLine.name} (${lineNumber})`)}
+            dd.breakdown-table__row-value $#{currencyFilter(refundLine.amount)}
 
           - count++
 

--- a/views/confirmation/review.pug
+++ b/views/confirmation/review.pug
@@ -48,7 +48,7 @@ block content
       
       p.breakdown-table__subheading #{__('Detailed breakdown of tax refund')}
 
-      .breakdown-table-data
+      dl.breakdown-table-data
         each refundLine in refundLines
           -var lineNumber = refundLine.multiLine ? refundLine.multiLine : refundLine.line
           .breakdown-table__row(

--- a/views/confirmation/review.pug
+++ b/views/confirmation/review.pug
@@ -22,14 +22,14 @@ block content
     p #{__('Take one final look before continuing. If something looks incorrect, please')} #[a(href="https://www.canada.ca/en/revenue-agency/corporate/contact-information/telephone-numbers.html") #{__('contact CRA')}] #{__('before filing.')}
 
   div
-    dl.breakdown-table
+    .breakdown-table
       h2.breakdown-table__heading 
         span #{__('Your annual benefits')}
         span $#{currencyFilter(totalBenefits)}
       
       p.breakdown-table__subheading #{__('Detailed breakdown of benefits')}
 
-      .breakdown-table-data
+      dl.breakdown-table-data
         each val, index in benefits
           if index !== "totalBenefits"
             .breakdown-table__row
@@ -41,7 +41,7 @@ block content
           dd.breakdown-table__row-value $#{currencyFilter(totalBenefits)}
 
   div
-    dl.breakdown-table
+    .breakdown-table
       h2.breakdown-table__heading 
         span #{__('Your projected refund')}
         span +$#{currencyFilter(totalRefund.amount)}

--- a/views/confirmation/review.pug
+++ b/views/confirmation/review.pug
@@ -22,7 +22,7 @@ block content
     p #{__('Take one final look before continuing. If something looks incorrect, please')} #[a(href="https://www.canada.ca/en/revenue-agency/corporate/contact-information/telephone-numbers.html") #{__('contact CRA')}] #{__('before filing.')}
 
   div
-    .breakdown-table
+    dl.breakdown-table
       h2.breakdown-table__heading 
         span #{__('Your annual benefits')}
         span $#{currencyFilter(totalBenefits)}
@@ -41,7 +41,7 @@ block content
           dd.breakdown-table__row-value $#{currencyFilter(totalBenefits)}
 
   div
-    .breakdown-table
+    dl.breakdown-table
       h2.breakdown-table__heading 
         span #{__('Your projected refund')}
         span +$#{currencyFilter(totalRefund.amount)}

--- a/views/financial/income.pug
+++ b/views/financial/income.pug
@@ -27,12 +27,12 @@ block content
       .breakdown-table-data
         each income in incomeSources
           .breakdown-table__row
-            dt.key #{income.name} #{__('Total Income')}
-            dd.value $#{currencyFilter(income.total)}
+            dt.breakdown-table__row-key #{income.name} #{__('Total Income')}
+            dd.breakdown-table__row-value $#{currencyFilter(income.total)}
 
         .breakdown-table__row.breakdown-table__row--summary
-          dt.key #{__(`Total Income for ${year}`)}
-          dd.value $#{currencyFilter(totalIncome.amount)}
+          dt.breakdown-table__row-key #{__(`Total Income for ${year}`)}
+          dd.breakdown-table__row-value $#{currencyFilter(totalIncome.amount)}
 
   .breakdown-table
       h2.breakdown-table__heading 
@@ -44,12 +44,12 @@ block content
       .breakdown-table-data
         each tax in taxes
           .breakdown-table__row
-            dt.key #{__(`${tax.name.replace('Net ', '')} deduction`)}
-            dd.value $#{currencyFilter(tax.amount)}
+            dt.breakdown-table__row-key #{__(`${tax.name.replace('Net ', '')} deduction`)}
+            dd.breakdown-table__row-value $#{currencyFilter(tax.amount)}
 
         .breakdown-table__row.breakdown-table__row--summary
-          dt.key #{__(`Total tax paid for ${year}`)}
-          dd.value $#{currencyFilter(totalTax)}
+          dt.breakdown-table__row-key #{__(`Total tax paid for ${year}`)}
+          dd.breakdown-table__row-value $#{currencyFilter(totalTax)}
 
   form.cra-form(method='post')
     +yesNoRadios('confirmIncome', null, 'Is this information correct?', errors)

--- a/views/financial/income.pug
+++ b/views/financial/income.pug
@@ -18,7 +18,9 @@ block content
 
   if incomeSources
     .breakdown-table
-      h2.breakdown-table__heading <span>#{__(`Total income earned in ${year}`)}</span> <span>$#{currencyFilter(totalIncome.amount, 0)}</span>
+      h2.breakdown-table__heading
+        span #{__(`Total income earned in ${year}`)} 
+        span $#{currencyFilter(totalIncome.amount, 0)}
   
       p.breakdown-table__subheading #{__(`Detailed breakdown of income earned in ${year}`)}
 

--- a/views/financial/income.pug
+++ b/views/financial/income.pug
@@ -7,7 +7,6 @@ block variables
   -var taxes = hasData(data, 'financial.taxes') ? data.financial.taxes : {}
   -var totalIncome = hasData(data, 'financial.incomes.totalIncome') ? data.financial.incomes.totalIncome : 0
   -var totalTax = hasData(data, 'financial.totalTax') ? data.financial.totalTax : 0
-  -var count = 1;
   -var year = new Date().getFullYear()-1
 
 block content
@@ -18,44 +17,37 @@ block content
     p #{__(`Here’s what CRA knows about your income for the current tax year (filing for ${year}). Additional claims and deductions can be made afterwards.`)}
 
   if incomeSources
-    div
-      table.breakdown-table
-        thead
-          tr
-            th.breakdown-table__heading #{__(`Total income earned in ${year}`)}
-            th.breakdown-table__heading $#{currencyFilter(totalIncome.amount, 0)}
-        tbody
-          tr
-            th(colspan="2").breakdown-table__subheading #{__(`Detailed breakdown of income earned in ${year}`)}
-          each income in incomeSources
-            tr
-              td #{income.name} #{__('Total Income')}
-              td $#{currencyFilter(income.total)}
+    .breakdown-table
+      h2.breakdown-table__heading <span>#{__(`Total income earned in ${year}`)}</span> <span>$#{currencyFilter(totalIncome.amount, 0)}</span>
+  
+      p.breakdown-table__subheading #{__(`Detailed breakdown of income earned in ${year}`)}
 
-            - count++
+      .breakdown-table-data
+        each income in incomeSources
+          .breakdown-table__row
+            dt.key #{income.name} #{__('Total Income')}
+            dd.value $#{currencyFilter(income.total)}
 
-          tr.breakdown-table__summary-row
-            td #{__(`Total Income for ${year}`)}
-            td $#{currencyFilter(totalIncome.amount)}
+        .breakdown-table__row.breakdown-table__row--summary
+          dt.key #{__(`Total Income for ${year}`)}
+          dd.value $#{currencyFilter(totalIncome.amount)}
 
-  div
-    table.breakdown-table
-      thead
-        tr
-          th.breakdown-table__heading #{__('Total tax')}
-          th.breakdown-table__heading $#{currencyFilter(totalTax, 0)}
-      tbody
-        tr
-          th(colspan="2").breakdown-table__subheading #{__(`Detailed breakdown of taxes paid in ${year}`)}
+  .breakdown-table
+      h2.breakdown-table__heading 
+        span #{__('Total tax')}
+        span.breakdown-table__heading $#{currencyFilter(totalTax, 0)}
 
+      p.breakdown-table__subheading #{__(`Detailed breakdown of taxes paid in ${year}`)}
+
+      .breakdown-table-data
         each tax in taxes
-          tr
-            td #{__(`${tax.name.replace('Net ', '')} deduction`)}
-            td $#{currencyFilter(tax.amount)}
+          .breakdown-table__row
+            dt.key #{__(`${tax.name.replace('Net ', '')} deduction`)}
+            dd.value $#{currencyFilter(tax.amount)}
 
-        tr.breakdown-table__summary-row
-          td #{__(`Total tax paid for ${year}`)}
-          td $#{currencyFilter(totalTax)}
+        .breakdown-table__row.breakdown-table__row--summary
+          dt.key #{__(`Total tax paid for ${year}`)}
+          dd.value $#{currencyFilter(totalTax)}
 
   form.cra-form(method='post')
     +yesNoRadios('confirmIncome', null, 'Is this information correct?', errors)

--- a/views/financial/income.pug
+++ b/views/financial/income.pug
@@ -17,7 +17,7 @@ block content
     p #{__(`Here’s what CRA knows about your income for the current tax year (filing for ${year}). Additional claims and deductions can be made afterwards.`)}
 
   if incomeSources
-    .breakdown-table
+    dl.breakdown-table
       h2.breakdown-table__heading
         span #{__(`Total income earned in ${year}`)} 
         span $#{currencyFilter(totalIncome.amount, 0)}
@@ -34,7 +34,7 @@ block content
           dt.breakdown-table__row-key #{__(`Total Income for ${year}`)}
           dd.breakdown-table__row-value $#{currencyFilter(totalIncome.amount)}
 
-  .breakdown-table
+  dl.breakdown-table
       h2.breakdown-table__heading 
         span #{__('Total tax')}
         span.breakdown-table__heading $#{currencyFilter(totalTax, 0)}

--- a/views/financial/income.pug
+++ b/views/financial/income.pug
@@ -17,7 +17,7 @@ block content
     p #{__(`Here’s what CRA knows about your income for the current tax year (filing for ${year}). Additional claims and deductions can be made afterwards.`)}
 
   if incomeSources
-    dl.breakdown-table
+    .breakdown-table
       h2.breakdown-table__heading
         span #{__(`Total income earned in ${year}`)} 
         span $#{currencyFilter(totalIncome.amount, 0)}
@@ -34,14 +34,14 @@ block content
           dt.breakdown-table__row-key #{__(`Total Income for ${year}`)}
           dd.breakdown-table__row-value $#{currencyFilter(totalIncome.amount)}
 
-  dl.breakdown-table
+  .breakdown-table
       h2.breakdown-table__heading 
         span #{__('Total tax')}
         span.breakdown-table__heading $#{currencyFilter(totalTax, 0)}
 
       p.breakdown-table__subheading #{__(`Detailed breakdown of taxes paid in ${year}`)}
 
-      .breakdown-table-data
+      dl.breakdown-table-data
         each tax in taxes
           .breakdown-table__row
             dt.breakdown-table__row-key #{__(`${tax.name.replace('Net ', '')} deduction`)}

--- a/views/financial/income.pug
+++ b/views/financial/income.pug
@@ -24,7 +24,7 @@ block content
   
       p.breakdown-table__subheading #{__(`Detailed breakdown of income earned in ${year}`)}
 
-      .breakdown-table-data
+      dl.breakdown-table-data
         each income in incomeSources
           .breakdown-table__row
             dt.breakdown-table__row-key #{income.name} #{__('Total Income')}


### PR DESCRIPTION
I went the long way of restructuring out tables, to be more in line with these [summary lists](https://design-system.service.gov.uk/components/summary-list/), which will allow for easier styling across devices

not 100% thrilled with spans inside a heading, but open to doing this another way if we'd like

Desktop  | Mobile
------------- | -------------
![localhost_3005_review (4)](https://user-images.githubusercontent.com/6607541/62229474-b9c58100-b38d-11e9-8184-2630936dd5bd.png)|![localhost_3005_review (3)](https://user-images.githubusercontent.com/6607541/62229545-dbbf0380-b38d-11e9-91fe-ea2f59bac410.png)
![localhost_3005_financial_income (3)](https://user-images.githubusercontent.com/6607541/62229585-fd1fef80-b38d-11e9-9316-0258a7856045.png) | ![localhost_3005_financial_income (4)](https://user-images.githubusercontent.com/6607541/62229589-ff824980-b38d-11e9-81ca-1c7172d53026.png)


