### PR TITLE
Add a few more units tests for /personal/name responses

### DIFF
--- a/routes/personal/personal.spec.js
+++ b/routes/personal/personal.spec.js
@@ -22,6 +22,29 @@ describe('Test /personal responses', () => {
     })
   })
 
+  describe('Test /personal/name responses', () => {
+    test('it returns a 422 with no option selected', async () => {
+      const response = await request(app).post('/personal/name')
+      expect(response.statusCode).toBe(422)
+    })
+
+    test('it redirects to the offramp page when selecting No', async () => {
+      const response = await request(app)
+        .post('/personal/name')
+        .send({ name: 'No' })
+      expect(response.headers.location).toEqual('/offramp/name')
+      expect(response.statusCode).toBe(302)
+    })
+
+    test('it redirects to the provided redirect value when selecting Yes', async () => {
+      const response = await request(app)
+        .post('/personal/name')
+        .send({ redirect: '/success', name: 'Yes' })
+      expect(response.headers.location).toEqual('/success')
+      expect(response.statusCode).toBe(302)
+    })
+  })
+
   describe('Test /personal/maritalStatus responses', () => {
     test('it has Married selected by default', async () => {
       const response = await request(app).get('/personal/maritalStatus')


### PR DESCRIPTION
For the /personal/name responses

- check posting no value is a 422
- check posting a 'No' goes to the offramp page
- check posting a 'Yes' goes to the redirect page

Top-level coverage numbers went up a bit.


|          | before | after |
|----------|--------|-------|
| % Stmts  |  92.83 | 93.72 |
| % Branch |  76.87 | 78.36 |
| % Funcs  |  91.14 | 92.41 | 
| % Lines  |  92.71 | 93.62 | 

## Reason for doing this

John O'Brien posted this in the channel today: https://github.com/18F/technology-budgeting/blob/master/handbook.md#appendix-b-sample-quality-assessment-surveillance-plan-qasp

It's a list of Quality Assessment criteria which we might consider applying to this project in the near future. One of the first things on the list is `Minimum of 90% test coverage of all code`, which is something we haven't actually looked at yet. Had a look at the jest documentation, and getting code coverage stats is as easy as adding `--coverage` to the jest command. In our case, we want to run 

```
npm test -- --coverage
```

As I suspected, our coverage is actually pretty good. 

The top level stat looks like this:

```
----------------------------------------|----------|----------|----------|----------|-------------------|
File                                    |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------------------------------------|----------|----------|----------|----------|-------------------|
All files                               |    92.83 |    76.87 |    91.14 |    92.71 |                   |
```

One of the files in there that wasn't being fully tested was the `personal.controller.js` file, which looked like this.

```
----------------------------------------|----------|----------|----------|----------|-------------------|
File                                    |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------------------------------------|----------|----------|----------|----------|-------------------|
  personal.controller.js                |    86.67 |       50 |       80 |    86.67 |       73,75,76,79 |
```

So I figured I would add a few tests to see what the change would be to the code coverage numbers. The personal controller is now at 100%, and the top level numbers are ~1-2% higher.

```
----------------------------------------|----------|----------|----------|----------|-------------------|
File                                    |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------------------------------------|----------|----------|----------|----------|-------------------|
All files                               |    93.72 |    78.36 |    92.41 |    93.62 |                   |
  personal.controller.js                |      100 |      100 |      100 |      100 |                   |
```

We don't have to get all the rest of them or anything, I was just investigating this to see what the change would be.
