### PR TITLE
Fixup/Add 'role="button"' to all of our link buttons AND remove '.button-link' class

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -5,8 +5,8 @@ if (typeof Promise !== 'function' && document.querySelector('details') !== null)
   document.write('<script src="/js/details-element-polyfill.js"></script>')
 }
 
-// Find all of the links with the 'button-link' class and add a click event to them
-var elements = document.querySelectorAll('a.button-link')
+// Find all of the links with the 'button' role and add a click event to them
+var elements = document.querySelectorAll('a[role="button"]')
 for (var i = 0, len = elements.length; i < len; i++) {
   elements[i].addEventListener('keydown', function(e) {
     if (e.keyCode == 32) {

--- a/public/scss/components/_buttons.scss
+++ b/public/scss/components/_buttons.scss
@@ -53,7 +53,7 @@
   width: 100%;
 }
 
-a.button-link {
+a[role='button'] {
   @extend %button-styles;
 
   &.full-width {

--- a/views/_includes/buttonMixin.pug
+++ b/views/_includes/buttonMixin.pug
@@ -3,11 +3,11 @@ mixin formButtons(submitButtonText = 'Continue', cancelUrl='/clear')
     .buttons--left
       button(type='submit') #{__(submitButtonText)}
     .buttons--right
-      a.button-link.transparent.full-width(href=cancelUrl) #{__('Cancel')}
+      a.button-link.transparent.full-width(href=cancelUrl role='button' draggable='false') #{__('Cancel')}
 
 mixin linkButtons(confirmURL)
   .buttons-row
-    a.button-link(href=confirmURL) #{__('Confirm')}
+    a.button-link(href=confirmURL role='button' draggable='false') #{__('Confirm')}
     if block
         block
-    a.button-link.transparent(href='/clear') #{__('Cancel')}
+    a.button-link.transparent(href='/clear' role='button' draggable='false') #{__('Cancel')}

--- a/views/_includes/buttonMixin.pug
+++ b/views/_includes/buttonMixin.pug
@@ -3,11 +3,11 @@ mixin formButtons(submitButtonText = 'Continue', cancelUrl='/clear')
     .buttons--left
       button(type='submit') #{__(submitButtonText)}
     .buttons--right
-      a.button-link.transparent.full-width(href=cancelUrl role='button' draggable='false') #{__('Cancel')}
+      a.transparent.full-width(href=cancelUrl role='button' draggable='false') #{__('Cancel')}
 
 mixin linkButtons(confirmURL)
   .buttons-row
-    a.button-link(href=confirmURL role='button' draggable='false') #{__('Confirm')}
+    a(href=confirmURL role='button' draggable='false') #{__('Confirm')}
     if block
         block
-    a.button-link.transparent(href='/clear' role='button' draggable='false') #{__('Cancel')}
+    a.transparent(href='/clear' role='button' draggable='false') #{__('Cancel')}

--- a/views/confirmation/confirmation.pug
+++ b/views/confirmation/confirmation.pug
@@ -21,13 +21,13 @@ block content
 
     p #{__('Use this confirmation number if you need to contact CRA for further information or for additional help with your tax return.')}
 
-    a.button-link(href='#' role='button' draggable='false') #{__('Print a summary of your tax return')}
+    a(href='#' role='button' draggable='false') #{__('Print a summary of your tax return')}
 
   div
 
     p #{__('Your Notice of Assessment is an official CRA communication that confirms that you’ve filed your taxes. It also contains the details of your refund or balance owing. Please read this document carefully.')}
 
-    a.button-link(href='#' role='button' draggable='false') #{__('Download your Notice of Assessment')}
+    a(href='#' role='button' draggable='false') #{__('Download your Notice of Assessment')}
 
   div
     h3 #{__('Do you have questions?')}

--- a/views/offramp/financial.pug
+++ b/views/offramp/financial.pug
@@ -7,11 +7,11 @@ block variables
 block content
 
   h1 #{title}
-  
+
   .offramp
     p #{__('If your records don’t match the income information displayed earlier, or you believe it to be incorrect, you shouldn’t use this service to file your taxes.')}
 
     div
       p #{__('There are also other free and secure ways to file your taxes:')}
-      include ../_includes/offramp-bullets    
-    a.button-link(href='/financial/income') #{__('Go back')}
+      include ../_includes/offramp-bullets
+    a.button-link(href='/financial/income' role='button' draggable='false') #{__('Go back')}

--- a/views/offramp/financial.pug
+++ b/views/offramp/financial.pug
@@ -14,4 +14,4 @@ block content
     div
       p #{__('There are also other free and secure ways to file your taxes:')}
       include ../_includes/offramp-bullets
-    a.button-link(href='/financial/income' role='button' draggable='false') #{__('Go back')}
+    a(href='/financial/income' role='button' draggable='false') #{__('Go back')}

--- a/views/personal/address.pug
+++ b/views/personal/address.pug
@@ -22,10 +22,10 @@ block content
               if hasData(data, 'personal.address.line2')
                 div #{data.personal.address.line2}-#{data.personal.address.line1}
               else
-                div #{data.personal.address.line1} 
+                div #{data.personal.address.line1}
               div #{data.personal.address.city}, #{data.personal.address.province}
               div #{data.personal.address.postalCode}
 
   +linkButtons('/financial/income')
-    a.button-link(href='/personal/address/edit') #{__('Change your mailing address')}
+    a.button-link(href='/personal/address/edit' role='button' draggable='false') #{__('Change your mailing address')}
 

--- a/views/personal/address.pug
+++ b/views/personal/address.pug
@@ -27,5 +27,5 @@ block content
               div #{data.personal.address.postalCode}
 
   +linkButtons('/financial/income')
-    a.button-link(href='/personal/address/edit' role='button' draggable='false') #{__('Change your mailing address')}
+    a(href='/personal/address/edit' role='button' draggable='false') #{__('Change your mailing address')}
 

--- a/views/personal/maritalStatus.pug
+++ b/views/personal/maritalStatus.pug
@@ -21,5 +21,5 @@ block content
             div #{__(data.personal.maritalStatus)}
 
   +linkButtons('/deductions/medical')
-    a.button-link(href='/personal/maritalStatus/edit' role='button' draggable='false') #{__('Change your marital status')}
+    a(href='/personal/maritalStatus/edit' role='button' draggable='false') #{__('Change your marital status')}
 

--- a/views/personal/maritalStatus.pug
+++ b/views/personal/maritalStatus.pug
@@ -21,5 +21,5 @@ block content
             div #{__(data.personal.maritalStatus)}
 
   +linkButtons('/deductions/medical')
-    a.button-link(href='/personal/maritalStatus/edit') #{__('Change your marital status')}
+    a.button-link(href='/personal/maritalStatus/edit' role='button' draggable='false') #{__('Change your marital status')}
 

--- a/views/start/index.pug
+++ b/views/start/index.pug
@@ -22,4 +22,4 @@ block content
       li #{__('Income information')}
 
   div
-    a.button-link(href='/login/code' role='button' draggable='false') #{__('Start now')} <span aria-hidden="true">→</span>
+    a(href='/login/code' role='button' draggable='false') #{__('Start now')} <span aria-hidden="true">→</span>


### PR DESCRIPTION
**Note: I closed #121 by accident. This does the same thing as well as removes the 'button-link' classname.**

***

This is something we need to shim our button links properly for assistive tech, so it's a mistake that I didn't catch earlier.

Similarly, I changed our CSS selector and our JavaScript selector to target our links based on the "button" role since that's the thing that assistive tech actually cares about.

Source: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role

**ALSO Remove '.button-link' class**
After changing the CSS and JS selectors, it occurred to me that we
don't even need the classname for anything anymore. So let's axe it.

