### PR TITLE
update address to conform to data shape requested

### DIFF
--- a/api/user.json
+++ b/api/user.json
@@ -9,9 +9,8 @@
     "sin": "847339283",
     "dateOfBirth": "1977/09/09",
     "address": {
-      "aptNumber": "Unit 202",
-      "streetNumber": "303",
-      "streetName": "Blake Blvd.",
+      "line1": "303 Blake Blvd.",
+      "line2": "Unit 202",
       "postalCode": "K2R 3Z9",
       "city": "Ottawa",
       "province": "Ontario"

--- a/formSchemas.js
+++ b/formSchemas.js
@@ -218,7 +218,7 @@ const maritalStatusSchema = {
 const addressSchema = {
   line1: {
     isEmpty: {
-      errorMessage: 'errors.address.streetName.empty',
+      errorMessage: 'errors.address.line1.empty',
       negated: true,
     },
   },

--- a/formSchemas.js
+++ b/formSchemas.js
@@ -216,7 +216,7 @@ const maritalStatusSchema = {
 }
 
 const addressSchema = {
-  streetName: {
+  line1: {
     isEmpty: {
       errorMessage: 'errors.address.streetName.empty',
       negated: true,

--- a/locales/en.json
+++ b/locales/en.json
@@ -13,7 +13,7 @@
   "errors.login.dateOfBirth.validMonth": "Please enter a valid month between 01 and 12",
   "errors.login.dateOfBirth.validDay": "Please enter a valid day",
   "errors.login.dateOfBirth.validYear": "Please enter a valid year",
-  "errors.address.streetName.empty": "Street address can’t be empty",
+  "errors.address.line1.empty": "Street address can’t be empty",
   "errors.address.city.empty": "City can’t be empty",
   "errors.address.postalCode.empty": "Postal code can’t be empty",
   "errors.address.postalCode.format": "Postal code is incorrect format",

--- a/locales/en.json
+++ b/locales/en.json
@@ -13,7 +13,7 @@
   "errors.login.dateOfBirth.validMonth": "Please enter a valid month between 01 and 12",
   "errors.login.dateOfBirth.validDay": "Please enter a valid day",
   "errors.login.dateOfBirth.validYear": "Please enter a valid year",
-  "errors.address.streetName.empty": "Street name can’t be empty",
+  "errors.address.streetName.empty": "Street address can’t be empty",
   "errors.address.city.empty": "City can’t be empty",
   "errors.address.postalCode.empty": "Postal code can’t be empty",
   "errors.address.postalCode.format": "Postal code is incorrect format",
@@ -283,5 +283,6 @@
   "Is this your name?": "Is this your name?",
   "Keep your notification letter with you. You need information on that letter to use this service.": "Keep your notification letter with you. You need information on that letter to use this service.",
   "For Example: A5G98S4K1": "For Example: A5G98S4K1",
-  "Your access code was validated!": "Your access code was validated!"
+  "Your access code was validated!": "Your access code was validated!",
+  "Street address": "Street address"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -13,7 +13,7 @@
   "errors.login.dateOfBirth.validMonth": "Veuillez inscrire un mois valide entre 01 et 12",
   "errors.login.dateOfBirth.validDay": "Veuillez inscrire un jour valide",
   "errors.login.dateOfBirth.validYear": "Veuillez inscrire une année valide",
-  "errors.address.streetName.empty": "Le nom de la rue doit être inscrit",
+  "errors.address.line1.empty": "Le nom de la rue doit être inscrit",
   "errors.address.city.empty": "La ville doit être inscrite",
   "errors.address.postalCode.empty": "Le code postal doit être inscrit",
   "errors.address.postalCode.format": "Le format du code postal est incorrect",

--- a/routes/personal/personal.spec.js
+++ b/routes/personal/personal.spec.js
@@ -87,7 +87,7 @@ describe('Test /personal responses', () => {
 
   describe('Test /personal/address responses', () => {
     let goodRequest = {
-      streetName: 'Awesome Avenue',
+      line1: 'Awesome Avenue',
       city: 'Awesawa',
       postalCode: 'H3L1Y4',
       province: 'Ontario',
@@ -96,19 +96,19 @@ describe('Test /personal responses', () => {
 
     const badRequests = [
       {
-        label: 'no streetName or city or postalCode or province',
-        firstErrorId: '#streetName',
+        label: 'no streetAddress or city or postalCode or province',
+        firstErrorId: '#line1',
         send: {
           ...goodRequest,
-          ...{ streetName: '', city: '', postalCode: '', province: '' },
+          ...{ line1: '', city: '', postalCode: '', province: '' },
         },
       },
       {
-        label: 'no streetName',
-        firstErrorId: '#streetName',
+        label: 'no streetAddress',
+        firstErrorId: '#line1',
         send: {
           ...goodRequest,
-          ...{ streetName: '' },
+          ...{ line1: '' },
         },
       },
       {

--- a/views/personal/address-edit.pug
+++ b/views/personal/address-edit.pug
@@ -22,7 +22,7 @@ block content
 
       +textInput('Street address', ['w-3-4','d--ib'])(class='w-3-4', value=streetAddress, name='line1' autofocus=(!errors || errors && firstError.param === 'line1' ? true : false))
 
-      +textInput('Apartment number', 'w-1-2', 'Optional')(class='w-3-4', value=aptNumber name='aptNumber')
+      +textInput('Apartment number', 'w-1-2', 'Optional')(class='w-3-4', value=aptNumber name='line2')
 
       +textInput('City', 'w-1-2')(class='w-3-4', value=city name='city')
 

--- a/views/personal/address-edit.pug
+++ b/views/personal/address-edit.pug
@@ -2,9 +2,8 @@ extends ../base
 
 block variables
   -var title = __('Change your mailing address')
-  -var aptNumber = hasData(body, 'aptNumber') ? body.aptNumber : hasData(data, 'personal.address.aptNumber') ? data.personal.address.aptNumber : ''
-  -var streetNumber = hasData(body, 'streetNumber') ? body.streetNumber : hasData(data, 'personal.address.streetNumber') ? data.personal.address.streetNumber : ''
-  -var streetName = hasData(body, 'streetName') ? body.streetName : hasData(data, 'personal.address.streetName') ? data.personal.address.streetName : ''
+  -var aptNumber = hasData(body, 'line2') ? body.line2 : hasData(data, 'personal.address.line2') ? data.personal.address.line2 : ''
+  -var streetAddress = hasData(body, 'line1') ? body.line1 : hasData(data, 'personal.address.line1') ? data.personal.address.line1 : ''
   -var city = hasData(body, 'city') ? body.city : hasData(data, 'personal.address.city') ? data.personal.address.city : ''
   -var postalCode = hasData(body, 'postalCode') ? body.postalCode : hasData(data, 'personal.address.postalCode') ? data.personal.address.postalCode : ''
   -var province = hasData(body, 'province') ? body.province : hasData(data, 'personal.address.province') ? data.personal.address.province : ''
@@ -21,10 +20,7 @@ block content
     form.cra-form.cra-form--lg(method='post')
       h2 #{__('Your mailing address')}
 
-      div
-        +textInput('Street number', ['w-1-4','d--ib'])(class='w-3-4', value=streetNumber, name='streetNumber' autofocus=(!errors || errors && firstError.param === 'streetNumber' ? true : false))
-
-        +textInput('Street name', ['w-3-4','d--ib'])(class='w-3-4', value=streetName, name='streetName')
+      +textInput('Street address', ['w-3-4','d--ib'])(class='w-3-4', value=streetAddress, name='line1' autofocus=(!errors || errors && firstError.param === 'line1' ? true : false))
 
       +textInput('Apartment number', 'w-1-2', 'Optional')(class='w-3-4', value=aptNumber name='aptNumber')
 

--- a/views/personal/address.pug
+++ b/views/personal/address.pug
@@ -19,10 +19,10 @@ block content
         tr
           td
             .address
-              if hasData(data, 'personal.address.aptNumber')
-                div #{data.personal.address.aptNumber}-#{data.personal.address.streetNumber} #{data.personal.address.streetName}
+              if hasData(data, 'personal.address.line2')
+                div #{data.personal.address.line2}-#{data.personal.address.line1}
               else
-                div #{data.personal.address.streetNumber} #{data.personal.address.streetName}
+                div #{data.personal.address.line1} 
               div #{data.personal.address.city}, #{data.personal.address.province}
               div #{data.personal.address.postalCode}
 


### PR DESCRIPTION
mainly that address is now line1 for street address
and line2 for apartment number
I've updated to calling it line1 + line2 in most places, despite it not being the clearest name for it. But otherwise we will get into situations where here you refer to it one way, and here your refer to it another way, and I'd rather keep it consistent for simplicity's sake. Decision not set in stone, though

![localhost_3005_personal_address_edit](https://user-images.githubusercontent.com/6607541/62304181-79c4d380-b44b-11e9-98ad-3dc8ef74c997.png)
