### PR TITLE
use aria-expanded more accessibly

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -20,7 +20,7 @@ var noInfoBox = document.getElementsByClassName('no-info')[0]
 if (noInfoBox) {
   var yesNoRadios = document.querySelectorAll('div.multiple-choice__item')
 
-  var noInput = yesNoRadios[1].childNodes[0]
+  var noInput = yesNoRadios[1]
 
   for (var i = 0, len = yesNoRadios.length; i < len; i++) {
     yesNoRadios[i].addEventListener('click', function(e) {

--- a/views/_includes/yesNoRadios.pug
+++ b/views/_includes/yesNoRadios.pug
@@ -8,8 +8,11 @@ mixin yesNoRadios(key, value, question, errors = false)
         .multiple-choice__item
           input(id=`${key}Yes` name=key type="radio" value="Yes" checked=(value =='Yes') aria-describedby=(errors ? `${key}-error` : false))
           label(for=`${key}Yes`) #{__('Yes')}
-        .multiple-choice__item
-          input(id=`${key}No` name=key type="radio" value="No" checked=(value =='No') aria-describedby=(errors ? `${key}-error` : false) aria-expanded=(block ? 'false': false))
+        .multiple-choice__item(
+          aria-expanded=(block ? 'false': false) 
+          aria-controls=(block ? '#no-info': false)
+        )
+          input(id=`${key}No` name=key type="radio" value="No" checked=(value =='No') aria-describedby=(errors ? `${key}-error` : false))
           label(for=`${key}No`) #{__('No')}
           if block
             block


### PR DESCRIPTION
according to wcag and axe, aria-expanded is not allowed on an input. So I moved this up to the div that wraps around the input, adding an aria-controls for good measure to clarify what region it controls.
And no more axe violations!