### PR TITLE
task/Add "secure" cookie setting to the app if we think we're on prod

### DIFF
--- a/config/cookieSession.config.js
+++ b/config/cookieSession.config.js
@@ -19,4 +19,9 @@ const cookieSessionConfig = {
   },
 }
 
+// If we're running in "production" and the github sha is there, then it's probable that we're on live on prod
+if (process.env.NODE_ENV === 'production' && process.env.GITHUB_SHA) {
+  cookieSessionConfig.cookie.secure = true
+}
+
 module.exports = cookieSessionConfig


### PR DESCRIPTION
If we're running with `"npm start"`, and we have a `GITHUB_SHA` environment variable, we're very likely to be in production, which in our case means we're running on Azure.

If that's the case, we're on `https` and the cookies should have [the "secure" flag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Secure_and_HttpOnly_cookies), which means they won't be served on http.

If misconfigured, this could mean that we're not saving data locally while developing, but it seems unlikely to me, and if the devs on the project know about it, then it should be fine.