### PR TITLE
Blank is valid answer to currency questions

### DIFF
--- a/formSchemas.js
+++ b/formSchemas.js
@@ -2,6 +2,11 @@ const API = require('./api')
 
 const currencySchema = (errorMessageString = 'errors.currency') => {
   return {
+    customSanitizer: {
+      options: value => {
+        return value ? value : 0 //if blank we want to assume they meant 0
+      },
+    },
     isCurrency: {
       errorMessage: errorMessageString,
       options: { allow_negatives: false },
@@ -306,22 +311,8 @@ const politicalSchema = {
 }
 
 const politicalAmountSchema = {
-  politicalProvincialAmount: {
-    customSanitizer: {
-      options: value => {
-        return value ? value : 0 //if blank we want to assume they meant 0
-      },
-    },
-    ...currencySchema(),
-  },
-  politicalFederalAmount: {
-    customSanitizer: {
-      options: value => {
-        return value ? value : 0 //if blank we want to assume they meant 0
-      },
-    },
-    ...currencySchema(),
-  },
+  politicalProvincialAmount: currencySchema(),
+  politicalFederalAmount: currencySchema(),
 }
 
 const residenceSchema = {

--- a/routes/deductions/deductions.spec.js
+++ b/routes/deductions/deductions.spec.js
@@ -269,14 +269,14 @@ describe('Test /deductions responses', () => {
           expect(response.statusCode).toBe(500)
         })
 
-        test('it returns a 422 response for no posted value', async () => {
+        test('it returns a 302 response for no posted value', async () => {
           const response = await request(app)
             .post(amountResponse.url)
             .send({ redirect: '/' })
-          expect(response.statusCode).toBe(422)
+          expect(response.statusCode).toBe(302)
         })
 
-        const badAmounts = ['', null, 'dinosaur', '10.0', '10.000', '-10', '.1']
+        const badAmounts = ['dinosaur', '10.0', '10.000', '-10', '.1']
         badAmounts.map(badAmount => {
           test(`it returns a 422 for a bad posted value: "${badAmount}"`, async () => {
             const response = await request(app)
@@ -286,7 +286,7 @@ describe('Test /deductions responses', () => {
           })
         })
 
-        const goodAmounts = ['0', '10', '10.00', '.10']
+        const goodAmounts = ['0', '10', '10.00', '.10', '', null]
         goodAmounts.map(goodAmount => {
           test(`it returns a 302 for a good posted value: "${goodAmount}"`, async () => {
             const response = await request(app)

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -372,12 +372,12 @@ describe('Test /login responses', () => {
       expect(response.statusCode).toBe(200)
     })
 
-    test('it returns a 422 response for no posted value', async () => {
+    test('it returns a 302 response for no posted value', async () => { // since 0 is what is displayed by default, a user could leave it blank and press enter. This might not be great in user testing scenario but should be a valid answer
       const response = await request(app).post('/login/auth')
-      expect(response.statusCode).toBe(422)
+      expect(response.statusCode).toBe(302)
     })
 
-    const badAuths = ['', null, 'dinosaur', '10.0', '10.000', '-10', '.1']
+    const badAuths = ['dinosaur', '10.0', '10.000', '-10', '.1']
     badAuths.map(auth => {
       test(`it returns a 422 for a bad posted value: "${auth}"`, async () => {
         const response = await request(app)
@@ -387,7 +387,7 @@ describe('Test /login responses', () => {
       })
     })
 
-    const goodAuths = ['0', '10', '10.00', '.10']
+    const goodAuths = ['0', '10', '10.00', '.10', '', null] // since 0 is what is displayed by default, a user could leave it blank and press enter. This might not be great in user testing scenario but should be a valid answer
     goodAuths.map(auth => {
       test(`it returns a 302 for a good posted value: "${auth}"`, async () => {
         const response = await request(app)


### PR DESCRIPTION
During usability testing some users had trouble with pressing "continue" because the placeholder was showing 0. Having a default value of 0 also made the users type in numbers incorrectly.
This patch changes it so that all fields that follow currencySchema can accept blank (and null).
Since we no longer need to have the logic separately for political contributions we just move them to use the currency schema.
For the /auth/ page the test have been changed to accept an empty value since it could be empty.