### PR TITLE
Feature/Date of Birth field overhaul

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 node_modules
 .git
 .gitignore
-

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,6 @@ public/styles.css*
 
 # Cypress files we're not using
 cypress/examples
-cypress/support
+cypress/support/commands.js
 cypress/plugins
 cypress/screenshots

--- a/api/user.json
+++ b/api/user.json
@@ -7,7 +7,6 @@
     "firstName": "Gabrielle",
     "lastName": "Roy",
     "sin": "847339283",
-    "dateOfBirth2": "1977/09/09",
     "dateOfBirth": "1977-09-09",
     "address": {
       "line1": "303 Blake Blvd.",

--- a/api/user.json
+++ b/api/user.json
@@ -7,7 +7,8 @@
     "firstName": "Gabrielle",
     "lastName": "Roy",
     "sin": "847339283",
-    "dateOfBirth": "1977/09/09",
+    "dateOfBirth2": "1977/09/09",
+    "dateOfBirth": "1977-09-09",
     "address": {
       "line1": "303 Blake Blvd.",
       "line2": "Unit 202",

--- a/app.js
+++ b/app.js
@@ -21,6 +21,7 @@ const express = require('express'),
     sortByLineNumber,
     checkLangQuery,
     currencyFilter,
+    isoDateHintText,
   } = require('./utils')
 
 // initialize application.
@@ -80,24 +81,7 @@ app.locals.SINFilter = SINFilter
 app.locals.hasData = hasData
 app.locals.currencyFilter = currencyFilter
 app.locals.sortByLineNumber = sortByLineNumber
-app.locals.splitISODate = (date, param) => {
-  const dateParts = date.split('-')
-
-  if (dateParts.length !== 3) {
-    throw new Error(`[GET /login/dateOfBirth] Bad date ${date}: must be formatted yyyy-mm-dd`)
-  }
-
-  switch (param) {
-    case 'y':
-      return dateParts[0]
-    case 'm':
-      return dateParts[1]
-    case 'd':
-      return dateParts[2]
-    default:
-      throw new Error(`[GET /login/dateOfBirth] Bad parameter '${param}'`)
-  }
-}
+app.locals.isoDateHintText = isoDateHintText
 
 // configure routes
 require('./routes/start/start.controller')(app)

--- a/app.js
+++ b/app.js
@@ -80,6 +80,24 @@ app.locals.SINFilter = SINFilter
 app.locals.hasData = hasData
 app.locals.currencyFilter = currencyFilter
 app.locals.sortByLineNumber = sortByLineNumber
+app.locals.splitISODate = (date, param) => {
+  const dateParts = date.split('-')
+
+  if (dateParts.length !== 3) {
+    throw new Error(`[GET /login/dateOfBirth] Bad date ${date}: must be formatted yyyy-mm-dd`)
+  }
+
+  switch (param) {
+    case 'y':
+      return dateParts[0]
+    case 'm':
+      return dateParts[1]
+    case 'd':
+      return dateParts[2]
+    default:
+      throw new Error(`[GET /login/dateOfBirth] Bad parameter '${param}'`)
+  }
+}
 
 // configure routes
 require('./routes/start/start.controller')(app)

--- a/cypress/fixtures/user.json
+++ b/cypress/fixtures/user.json
@@ -3,7 +3,7 @@
   "firstName": "Gabrielle",
   "lastName": "Roy",
   "sin": "847339283",
-  "dateOfBirth": "1977/09/09",
+  "dateOfBirth": "1977-09-09",
   "address": {
     "line1": "303 Blake Blvd.",
     "line2": "Unit 202",

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,0 +1,18 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+// import './commands'
+import 'cypress-axe'

--- a/cypress/utils.js
+++ b/cypress/utils.js
@@ -10,13 +10,13 @@ const checkTableRows = (cy, rows) => {
   })
 }
 
-const getIncomeBreakdownRows = (user) => {
-  const incomeRows = [];
-  
-  user.incomeSources.map((source) => {
+const getIncomeBreakdownRows = user => {
+  const incomeRows = []
+
+  user.incomeSources.map(source => {
     const incomeRow = {
       key: source.name,
-      value: currencyFilter(source.total)
+      value: currencyFilter(source.total),
     }
     incomeRows.push(incomeRow)
   })
@@ -24,34 +24,32 @@ const getIncomeBreakdownRows = (user) => {
   return incomeRows
 }
 
-const getTaxBreakdownRows = (user) => {
-  const taxRows = [];
-  
-  Object.values(user.taxes).map((source) => {
+const getTaxBreakdownRows = user => {
+  const taxRows = []
+
+  Object.values(user.taxes).map(source => {
     const taxRow = {
       key: `${source.name.replace('Net ', '')} deduction`,
-      value: currencyFilter(source.amount)
+      value: currencyFilter(source.amount),
     }
     taxRows.push(taxRow)
   })
-  
-  taxRows.push(
-    {
-      key: 'Total tax paid for 2018',
-      value: currencyFilter(user.totalTax)
-    }
-  )
+
+  taxRows.push({
+    key: 'Total tax paid for 2018',
+    value: currencyFilter(user.totalTax),
+  })
 
   return taxRows
 }
 
-const getBenefitsBreakdownRows = (user) => {
-  const benefitsRows = [];
-  
-  Object.values(user.benefits).map((source) => {
+const getBenefitsBreakdownRows = user => {
+  const benefitsRows = []
+
+  Object.values(user.benefits).map(source => {
     const benefitsRow = {
       key: source.name,
-      value: currencyFilter(source.amount)
+      value: currencyFilter(source.amount),
     }
     benefitsRows.push(benefitsRow)
   })
@@ -59,10 +57,10 @@ const getBenefitsBreakdownRows = (user) => {
   return benefitsRows
 }
 
-const allIncomeRows = (user) => getIncomeBreakdownRows(user).concat(getTaxBreakdownRows(user))
+const allIncomeRows = user => getIncomeBreakdownRows(user).concat(getTaxBreakdownRows(user))
 
-const getAddress = (address) => {
-  const fullAddress = [`${address.city}, ${address.province}`, `${address.postalCode}`];
+const getAddress = address => {
+  const fullAddress = [`${address.city}, ${address.province}`, `${address.postalCode}`]
   if (address.line2 && address.line2 !== '') {
     fullAddress.unshift(`${address.line2}-${address.line1}`)
   } else {
@@ -89,8 +87,7 @@ const logIn = (cy, user) => {
   cy.injectAxe().checkA11y()
   cy.url().should('contain', '/login/sin')
   cy.get('h1').should('contain', 'Enter your Social Insurance Number (SIN)')
-  cy.get('h2')
-    .should('contain', `Thanks, ${user.firstName} ${user.lastName}!`)
+  cy.get('h2').should('contain', `Thanks, ${user.firstName} ${user.lastName}!`)
   cy.get('form label').should('have.attr', 'for', 'sin')
   cy.get('form input#sin')
     .type(user.sin)
@@ -104,10 +101,30 @@ const logIn = (cy, user) => {
   cy.url().should('contain', '/login/dateOfBirth')
   cy.get('h1').should('contain', 'Enter your date of birth')
 
-  cy.get('form label').should('have.attr', 'for', 'dateOfBirth')
-  cy.get('form input#dateOfBirth')
-    .type(user.dateOfBirth)
-    .should('have.value', user.dateOfBirth)
+  cy.get('form label')
+    .eq(0)
+    .should('have.attr', 'for', 'dobDay')
+  cy.get('form label')
+    .eq(1)
+    .should('have.attr', 'for', 'dobMonth')
+  cy.get('form label')
+    .eq(2)
+    .should('have.attr', 'for', 'dobYear')
+
+  const [dobYear, dobMonth, dobDay] = user.dateOfBirth.split('-')
+
+  cy.get('form input#dobDay')
+    .type(dobDay)
+    .should('have.value', dobDay)
+
+  cy.get('form input#dobMonth')
+    .type(dobMonth)
+    .should('have.value', dobMonth)
+
+  cy.get('form input#dobYear')
+    .type(dobYear)
+    .should('have.value', dobYear)
+
   cy.get('form button[type="submit"]')
     .should('contain', 'Continue')
     .click()

--- a/locales/en.json
+++ b/locales/en.json
@@ -284,5 +284,9 @@
   "Keep your notification letter with you. You need information on that letter to use this service.": "Keep your notification letter with you. You need information on that letter to use this service.",
   "For Example: A5G98S4K1": "For Example: A5G98S4K1",
   "Your access code was validated!": "Your access code was validated!",
-  "Street address": "Street address"
+  "Street address": "Street address",
+  "Your date of birth": "Your date of birth",
+  "Day": "Day",
+  "Month": "Month",
+  "Year": "Year"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -269,5 +269,9 @@
   "RRSP (208)": "REER (208)",
   "A benefit signup prototype by the Canadian Digital Service": "Un prototype d’inscription à des avantages fiscaux du Service numérique canadien",
   "This site will change as we test ideas.": "Ce site évoluera au fur et à mesure que nous testons des idées.",
-  "Keep your notification letter with you. You need information on that letter to use this service.": "Keep your notification letter with you. You need information on that letter to use this service."
+  "Keep your notification letter with you. You need information on that letter to use this service.": "Keep your notification letter with you. You need information on that letter to use this service.",
+  "Your date of birth": "Votre date de naissance",
+  "Day": "Jour",
+  "Month": "Mois",
+  "Year": "Année"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3684,28 +3684,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
@@ -3716,14 +3716,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
@@ -3734,42 +3734,42 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
@@ -3779,28 +3779,28 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -3810,14 +3810,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -3834,7 +3834,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
@@ -3849,14 +3849,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
@@ -3866,7 +3866,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -3876,7 +3876,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -3887,21 +3887,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
@@ -3911,14 +3911,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
@@ -3928,14 +3928,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "optional": true,
@@ -3946,7 +3946,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
@@ -3956,7 +3956,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
@@ -3966,14 +3966,14 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
           "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "dev": true,
           "optional": true,
@@ -3985,7 +3985,7 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
           "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "dev": true,
           "optional": true,
@@ -4004,7 +4004,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -4015,14 +4015,14 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
           "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
           "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
@@ -4033,7 +4033,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -4046,21 +4046,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
@@ -4070,21 +4070,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -4095,21 +4095,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
@@ -4122,7 +4122,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -4131,7 +4131,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -4147,7 +4147,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
@@ -4157,49 +4157,49 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
@@ -4211,7 +4211,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -4221,7 +4221,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
@@ -4231,14 +4231,14 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
@@ -4254,14 +4254,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
@@ -4271,14 +4271,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true,
           "optional": true

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "pug": "^2.0.4",
     "purecss": "^1.0.1",
     "request-promise": "^4.2.4",
+    "validator": "^11.1.0",
     "winston": "^3.2.1"
   },
   "devDependencies": {

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -165,6 +165,32 @@ form.cra-form {
   }
 }
 
+form.cra-form.cra-form--dob {
+  @include sm {
+    width: 60%;
+  }
+
+  @include md {
+    width: 50%;
+  }
+
+  > div {
+    &.d--ib {
+      display: inline-block;
+
+      &:not(:nth-child(4)) {
+        padding-right: $space-sm;
+      }
+    }
+    &.w-1-2 {
+      width: 50%;
+    }
+    &.w-1-4 {
+      width: 25%;
+    }
+  }
+}
+
 .fieldset {
   border: 0;
   padding: 0;

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -175,9 +175,12 @@ form.cra-form.cra-form--dob {
   }
 
   .dob-container {
-    h3 {
-      margin-top: 0;
+    legend {
       margin-bottom: $space-xxs;
+    }
+
+    h3 {
+      margin: 0;
     }
 
     .cra-form-message {
@@ -198,7 +201,7 @@ form.cra-form.cra-form--dob {
       }
     }
 
-    > div {
+    fieldset > div {
       &.d--ib {
         display: inline-block;
         padding-right: $space-sm;
@@ -214,11 +217,12 @@ form.cra-form.cra-form--dob {
   }
 }
 
-.fieldset {
+fieldset {
+  margin: 0;
   border: 0;
   padding: 0;
 
-  &__legend {
+  legend {
     border-bottom: 0;
     margin-bottom: $space-md;
 
@@ -227,7 +231,7 @@ form.cra-form.cra-form--dob {
     }
   }
 
-  .has-error &__legend {
+  .has-error & legend {
     margin-bottom: $space-xxs;
   }
 }

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -179,7 +179,7 @@ form.cra-form.cra-form--dob {
       margin-bottom: $space-xxs;
     }
 
-    h3 {
+    h2 {
       margin: 0;
     }
 

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -167,11 +167,11 @@ form.cra-form {
 
 form.cra-form.cra-form--dob {
   @include sm {
-    width: 60%;
+    width: 50%;
   }
 
   @include md {
-    width: 50%;
+    width: 40%;
   }
 
   .dob-container {
@@ -189,8 +189,12 @@ form.cra-form.cra-form--dob {
       padding: 0;
       margin-bottom: $space-sm;
 
+      @include sm {
+        width: 150%;
+      }
+
       @include md {
-        width: 135%;
+        width: 200%;
       }
     }
 

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -174,19 +174,38 @@ form.cra-form.cra-form--dob {
     width: 50%;
   }
 
-  > div {
-    &.d--ib {
-      display: inline-block;
+  .dob-container {
+    h3 {
+      margin-top: 0;
+      margin-bottom: $space-xxs;
+    }
 
-      &:not(:nth-child(4)) {
-        padding-right: $space-sm;
+    .cra-form-message {
+      margin-bottom: $space-sm;
+    }
+
+    ul {
+      list-style: none;
+      padding: 0;
+      margin-bottom: $space-sm;
+
+      @include md {
+        width: 135%;
       }
     }
-    &.w-1-2 {
-      width: 50%;
-    }
-    &.w-1-4 {
-      width: 25%;
+
+    > div {
+      &.d--ib {
+        display: inline-block;
+        padding-right: $space-sm;
+        margin-bottom: 0;
+      }
+      &.w-1-2 {
+        width: 50%;
+      }
+      &.w-1-4 {
+        width: 25%;
+      }
     }
   }
 }

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -1,6 +1,6 @@
 const { validationResult, checkSchema } = require('express-validator')
 const { errorArray2ErrorObject, doRedirect, renderWithData, checkErrors } = require('./../../utils')
-const { loginSchema, sinSchema, birthSchema, authSchema } = require('./../../schemas')
+const { loginSchema, sinSchema, dobSchema, authSchema } = require('./../../schemas')
 const API = require('../../api')
 const request = require('request-promise')
 
@@ -16,12 +16,7 @@ module.exports = function(app) {
 
   // Date of Birth
   app.get('/login/dateOfBirth', renderWithData('login/dateOfBirth'))
-  app.post(
-    '/login/dateOfBirth',
-    checkSchema(birthSchema),
-    checkErrors('login/dateOfBirth'),
-    doRedirect,
-  )
+  app.post('/login/dateOfBirth', checkSchema(dobSchema), postDateOfBirth, doRedirect)
 
   // Auth page
   app.get('/login/auth', getAuth)
@@ -58,6 +53,24 @@ const postLoginCode = async (req, res, next) => {
   }
 
   req.session = user // eslint-disable-line require-atomic-updates
+
+  next()
+}
+
+const postDateOfBirth = async (req, res, next) => {
+  const errors = validationResult(req)
+
+  // copy all posted parameters, but remove the redirect
+  let body = Object.assign({}, req.body)
+  delete body.redirect
+
+  if (!errors.isEmpty()) {
+    return res.status(422).render('login/dateOfBirth', {
+      data: req.session,
+      body,
+      errors: errorArray2ErrorObject(errors),
+    })
+  }
 
   next()
 }

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -65,10 +65,27 @@ const postDateOfBirth = async (req, res, next) => {
   delete body.redirect
 
   if (!errors.isEmpty()) {
+    let errObj = errorArray2ErrorObject(errors)
+
+    /*
+    We don't want to show the "birthdate doesn't match" error if there
+    are other errors, because it is obvious the birthdate doesn't match if
+    you enter a month of 99.
+
+    If exists more than 1 error, and the match error exists, delete the match error
+    */
+    if (
+      Object.keys(errObj).length > 1 &&
+      errObj.dobDay &&
+      errObj.dobDay.msg === 'errors.login.dateOfBirth.match'
+    ) {
+      delete errObj.dobDay
+    }
+
     return res.status(422).render('login/dateOfBirth', {
       data: req.session,
       body,
-      errors: errorArray2ErrorObject(errors),
+      errors: errObj,
     })
   }
 

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -208,21 +208,6 @@ describe('Test /login responses', () => {
     }
 
     const currentDate = new Date()
-    const year = currentDate.getFullYear()
-    const month = currentDate.getMonth()
-    const day = currentDate.getDate()
-
-    const dateToString = dateInput => {
-      const add0 = s => {
-        return s < 10 ? '0' + s : s
-      }
-      const d = new Date(dateInput)
-      return [add0(d.getDate()), add0(d.getMonth() + 1), d.getFullYear()].join('-')
-    }
-
-    const fewMonthsAgo = dateToString(new Date(year, month - 3, day))
-
-    const tooLongAgo = dateToString(new Date(year - 201, month, day))
 
     const badDoBRequests = [
       {
@@ -288,19 +273,6 @@ describe('Test /login responses', () => {
           ...{ dobDay: '29', dobMonth: '02', dobYear: '2019' },
         },
       },
-
-      /*
-
-      const currentDate = new Date()
-      const year = currentDate.getFullYear()
-      const month = currentDate.getMonth()
-      const day = currentDate.getDate()
-
-    const fewMonthsAgo = dateToString(new Date(year, month - 3, day))
-
-    const tooLongAgo = dateToString(new Date(year - 201, month, day))
-    */
-
       {
         label: 'date of birth is less than a year ago',
         send: {

--- a/schemas/login.schema.js
+++ b/schemas/login.schema.js
@@ -170,6 +170,40 @@ const birthSchema = {
   },
 }
 
+const currentDate = new Date()
+
+const dobSchema = {
+  dobYear: {
+    isInt: {
+      errorMessage: 'errors.login.dateOfBirth.validYear',
+      options: { min: currentDate.getFullYear() - 200, max: currentDate.getFullYear() - 1 },
+    },
+  },
+  dobMonth: {
+    isInt: {
+      errorMessage: 'errors.login.dateOfBirth.validMonth',
+      options: { min: 1, max: 12 },
+    },
+  },
+  dobDay: {
+    errorMessage: 'errors.login.dateOfBirth.validDay',
+    custom: {
+      options: (value, { req }) => {
+        const year = parseInt(req.body.dobYear, 10)
+        //subtract one because Date for months starts at a 0 index for Jan 🤓
+        const month = parseInt(req.body.dobMonth, 10) - 1
+        const day = parseInt(value, 10)
+
+        if (!day || !month || !year) {
+          return false
+        }
+
+        return day >= 1 && day <= lastDayInMonth(year, month)
+      },
+    },
+  },
+}
+
 const authSchema = {
   auth: currencySchema(),
 }
@@ -178,5 +212,6 @@ module.exports = {
   authSchema,
   birthSchema,
   loginSchema,
+  dobSchema,
   sinSchema,
 }

--- a/schemas/login.schema.js
+++ b/schemas/login.schema.js
@@ -202,11 +202,8 @@ const isMatchingDoB = {
 }
 
 const dobSchema = {
-  dobYear: {
-    isInt: {
-      errorMessage: 'errors.login.dateOfBirth.validYear',
-      options: { min: currentDate.getFullYear() - 200, max: currentDate.getFullYear() - 1 },
-    },
+  dobDay: {
+    ...validationArray([isValidDay, isMatchingDoB]),
   },
   dobMonth: {
     isInt: {
@@ -214,8 +211,11 @@ const dobSchema = {
       options: { min: 1, max: 12 },
     },
   },
-  dobDay: {
-    ...validationArray([isValidDay, isMatchingDoB]),
+  dobYear: {
+    isInt: {
+      errorMessage: 'errors.login.dateOfBirth.validYear',
+      options: { min: currentDate.getFullYear() - 200, max: currentDate.getFullYear() - 1 },
+    },
   },
 }
 

--- a/schemas/login.schema.js
+++ b/schemas/login.schema.js
@@ -133,7 +133,7 @@ const validYear = {
   },
 }
 
-const isMatchingDoB = {
+const matchingDoB = {
   errorMessage: 'errors.login.dateOfBirth.match',
   validate: (value, req) => {
     /* If there is no session, always return true */
@@ -160,7 +160,7 @@ const birthSchema = {
       validMonth,
       validDay,
       validYear,
-      isMatchingDoB,
+      matchingDoB,
     ]),
     isLength: {
       errorMessage: 'errors.login.dateOfBirth',
@@ -171,6 +171,35 @@ const birthSchema = {
 }
 
 const currentDate = new Date()
+
+const isValidDay = {
+  errorMessage: 'errors.login.dateOfBirth.validDay',
+  validate: (value, req) => {
+    const year = parseInt(req.body.dobYear, 10)
+    //subtract one because Date for months starts at a 0 index for Jan 🤓
+    const month = parseInt(req.body.dobMonth, 10) - 1
+    const day = parseInt(value, 10)
+
+    if (!day || !month || !year) {
+      return false
+    }
+
+    return day >= 1 && day <= lastDayInMonth(year, month)
+  },
+}
+
+const isMatchingDoB = {
+  errorMessage: 'errors.login.dateOfBirth.match',
+  validate: (value, req) => {
+    /* If there is no session, always return true */
+    if (!req.session || !req.session.personal) {
+      return true
+    }
+
+    const { dobYear: y, dobMonth: m, dobDay: d } = req.body
+    return `${y}-${m}-${d}` === req.session.personal.dateOfBirth
+  },
+}
 
 const dobSchema = {
   dobYear: {
@@ -186,21 +215,7 @@ const dobSchema = {
     },
   },
   dobDay: {
-    errorMessage: 'errors.login.dateOfBirth.validDay',
-    custom: {
-      options: (value, { req }) => {
-        const year = parseInt(req.body.dobYear, 10)
-        //subtract one because Date for months starts at a 0 index for Jan 🤓
-        const month = parseInt(req.body.dobMonth, 10) - 1
-        const day = parseInt(value, 10)
-
-        if (!day || !month || !year) {
-          return false
-        }
-
-        return day >= 1 && day <= lastDayInMonth(year, month)
-      },
-    },
+    ...validationArray([isValidDay, isMatchingDoB]),
   },
 }
 

--- a/schemas/login.schema.js
+++ b/schemas/login.schema.js
@@ -51,126 +51,11 @@ const sinSchema = {
   },
 }
 
+const currentDate = new Date()
+
 const lastDayInMonth = (year, month) => {
   return new Date(year, month + 1, 0).getDate()
 }
-
-const validBirthDateLengths = {
-  errorMessage: 'errors.login.dateOfBirth.format',
-  validate: value => {
-    if (!value) {
-      return false
-    }
-
-    const birthDateSplit = value.split('/')
-
-    if (birthDateSplit.length !== 3) {
-      return false
-    }
-
-    return (
-      birthDateSplit[0].length === 4 &&
-      birthDateSplit[1].length === 2 &&
-      birthDateSplit[2].length === 2
-    )
-  },
-}
-
-const validBirthDateChars = {
-  errorMessage: 'errors.login.dateOfBirth.characters',
-  validate: value => {
-    const numAndSlash = new RegExp(/^[0-9/]*$/)
-    return numAndSlash.test(value)
-  },
-}
-
-const validMonth = {
-  errorMessage: 'errors.login.dateOfBirth.validMonth',
-  validate: value => {
-    if (!value) {
-      return false
-    }
-
-    //month is not less than 1 or greater than 12
-    const month = parseInt(value.split('/')[1], 10)
-    return month >= 1 && month <= 12
-  },
-}
-
-const validDay = {
-  errorMessage: 'errors.login.dateOfBirth.validDay',
-  validate: value => {
-    if (!value) {
-      return false
-    }
-
-    //day is within the acceptable range
-    const dateSplit = value.split('/')
-    //subtract one because Date for months starts at a 0 index for Jan
-    const month = parseInt(dateSplit[1]) - 1
-    const day = parseInt(dateSplit[2], 10)
-    const lastDay = lastDayInMonth(dateSplit[0], month)
-    return day >= 1 && day <= lastDay
-  },
-}
-
-const validYear = {
-  errorMessage: 'errors.login.dateOfBirth.validYear',
-  validate: value => {
-    //year is within the acceptable range. Person not older than 200, not younger than 1
-    //listen, if you've lived to 201, why are you even bothering with taxes?
-    const dateEntered = new Date(value)
-    const currentDate = new Date()
-    const year = currentDate.getFullYear()
-    const month = currentDate.getMonth()
-    const day = currentDate.getDate()
-
-    const lastYear = new Date(year - 1, month, day)
-
-    const longAgo = new Date(year - 200, month, day)
-
-    return dateEntered <= lastYear && dateEntered >= longAgo
-  },
-}
-
-const matchingDoB = {
-  errorMessage: 'errors.login.dateOfBirth.match',
-  validate: (value, req) => {
-    /* If there is no session, always return true */
-    if (!req.session || !req.session.personal) {
-      return true
-    }
-
-    return value === req.session.personal.dateOfBirth
-  },
-}
-
-const birthSchema = {
-  dateOfBirth: {
-    //pro-tip: the order of the sanitizers does matter
-    customSanitizer: {
-      options: value => {
-        //We want to remove any spaces, dash or underscores
-        return value ? value.replace(/[ \-_]*/g, '') : value
-      },
-    },
-    ...validationArray([
-      validBirthDateLengths,
-      validBirthDateChars,
-      validMonth,
-      validDay,
-      validYear,
-      matchingDoB,
-    ]),
-    isLength: {
-      errorMessage: 'errors.login.dateOfBirth',
-      //length with slashes
-      options: { min: 10, max: 10 },
-    },
-  },
-}
-
-const currentDate = new Date()
 
 const isValidDay = {
   errorMessage: 'errors.login.dateOfBirth.validDay',
@@ -225,7 +110,6 @@ const authSchema = {
 
 module.exports = {
   authSchema,
-  birthSchema,
   loginSchema,
   dobSchema,
   sinSchema,

--- a/schemas/login.schema.js
+++ b/schemas/login.schema.js
@@ -229,4 +229,5 @@ module.exports = {
   loginSchema,
   dobSchema,
   sinSchema,
+  lastDayInMonth,
 }

--- a/schemas/login.schema.test.js
+++ b/schemas/login.schema.test.js
@@ -1,0 +1,35 @@
+const { lastDayInMonth } = require('./index')
+
+describe('Test lastDayInMonth', () => {
+  const monthLengths = [
+    ['january', 31],
+    ['february', 28],
+    ['march', 31],
+    ['april', 30],
+    ['may', 31],
+    ['june', 30],
+    ['july', 31],
+    ['august', 31],
+    ['september', 30],
+    ['october', 31],
+    ['november', 30],
+    ['december', 31],
+  ]
+
+  monthLengths.map((v, index) => {
+    test(`returns ${v[1]} days for ${v[0]}`, () => {
+      expect(lastDayInMonth('2019', index)).toEqual(v[1])
+    })
+  })
+
+  describe('knows about leap years', () => {
+    const february = 1
+    const daysInFeb = [['2020', 29], ['2019', 28], ['2018', 28], ['2017', 28], ['2016', 29]]
+
+    daysInFeb.map(v => {
+      test(`returns ${v[1]} days in February in ${v[0]}`, () => {
+        expect(lastDayInMonth(v[0], february)).toEqual(v[1])
+      })
+    })
+  })
+})

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,5 +1,6 @@
 const API = require('./../api')
 const { validationResult } = require('express-validator')
+const validator = require('validator')
 
 /*
   original format is an array of error objects: https://express-validator.github.io/docs/validation-result-api.html
@@ -221,6 +222,26 @@ const sortByLineNumber = (...objToSort) => {
   return sortedArrayObj
 }
 
+/**
+ * Accepts an ISO-format date (1999-09-30)
+ * and returns a string formatted "dd mm yyyy" (30 09 1999)
+ *
+ * @param {*} date a string ISO-format date
+ */
+const isoDateHintText = date => {
+  if (!validator.isISO8601(date)) {
+    throw new Error(`[GET /login/dateOfBirth] Bad date "${date}": must be a valid ISO date`)
+  }
+
+  const dateParts = date.split('-')
+
+  if (dateParts.length !== 3 || dateParts[2].length > 2) {
+    throw new Error(`[GET /login/dateOfBirth] Bad date "${date}": must be formatted yyyy-mm-dd`)
+  }
+
+  return `${dateParts[2]} ${dateParts[1]} ${dateParts[0]}`
+}
+
 module.exports = {
   errorArray2ErrorObject,
   checkErrors,
@@ -233,4 +254,5 @@ module.exports = {
   sortByLineNumber,
   checkLangQuery,
   doRedirect,
+  isoDateHintText,
 }

--- a/utils/index.spec.js
+++ b/utils/index.spec.js
@@ -1,4 +1,4 @@
-const { SINFilter, hasData } = require('./index')
+const { SINFilter, hasData, isoDateHintText } = require('./index')
 const API = require('./../api')
 
 describe('Test SINFilter', () => {
@@ -50,5 +50,21 @@ describe('Test hasData function', () => {
 
   test('returns true for disabilityClaim', () => {
     expect(hasData(user, 'deductions.disabilityClaim')).toBe(false)
+  })
+})
+
+describe('Test isoDateHintText function', () => {
+  test('an ISO date formatted "dd mm yyyy"', () => {
+    expect(isoDateHintText('1961-04-12')).toBe('12 04 1961')
+  })
+
+  test('an non-ISO date string to throw an error', () => {
+    expect(() => isoDateHintText('Cretaceous period')).toThrowError(/must be a valid ISO date/)
+  })
+
+  test('an ISO datetime string to throw an error', () => {
+    expect(() => isoDateHintText('1961-04-12T12:34:56.000Z')).toThrowError(
+      /must be formatted yyyy-mm-dd/,
+    )
   })
 })

--- a/views/_includes/yesNoRadios.pug
+++ b/views/_includes/yesNoRadios.pug
@@ -1,7 +1,7 @@
 mixin yesNoRadios(key, value, question, errors = false)
   div(class={['has-error']: errors && errors[key]})
-    fieldset.fieldset
-      legend.fieldset__legend #{__(question)}
+    fieldset
+      legend #{__(question)}
       .multiple-choice.multiple-choice--radios
         if errors
           +validationMessage(errors[key].msg, key)
@@ -9,7 +9,7 @@ mixin yesNoRadios(key, value, question, errors = false)
           input(id=`${key}Yes` name=key type="radio" value="Yes" checked=(value =='Yes') aria-describedby=(errors ? `${key}-error` : false))
           label(for=`${key}Yes`) #{__('Yes')}
         .multiple-choice__item(
-          aria-expanded=(block ? 'false': false) 
+          aria-expanded=(block ? 'false': false)
           aria-controls=(block ? 'noInfo': false)
         )
           input(id=`${key}No` name=key type="radio" value="No" checked=(value =='No') aria-describedby=(errors ? `${key}-error` : false))

--- a/views/login/dateOfBirth.pug
+++ b/views/login/dateOfBirth.pug
@@ -16,18 +16,34 @@ block content
 
     p #{__('Please enter your date of birth in the field below.')}
 
-    p For example, #{isoDateHintText(data.personal.dateOfBirth)}
 
   div
     form.cra-form.cra-form--lg.cra-form--dob(method='post')
-      h2 #{__('Your date of birth')}
 
-      +textInput('Day', ['w-1-4','d--ib'])(class='', value=dobDay, name='dobDay' autofocus=(!errors || errors && firstError.param === 'dobDay' ? true : false))
+      div.dob-container(class={['has-error']: errors && errors.dobDay})
 
-      +textInput('Month', ['w-1-4','d--ib'])(class='', value=dobMonth name='dobMonth')
+        h3 #{__('Your date of birth')}
 
-      +textInput('Year', ['w-1-2','d--ib'])(class='', value=dobYear name='dobYear')
+        span.cra-form-message #{__('For Example:')} #{isoDateHintText(data.personal.dateOfBirth)}
 
-      input#redirect(name='redirect', type='hidden', value='/personal/name')
+        if errors
+          ul
+            each err in errors
+              li
+                +validationMessage(err.msg, err.param)
+
+        div.w-1-4.d--ib
+          label(for='dobDay') #{__('Day')}
+          input#dobDay(name='dobDay', autofocus, type='text', value=dobDay, autocomplete='off' aria-describedby=(errors && errors.dobDay ? 'dobDay-error' : false))
+
+        div.w-1-4.d--ib
+          label(for='dobMonth') #{__('Month')}
+          input#dobMonth(name='dobMonth', autofocus, type='text', value=dobMonth, autocomplete='off' aria-describedby=(errors && errors.dobMonth ? 'dobMonth-error' : false))
+
+        div.w-1-2.d--ib
+          label(for='dobYear') #{__('Year')}
+          input#dobYear(name='dobYear', autofocus, type='text', value=dobYear, autocomplete='off' aria-describedby=(errors && errors.dobYear ? 'dobYear-error' : false))
+
+        input#redirect(name='redirect', type='hidden', value='/personal/name')
 
       +formButtons()

--- a/views/login/dateOfBirth.pug
+++ b/views/login/dateOfBirth.pug
@@ -3,6 +3,9 @@ extends ../base
 block variables
   -var title = __('Enter your date of birth')
   -var dateOfBirth = hasData(body, 'dateOfBirth') ? body.dateOfBirth : ''
+  -var dobDay = hasData(body, 'dobDay') ? body.dobDay : ''
+  -var dobMonth = hasData(body, 'dobMonth') ? body.dobMonth : ''
+  -var dobYear = hasData(body, 'dobYear') ? body.dobYear : ''
 
 block content
 
@@ -14,13 +17,14 @@ block content
     p #{__('Please enter your date of birth in the field below.')}
 
   div
-    form.cra-form(method='post')
-      div(class={['has-error']: errors && errors.dateOfBirth})
-        label(for='dateOfBirth') #{__('Date of Birth')}
-        span.cra-form-message #{__('For Example:')} #{data.personal.dateOfBirth}
-        if errors
-          +validationMessage(errors.dateOfBirth.msg, 'dateOfBirth')
-        input.w-3-4#dateOfBirth(name='dateOfBirth', autofocus, type='text', value=dateOfBirth, autocomplete='off' aria-describedby=(errors && errors.dateOfBirth ? 'dateOfBirth-error' : false))
+    form.cra-form.cra-form--lg.cra-form--dob(method='post')
+      h2 #{__('Your date of birth')}
+
+      +textInput('Day', ['w-1-4','d--ib'])(class='', value=dobDay, name='dobDay' autofocus=(!errors || errors && firstError.param === 'dobDay' ? true : false))
+
+      +textInput('Month', ['w-1-4','d--ib'])(class='', value=dobMonth name='dobMonth')
+
+      +textInput('Year', ['w-1-2','d--ib'])(class='', value=dobYear name='dobYear')
 
       input#redirect(name='redirect', type='hidden', value='/personal/name')
 

--- a/views/login/dateOfBirth.pug
+++ b/views/login/dateOfBirth.pug
@@ -16,6 +16,8 @@ block content
 
     p #{__('Please enter your date of birth in the field below.')}
 
+    p For example, #{splitISODate(data.personal.dateOfBirth, 'd')} #{splitISODate(data.personal.dateOfBirth, 'm')} #{splitISODate(data.personal.dateOfBirth, 'y')}
+
   div
     form.cra-form.cra-form--lg.cra-form--dob(method='post')
       h2 #{__('Your date of birth')}

--- a/views/login/dateOfBirth.pug
+++ b/views/login/dateOfBirth.pug
@@ -23,7 +23,7 @@ block content
       div.dob-container(class={['has-error']: errors && errors.dobDay})
         fieldset.fieldset(role="group", aria-describedby="dobHint",)
           legend
-            h3 #{__('Your date of birth')}
+            h2 #{__('Your date of birth')}
 
           span#dobHint.cra-form-message #{__('For Example:')} #{isoDateHintText(data.personal.dateOfBirth)}
 

--- a/views/login/dateOfBirth.pug
+++ b/views/login/dateOfBirth.pug
@@ -21,29 +21,30 @@ block content
     form.cra-form.cra-form--lg.cra-form--dob(method='post')
 
       div.dob-container(class={['has-error']: errors && errors.dobDay})
+        fieldset.fieldset(role="group", aria-describedby="dobHint",)
+          legend
+            h3 #{__('Your date of birth')}
 
-        h3 #{__('Your date of birth')}
+          span#dobHint.cra-form-message #{__('For Example:')} #{isoDateHintText(data.personal.dateOfBirth)}
 
-        span.cra-form-message #{__('For Example:')} #{isoDateHintText(data.personal.dateOfBirth)}
+          if errors
+            ul
+              each err in errors
+                li
+                  +validationMessage(err.msg, err.param)
 
-        if errors
-          ul
-            each err in errors
-              li
-                +validationMessage(err.msg, err.param)
+          div.w-1-4.d--ib
+            label(for='dobDay') #{__('Day')}
+            input#dobDay(name='dobDay', autofocus, type='text', value=dobDay, autocomplete='off' aria-describedby=(errors && errors.dobDay ? 'dobDay-error' : false))
 
-        div.w-1-4.d--ib
-          label(for='dobDay') #{__('Day')}
-          input#dobDay(name='dobDay', autofocus, type='text', value=dobDay, autocomplete='off' aria-describedby=(errors && errors.dobDay ? 'dobDay-error' : false))
+          div.w-1-4.d--ib
+            label(for='dobMonth') #{__('Month')}
+            input#dobMonth(name='dobMonth', autofocus, type='text', value=dobMonth, autocomplete='off' aria-describedby=(errors && errors.dobMonth ? 'dobMonth-error' : false))
 
-        div.w-1-4.d--ib
-          label(for='dobMonth') #{__('Month')}
-          input#dobMonth(name='dobMonth', autofocus, type='text', value=dobMonth, autocomplete='off' aria-describedby=(errors && errors.dobMonth ? 'dobMonth-error' : false))
+          div.w-1-2.d--ib
+            label(for='dobYear') #{__('Year')}
+            input#dobYear(name='dobYear', autofocus, type='text', value=dobYear, autocomplete='off' aria-describedby=(errors && errors.dobYear ? 'dobYear-error' : false))
 
-        div.w-1-2.d--ib
-          label(for='dobYear') #{__('Year')}
-          input#dobYear(name='dobYear', autofocus, type='text', value=dobYear, autocomplete='off' aria-describedby=(errors && errors.dobYear ? 'dobYear-error' : false))
-
-        input#redirect(name='redirect', type='hidden', value='/personal/name')
+          input#redirect(name='redirect', type='hidden', value='/personal/name')
 
       +formButtons()

--- a/views/login/dateOfBirth.pug
+++ b/views/login/dateOfBirth.pug
@@ -16,7 +16,7 @@ block content
 
     p #{__('Please enter your date of birth in the field below.')}
 
-    p For example, #{splitISODate(data.personal.dateOfBirth, 'd')} #{splitISODate(data.personal.dateOfBirth, 'm')} #{splitISODate(data.personal.dateOfBirth, 'y')}
+    p For example, #{isoDateHintText(data.personal.dateOfBirth)}
 
   div
     form.cra-form.cra-form--lg.cra-form--dob(method='post')

--- a/views/login/dateOfBirth.pug
+++ b/views/login/dateOfBirth.pug
@@ -35,15 +35,15 @@ block content
 
           div.w-1-4.d--ib
             label(for='dobDay') #{__('Day')}
-            input#dobDay(name='dobDay', autofocus, type='text', value=dobDay, autocomplete='off' aria-describedby=(errors && errors.dobDay ? 'dobDay-error' : false))
+            input#dobDay(name='dobDay', autofocus, type='text', value=dobDay, autocomplete='bday-day', aria-describedby=(errors && errors.dobDay ? 'dobDay-error' : false))
 
           div.w-1-4.d--ib
             label(for='dobMonth') #{__('Month')}
-            input#dobMonth(name='dobMonth', autofocus, type='text', value=dobMonth, autocomplete='off' aria-describedby=(errors && errors.dobMonth ? 'dobMonth-error' : false))
+            input#dobMonth(name='dobMonth', autofocus, type='text', value=dobMonth, autocomplete='bday-month', aria-describedby=(errors && errors.dobMonth ? 'dobMonth-error' : false))
 
           div.w-1-2.d--ib
             label(for='dobYear') #{__('Year')}
-            input#dobYear(name='dobYear', autofocus, type='text', value=dobYear, autocomplete='off' aria-describedby=(errors && errors.dobYear ? 'dobYear-error' : false))
+            input#dobYear(name='dobYear', autofocus, type='text', value=dobYear, autocomplete='bday-year', aria-describedby=(errors && errors.dobYear ? 'dobYear-error' : false))
 
           input#redirect(name='redirect', type='hidden', value='/personal/name')
 

--- a/views/personal/maritalStatus-edit.pug
+++ b/views/personal/maritalStatus-edit.pug
@@ -13,8 +13,8 @@ block content
 
   form.cra-form(method='post')
     div(class={['has-error']: errors && errors.maritalStatus})
-        fieldset.fieldset
-            legend.fieldset__legend #{__('Marital Status')}
+        fieldset
+            legend #{__('Marital Status')}
             .multiple-choice.multiple-choice--radios
                 if errors
                   +validationMessage(errors.maritalStatus.msg, 'maritalStatus')


### PR DESCRIPTION
Finally! 

We had a card on the backburner for a while to split the date of birth input int 3 fields to match the [GOV.UK design pattern for date inputs](https://design-system.service.gov.uk/components/date-input/). However, earlier in the project, we didn't time to implement this, so it was deprioritized.

However, we then saw people getting confused how to enter their date of birth in usability testing, so it was time to improve this.

Had to revamp it quite a bit, it turns out:

- changed our date format to an ISO date in the API (`yyyy/mm/dd` → `yyyy-mm-dd`)
- wrote a bunch of custom HTML for the DoB fields (instead of using our textInput)
  - now have 3 fields instead of 1
  - works on desktop and mobile
- added a function to display the hint text properly
- rewrote the dob schema pretty seriously (mostly removed things)
  - pretty sure all the edge cases are covered 🤞
- refactored all our tests (unit tests + cypress tests)

## gif

Works on mobile screens or desktop-sized screens

![dob](https://user-images.githubusercontent.com/2454380/64564015-a90a1280-d31e-11e9-8b70-55ae01cbf220.gif)

## Screenshots

| before | after |
|--------|-------|
|  1 field    |  3 fields      |
| <img width="1502" alt="Screen Shot 2019-09-09 at 12 17 08 PM" src="https://user-images.githubusercontent.com/2454380/64561220-3ac25180-d318-11e9-9bf7-8ee597bd70b2.png">  |   <img width="1502" alt="Screen Shot 2019-09-09 at 12 17 12 PM" src="https://user-images.githubusercontent.com/2454380/64561222-3c8c1500-d318-11e9-88b8-d4c41b7fd456.png">  |
|  errors for 1 field   |  errors for 3 fields      |
|   <img width="1514" alt="Screen Shot 2019-09-09 at 12 20 41 PM" src="https://user-images.githubusercontent.com/2454380/64561326-76f5b200-d318-11e9-8acd-6b9ae55ba329.png">  | <img width="1514" alt="Screen Shot 2019-09-09 at 12 20 38 PM" src="https://user-images.githubusercontent.com/2454380/64561329-7826df00-d318-11e9-9bb0-2eefd4bf4e28.png">   |




