### PR TITLE
Make the no info-box on yes/no radios more accessible

### DIFF
--- a/public/scss/components/_multiple-choice.scss
+++ b/public/scss/components/_multiple-choice.scss
@@ -135,8 +135,10 @@
   > input:not(:checked) + label + .no-info {
     max-height: 0;
     overflow: hidden;
+    visibility: hidden;
   }
   > input:checked + label + .no-info {
     overflow-y: hidden;
+    visibility: visible;
   }
 }

--- a/views/_includes/script.pug
+++ b/views/_includes/script.pug
@@ -7,5 +7,25 @@ script.
   }
 
 script.
+  var noInfoBox = document.getElementsByClassName('no-info')[0]
+
+  if (noInfoBox) {
+    var yesNoRadios = document.querySelectorAll('div.multiple-choice__item')
+    
+    var noInput = yesNoRadios[1].childNodes[0]
+
+    for (var i = 0, len = yesNoRadios.length; i < len; i++) {
+      yesNoRadios[i].addEventListener('click', function(e) {
+        if(e.target.value === 'No') {
+          noInput.setAttribute('aria-expanded', 'true');
+        } else {
+          noInput.setAttribute('aria-expanded', 'false');
+        }
+      })
+    }
+  }
+
+
+script.
   if (typeof Promise !== "function" && document.querySelector('details') !== null)
   document.write('<script src="/js/details-element-polyfill.js"><\/script>');

--- a/views/_includes/yesNoRadios.pug
+++ b/views/_includes/yesNoRadios.pug
@@ -9,7 +9,7 @@ mixin yesNoRadios(key, value, question, errors = false)
           input(id=`${key}Yes` name=key type="radio" value="Yes" checked=(value =='Yes') aria-describedby=(errors ? `${key}-error` : false))
           label(for=`${key}Yes`) #{__('Yes')}
         .multiple-choice__item
-          input(id=`${key}No` name=key type="radio" value="No" checked=(value =='No') aria-describedby=(errors ? `${key}-error` : false))
+          input(id=`${key}No` name=key type="radio" value="No" checked=(value =='No') aria-describedby=(errors ? `${key}-error` : false) aria-expanded=(block ? 'false': false))
           label(for=`${key}No`) #{__('No')}
           if block
             block


### PR DESCRIPTION
- added some js to toggle aria-expanded on yes/no radios, but only if they have the no-info div for the no option
- added visibility visible/hidden css to boot (just to be sure screen readers aren't reading it)
- checked with axe in chrome 👍 