### PR TITLE
Remove the "secure" flag on cookies

### DIFF
--- a/config/cookieSession.config.js
+++ b/config/cookieSession.config.js
@@ -16,12 +16,7 @@ const cookieSessionConfig = {
   // Cookie options: https://github.com/expressjs/cookie-session#options
   httpOnly: true,
   maxAge: oneHour,
-  sameSite: true,
-}
-
-// If we're running in "production" and the github sha is there, then it's probable that we're on live on prod
-if (process.env.NODE_ENV === 'production' && process.env.GITHUB_SHA) {
-  cookieSessionConfig.secure = true
+  sameSite: 'strict',
 }
 
 module.exports = cookieSessionConfig


### PR DESCRIPTION
Unfortunately, setting secure cookies for us in production doesn't actually work because (I am pretty sure) our app is sitting behind a proxy of some kind.

### Explanation

The Google Chrome Network interface shows “request cookies” and “response cookies” in a table.

I was looking for the  “httponly” and “samesite” values checked off in the “request cookies” section, not realizing that there were two different sections. And they never showed up, because [you can't set those on request cookies](https://stackoverflow.com/questions/21057331/httponly-for-request-cookies) (ie, from the client to the server).

You can only set them on _Response cookies_.

Okay, but currently, nothing is showing up under "Response cookies".

![cookie-2](https://user-images.githubusercontent.com/2454380/64050819-24add780-cb47-11e9-9298-499868b48098.gif)

I noticed that when ‘secure’ cookies were set and the app was running locally (ie, over `http://localhost`), you don’t see any "Response cookies" in Chrome's Network tab, which is the same behaviour as the "prod" version of the app.

When we upload our app to app service, we click some option that says “only serve traffic over HTTPS”, which means probably our app is running on HTTP behind a proxy.

This means the secure option is set, but the cookies don't get set at all. So the solution for now is to not set the "secure" flag. 

Once the "secure" flag is removed, the Response cookies show up again.

![cookie](https://user-images.githubusercontent.com/2454380/64050886-5f177480-cb47-11e9-9ff8-2f2665cf7b59.gif)

_Bref_, unsetting the 'secure' cookie flag resolves #124.