### PR TITLE
Task/Add "yes/no" page for the property tax + energy costs trillium benefits

### DIFF
--- a/api/user.json
+++ b/api/user.json
@@ -145,6 +145,7 @@
     "seniorHomeownerClaim": null,
     "trilliumRentClaim": null,
     "trilliumRentAmount": 0,
+    "trilliumPropertyTaxClaim": null,
     "trilliumPropertyTaxAmount": 0,
     "trilliumStudentResidence": null,
     "trilliumEnergyAmount": 0,

--- a/api/user.json
+++ b/api/user.json
@@ -148,6 +148,7 @@
     "trilliumPropertyTaxClaim": null,
     "trilliumPropertyTaxAmount": 0,
     "trilliumStudentResidence": null,
+    "trilliumEnergyClaim": null,
     "trilliumEnergyAmount": 0,
     "trilliumLongTermCareAmount": 0,
     "climateActionIncentiveIsRural": null

--- a/config/routes.config.js
+++ b/config/routes.config.js
@@ -27,6 +27,7 @@ const routes = [
   { path: '/trillium/propertyTax' },
   { path: '/trillium/propertyTax/amount', editInfo: 'deductions.trilliumPropertyTaxAmount' },
   { path: '/trillium/studentResidence' },
+  { path: '/trillium/energy' },
   { path: '/trillium/energy/amount', editInfo: 'deductions.trilliumEnergyAmount' },
   { path: '/trillium/longTermCare/amount', editInfo: 'deductions.trilliumLongTermCareAmount' },
   { path: '/deductions/climate-action-incentive' },

--- a/config/routes.config.js
+++ b/config/routes.config.js
@@ -24,6 +24,7 @@ const routes = [
   { path: '/deductions/donations/amount', editInfo: 'deductions.charitableDonationAmount' },
   { path: '/trillium/rent' },
   { path: '/trillium/rent/amount', editInfo: 'deductions.trilliumRentAmount' },
+  { path: '/trillium/propertyTax' },
   { path: '/trillium/propertyTax/amount', editInfo: 'deductions.trilliumPropertyTaxAmount' },
   { path: '/trillium/studentResidence' },
   { path: '/trillium/energy/amount', editInfo: 'deductions.trilliumEnergyAmount' },

--- a/cypress/integration/full_run_simple.spec.js
+++ b/cypress/integration/full_run_simple.spec.js
@@ -188,12 +188,17 @@ describe('Full run through', function() {
 
   it('navigates the Trillium Property Tax page', function() {
     //TRILLIUM PROPERTY TAX
-    cy.url().should('contain', '/trillium/propertyTax/amount')
-    cy.get('h1').should('contain', 'Enter property tax paid in 2018')
-    cy.get('form input#trilliumPropertyTaxAmount')
-      .clear()
-      .type(this.user.trilliumPropertyTaxAmount)
-      .should('have.value', `${this.user.trilliumPropertyTaxAmount}`)
+    cy.url().should('contain', '/trillium/propertyTax')
+    cy.get('h1').should('contain', 'Deduct your property tax')
+
+    cy.get('input#trilliumPropertyTaxClaimNo + label').should(
+      'have.attr',
+      'for',
+      'trilliumPropertyTaxClaimNo',
+    )
+
+    cy.get('input#trilliumPropertyTaxClaimNo').click()
+
     cy.get('form button[type="submit"]')
       .should('contain', 'Continue')
       .click()

--- a/cypress/integration/full_run_simple.spec.js
+++ b/cypress/integration/full_run_simple.spec.js
@@ -223,12 +223,17 @@ describe('Full run through', function() {
 
   it('navigates the Trillium Home Energy page', function() {
     //TRILLIUM HOME ENERGY
-    cy.url().should('contain', '/trillium/energy/amount')
-    cy.get('h1').should('contain', 'Home energy costs on a reserve')
-    cy.get('form input#trilliumEnergyAmount')
-      .clear()
-      .type(this.user.trilliumEnergyAmount)
-      .should('have.value', `${this.user.trilliumEnergyAmount}`)
+    cy.url().should('contain', '/trillium/energy')
+    cy.get('h1').should('contain', 'Deduct your home energy costs on a reserve')
+
+    cy.get('input#trilliumEnergyClaimNo + label').should(
+      'have.attr',
+      'for',
+      'trilliumEnergyClaimNo',
+    )
+
+    cy.get('input#trilliumEnergyClaimNo').click()
+
     cy.get('form button[type="submit"]')
       .should('contain', 'Continue')
       .click()

--- a/locales/en.json
+++ b/locales/en.json
@@ -293,5 +293,10 @@
   "Deduct your rent payments": "Deduct your rent payments",
   "Deduct your property tax": "Deduct your property tax",
   "If you paid property tax in 2018, you may be entitled to receive credits from your": "If you paid property tax in 2018, you may be entitled to receive credits from your",
-  "Did you pay property tax in 2018?": "Did you pay property tax in 2018?"
+  "Did you pay property tax in 2018?": "Did you pay property tax in 2018?",
+  "Deduct your home energy costs on a reserve": "Deduct your home energy costs on a reserve",
+  "If you lived on a reserve and had home energy costs in 2018, you may be entitled to receive credits from your": "If you lived on a reserve and had home energy costs in 2018, you may be entitled to receive credits from your",
+  "Did you live on a reserve and have home energy costs 2018?": "Did you live on a reserve and have home energy costs 2018?",
+  "Enter home energy costs on a reserve in 2018": "Enter home energy costs on a reserve in 2018",
+  "Please enter your home energy costs for your principal residence on a reserve in 2018.": "Please enter your home energy costs for your principal residence on a reserve in 2018."
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -290,5 +290,8 @@
   "Rent paid in 2018": "Rent paid in 2018",
   "If you paid rent in 2018, you may be entitled to receive more credits from your": "If you paid rent in 2018, you may be entitled to receive more credits from your",
   "Did you pay rent in 2018?": "Did you pay rent in 2018?",
-  "Deduct your rent payments": "Deduct your rent payments"
+  "Deduct your rent payments": "Deduct your rent payments",
+  "Deduct your property tax": "Deduct your property tax",
+  "If you paid property tax in 2018, you may be entitled to receive credits from your": "If you paid property tax in 2018, you may be entitled to receive credits from your",
+  "Did you pay property tax in 2018?": "Did you pay property tax in 2018?"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -273,5 +273,8 @@
   "If you paid rent in 2018, you may be entitled to receive more credits from your": "If you paid rent in 2018, you may be entitled to receive more credits from your",
   "Did you pay rent in 2018?": "Did you pay rent in 2018?",
   "enter the amount you paid in rent in 2018.": "enter the amount you paid in rent in 2018.",
-  "Please note you may be asked to provide receipts to verify this information later.": "Please note you may be asked to provide receipts to verify this information later."
+  "Please note you may be asked to provide receipts to verify this information later.": "Please note you may be asked to provide receipts to verify this information later.",
+  "Deduct your property tax": "Deduct your property tax",
+  "If you paid property tax in 2018, you may be entitled to receive credits from your": "If you paid property tax in 2018, you may be entitled to receive credits from your",
+  "Did you pay property tax in 2018?": "Did you pay property tax in 2018?"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -276,5 +276,10 @@
   "Please note you may be asked to provide receipts to verify this information later.": "Please note you may be asked to provide receipts to verify this information later.",
   "Deduct your property tax": "Deduct your property tax",
   "If you paid property tax in 2018, you may be entitled to receive credits from your": "If you paid property tax in 2018, you may be entitled to receive credits from your",
-  "Did you pay property tax in 2018?": "Did you pay property tax in 2018?"
+  "Did you pay property tax in 2018?": "Did you pay property tax in 2018?",
+  "Deduct your home energy costs on a reserve": "Deduct your home energy costs on a reserve",
+  "If you lived on a reserve and had home energy costs in 2018, you may be entitled to receive credits from your": "If you lived on a reserve and had home energy costs in 2018, you may be entitled to receive credits from your",
+  "Did you live on a reserve and have home energy costs 2018?": "Did you live on a reserve and have home energy costs 2018?",
+  "Enter home energy costs on a reserve in 2018": "Enter home energy costs on a reserve in 2018",
+  "Please enter your home energy costs for your principal residence on a reserve in 2018.": "Please enter your home energy costs for your principal residence on a reserve in 2018."
 }

--- a/routes/deductions/deductions.controller.js
+++ b/routes/deductions/deductions.controller.js
@@ -26,7 +26,7 @@ module.exports = function(app) {
     '/deductions/rrsp',
     checkSchema(rrspSchema),
     checkErrors('deductions/rrsp'),
-    postRRSP,
+    doYesNo('rrspClaim', 'rrspAmount'),
     doRedirect,
   )
   app.get('/deductions/rrsp/amount', renderWithData('deductions/rrsp-amount'))
@@ -208,23 +208,6 @@ module.exports = function(app) {
     doRedirect,
   )
 }
-
-//Start of RRSP controller functions
-const postRRSP = (req, res, next) => {
-  const rrspClaim = req.body.rrspClaim
-
-  if (rrspClaim === 'Yes') {
-    req.session.deductions.rrspClaim = true
-
-    // These two pages are hardcoded together
-    return res.redirect('/deductions/rrsp/amount')
-  }
-
-  req.session.deductions.rrspClaim = false
-
-  next()
-}
-// End of RRSP controller functions
 
 //Start of Charitable Donations controller functions
 const postDonations = (req, res, next) => {

--- a/routes/deductions/deductions.controller.js
+++ b/routes/deductions/deductions.controller.js
@@ -14,6 +14,7 @@ const {
   trilliumPropertyTaxSchema,
   trilliumPropertyTaxAmountSchema,
   trilliumStudentResidenceSchema,
+  trilliumEnergySchema,
   trilliumEnergyAmountSchema,
   trilliumlongTermCareAmountSchema,
   climateActionIncentiveSchema,
@@ -118,7 +119,6 @@ module.exports = function(app) {
     doYesNo('trilliumRentClaim', 'trilliumRentAmount'),
     doRedirect,
   )
-
   app.get('/trillium/rent/amount', renderWithData('deductions/trillium-rent-amount'))
   app.post(
     '/trillium/rent/amount',
@@ -139,7 +139,6 @@ module.exports = function(app) {
     doYesNo('trilliumPropertyTaxClaim', 'trilliumPropertyTaxAmount'),
     doRedirect,
   )
-
   app.get('/trillium/propertyTax/amount', renderWithData('deductions/trillium-propertyTax-amount'))
   app.post(
     '/trillium/propertyTax/amount',
@@ -165,6 +164,14 @@ module.exports = function(app) {
     doRedirect,
   )
 
+  app.get('/trillium/energy', renderWithData('deductions/trillium-energy'))
+  app.post(
+    '/trillium/energy',
+    checkSchema(trilliumEnergySchema),
+    checkErrors('deductions/trillium-energy'),
+    doYesNo('trilliumEnergyClaim', 'trilliumEnergyAmount'),
+    doRedirect,
+  )
   app.get('/trillium/energy/amount', renderWithData('deductions/trillium-energy-amount'))
   app.post(
     '/trillium/energy/amount',

--- a/routes/deductions/deductions.controller.js
+++ b/routes/deductions/deductions.controller.js
@@ -11,6 +11,7 @@ const {
   medicalAmountSchema,
   trilliumRentSchema,
   trilliumRentAmountSchema,
+  trilliumPropertyTaxSchema,
   trilliumPropertyTaxAmountSchema,
   trilliumStudentResidenceSchema,
   trilliumEnergyAmountSchema,
@@ -127,6 +128,15 @@ module.exports = function(app) {
       req.session.deductions.trilliumRentAmount = req.body.trilliumRentAmount
       next()
     },
+    doRedirect,
+  )
+
+  app.get('/trillium/propertyTax', renderWithData('deductions/trillium-propertyTax'))
+  app.post(
+    '/trillium/propertyTax',
+    checkSchema(trilliumPropertyTaxSchema),
+    checkErrors('deductions/trillium-propertyTax'),
+    postTrilliumPropertyTax,
     doRedirect,
   )
 
@@ -279,6 +289,21 @@ const postTrilliumRent = (req, res, next) => {
   }
 
   req.session.deductions.trilliumRentClaim = false
+
+  next()
+}
+
+const postTrilliumPropertyTax = (req, res, next) => {
+  const trilliumPropertyTaxClaim = req.body.trilliumPropertyTaxClaim
+
+  if (trilliumPropertyTaxClaim === 'Yes') {
+    req.session.deductions.trilliumPropertyTaxClaim = true
+
+    // These two pages are hardcoded together
+    return res.redirect('/trillium/propertyTax/amount')
+  }
+
+  req.session.deductions.trilliumPropertyTaxClaim = false
 
   next()
 }

--- a/routes/deductions/deductions.controller.js
+++ b/routes/deductions/deductions.controller.js
@@ -1,5 +1,5 @@
 const { checkSchema } = require('express-validator')
-const { doRedirect, renderWithData, checkErrors } = require('./../../utils')
+const { doRedirect, doYesNo, renderWithData, checkErrors } = require('./../../utils')
 const {
   rrspSchema,
   rrspAmountSchema,
@@ -115,7 +115,7 @@ module.exports = function(app) {
     '/trillium/rent',
     checkSchema(trilliumRentSchema),
     checkErrors('deductions/trillium-rent'),
-    postTrilliumRent,
+    doYesNo('trilliumRentClaim', 'trilliumRentAmount'),
     doRedirect,
   )
 
@@ -136,7 +136,7 @@ module.exports = function(app) {
     '/trillium/propertyTax',
     checkSchema(trilliumPropertyTaxSchema),
     checkErrors('deductions/trillium-propertyTax'),
-    postTrilliumPropertyTax,
+    doYesNo('trilliumPropertyTaxClaim', 'trilliumPropertyTaxAmount'),
     doRedirect,
   )
 
@@ -276,35 +276,3 @@ const postPolitical = (req, res, next) => {
   next()
 }
 //End of Political controller functions
-
-// Start of Trillium controller functions
-const postTrilliumRent = (req, res, next) => {
-  const trilliumRentClaim = req.body.trilliumRentClaim
-
-  if (trilliumRentClaim === 'Yes') {
-    req.session.deductions.trilliumRentClaim = true
-
-    // These two pages are hardcoded together
-    return res.redirect('/trillium/rent/amount')
-  }
-
-  req.session.deductions.trilliumRentClaim = false
-
-  next()
-}
-
-const postTrilliumPropertyTax = (req, res, next) => {
-  const trilliumPropertyTaxClaim = req.body.trilliumPropertyTaxClaim
-
-  if (trilliumPropertyTaxClaim === 'Yes') {
-    req.session.deductions.trilliumPropertyTaxClaim = true
-
-    // These two pages are hardcoded together
-    return res.redirect('/trillium/propertyTax/amount')
-  }
-
-  req.session.deductions.trilliumPropertyTaxClaim = false
-
-  next()
-}
-// End of Trillium controller functions

--- a/routes/deductions/deductions.spec.js
+++ b/routes/deductions/deductions.spec.js
@@ -82,17 +82,21 @@ describe('Test /deductions responses', () => {
         key: 'donationsClaim',
       },
       {
-        url: '/trillium/studentResidence',
-        key: 'trilliumStudentResidence',
-        yesRedir: '/success',
+        url: '/deductions/political',
+        key: 'politicalClaim',
       },
       {
         url: '/trillium/rent',
         key: 'trilliumRentClaim',
       },
       {
-        url: '/deductions/political',
-        key: 'politicalClaim',
+        url: '/trillium/propertyTax',
+        key: 'trilliumPropertyTaxClaim',
+      },
+      {
+        url: '/trillium/studentResidence',
+        key: 'trilliumStudentResidence',
+        yesRedir: '/success',
       },
       {
         url: '/deductions/climate-action-incentive',

--- a/routes/deductions/deductions.spec.js
+++ b/routes/deductions/deductions.spec.js
@@ -99,6 +99,10 @@ describe('Test /deductions responses', () => {
         yesRedir: '/success',
       },
       {
+        url: '/trillium/energy',
+        key: 'trilliumEnergyClaim',
+      },
+      {
         url: '/deductions/climate-action-incentive',
         key: 'climateActionIncentiveIsRural',
         yesRedir: '/success',

--- a/schemas/deductions.schema.js
+++ b/schemas/deductions.schema.js
@@ -41,6 +41,10 @@ const trilliumRentAmountSchema = {
   trilliumRentAmount: currencySchema(),
 }
 
+const trilliumPropertyTaxSchema = {
+  trilliumPropertyTaxClaim: yesNoSchema(),
+}
+
 const trilliumPropertyTaxAmountSchema = {
   trilliumPropertyTaxAmount: currencySchema(),
 }
@@ -73,6 +77,7 @@ module.exports = {
   rrspAmountSchema,
   trilliumRentSchema,
   trilliumRentAmountSchema,
+  trilliumPropertyTaxSchema,
   trilliumPropertyTaxAmountSchema,
   trilliumEnergyAmountSchema,
   trilliumlongTermCareAmountSchema,

--- a/schemas/deductions.schema.js
+++ b/schemas/deductions.schema.js
@@ -53,6 +53,10 @@ const trilliumStudentResidenceSchema = {
   trilliumStudentResidence: yesNoSchema(),
 }
 
+const trilliumEnergySchema = {
+  trilliumEnergyClaim: yesNoSchema(),
+}
+
 const trilliumEnergyAmountSchema = {
   trilliumEnergyAmount: currencySchema(),
 }
@@ -79,6 +83,7 @@ module.exports = {
   trilliumRentAmountSchema,
   trilliumPropertyTaxSchema,
   trilliumPropertyTaxAmountSchema,
+  trilliumEnergySchema,
   trilliumEnergyAmountSchema,
   trilliumlongTermCareAmountSchema,
   trilliumStudentResidenceSchema,

--- a/utils/index.js
+++ b/utils/index.js
@@ -153,7 +153,14 @@ const doYesNo = (claim, amount) => {
     }
 
     req.session.deductions[claim] = false
-    req.session.deductions[amount] = 0
+
+    if (amount && req.session.deductions[amount]) {
+      if (Object.keys(req.session.deductions[amount]).includes('amount')) {
+        req.session.deductions[amount].amount = 0.0
+      } else {
+        req.session.deductions[amount] = 0
+      }
+    }
 
     next()
   }

--- a/utils/index.js
+++ b/utils/index.js
@@ -127,6 +127,38 @@ const renderWithData = template => {
   }
 }
 
+/**
+ * Middleware to handle our yes/no question routing logic.
+ * If the yesNo page comes back "Yes"
+ * - set the session variable to "true"
+ * - redirect to the "/amount" url
+ *
+ * If the yesNo page comes back "No"
+ * - set the session variable to "false"
+ * - reset the "amount" var to 0
+ * - continue
+ *
+ * @param string claim the variable name with the claim
+ * @param string amount the variable name with the amount
+ */
+const doYesNo = (claim, amount) => {
+  return (req, res, next) => {
+    const claimVal = req.body[claim]
+
+    if (claimVal === 'Yes') {
+      req.session.deductions[claim] = true
+
+      // These two pages are hardcoded together
+      return res.redirect(`${req.path}/amount`)
+    }
+
+    req.session.deductions[claim] = false
+    req.session.deductions[amount] = 0
+
+    next()
+  }
+}
+
 /* Pug filters */
 /**
  * Accepts a string (assumed to be a SIN)
@@ -302,6 +334,7 @@ module.exports = {
   sortByLineNumber,
   checkLangQuery,
   doRedirect,
+  doYesNo,
   getPreviousRoute,
   isoDateHintText,
 }

--- a/views/deductions/trillium-energy-amount.pug
+++ b/views/deductions/trillium-energy-amount.pug
@@ -1,8 +1,8 @@
 extends ../base
 
 block variables
-  -var title = __('Home energy costs on a reserve')
-  -var trilliumEnergyAmount = hasData(data, 'deductions.trilliumEnergyAmount') ? data.deductions.trilliumEnergyAmount : '0'
+  -var title = __('Enter home energy costs on a reserve in 2018')
+  -var trilliumEnergyAmount = hasData(data, 'deductions.trilliumEnergyAmount') && data.deductions.trilliumEnergyAmount !== 0 ? data.deductions.trilliumEnergyAmount : ''
 
 block content
 
@@ -11,9 +11,9 @@ block content
   include ../_includes/backButton
 
   div
-    p #{__('Please enter the home energy costs paid for your principal residence on a reserve in Ontario in 2018.')}
+    p #{__('Please enter your home energy costs for your principal residence on a reserve in 2018.')}
 
-    p #{__('Leave the field as')} <strong>0</strong>, #{__('if this doesn’t apply to you or if you don’t have the receipts to verify this information later.')}
+    p #{__('Please note you may be asked to provide receipts to verify this information later.')}
 
   form.cra-form(method='post')
     +textInput('Home energy costs on a reserve in 2018')(class='w-1-2 input-with-unit' name='trilliumEnergyAmount' placeholder='0.00' aria-labelledby='trilliumEnergyAmount__unit trilliumEnergyAmount__label' value=trilliumEnergyAmount)

--- a/views/deductions/trillium-energy.pug
+++ b/views/deductions/trillium-energy.pug
@@ -1,0 +1,22 @@
+extends ../base
+include ../_includes/yesNoRadios
+
+block variables
+  -var title = __('Deduct your home energy costs on a reserve')
+  -var trilliumEnergyClaim = !hasData(data, 'deductions.trilliumEnergyClaim') ? '' : data.deductions.trilliumEnergyClaim ? 'Yes' : 'No'
+
+block content
+
+  h1 #{title}
+
+  include ../_includes/backButton
+
+  div
+    p #{__('If you lived on a reserve and had home energy costs in 2018, you may be entitled to receive credits from your')} <strong>#{__('Ontario Trillium Benefit')}</strong>.
+
+  form.cra-form(method='post')
+    +yesNoRadios('trilliumEnergyClaim', trilliumEnergyClaim, 'Did you live on a reserve and have home energy costs 2018?', errors)
+
+    input#redirect(name='redirect', type='hidden', value='/trillium/longTermCare/amount')
+
+    +formButtons()

--- a/views/deductions/trillium-propertyTax-amount.pug
+++ b/views/deductions/trillium-propertyTax-amount.pug
@@ -13,7 +13,7 @@ block content
   div
     p #{__('Please enter the total property tax paid for your principal residence in 2018.')}
 
-    p #{__('Leave the field as')} <strong>0</strong>, #{__('if you paid no property tax in 2018 or if you don’t have the receipts to verify this information later.')}
+    p #{__('Please note you may be asked to provide receipts to verify this information later.')}
 
   form.cra-form(method='post')
     +textInput('Total property tax in 2018')(class='w-1-2 input-with-unit' name='trilliumPropertyTaxAmount' placeholder='0.00' aria-labelledby='trilliumPropertyTaxAmount__unit trilliumPropertyTaxAmount__label' value=trilliumPropertyTaxAmount)

--- a/views/deductions/trillium-propertyTax-amount.pug
+++ b/views/deductions/trillium-propertyTax-amount.pug
@@ -2,7 +2,7 @@ extends ../base
 
 block variables
   -var title = __('Enter property tax paid in 2018')
-  -var trilliumPropertyTaxAmount = hasData(data, 'deductions.trilliumPropertyTaxAmount') ? data.deductions.trilliumPropertyTaxAmount : '0'
+  -var trilliumPropertyTaxAmount = hasData(data, 'deductions.trilliumPropertyTaxAmount') &&  data.deductions.trilliumPropertyTaxAmount !== 0 ? data.deductions.trilliumPropertyTaxAmount : ''
 
 block content
 

--- a/views/deductions/trillium-propertyTax.pug
+++ b/views/deductions/trillium-propertyTax.pug
@@ -3,7 +3,7 @@ include ../_includes/yesNoRadios
 
 block variables
   -var title = __('Deduct your property tax')
-  -var trilliumPropertyTaxClaim = hasData(data, 'deductions.trilliumPropertyTaxClaim') ? data.deductions.trilliumPropertyTaxClaim : ''
+  -var trilliumPropertyTaxClaim = !hasData(data, 'deductions.trilliumPropertyTaxClaim') ? '' : data.deductions.trilliumPropertyTaxClaim ? 'Yes' : 'No'
 
 block content
 

--- a/views/deductions/trillium-propertyTax.pug
+++ b/views/deductions/trillium-propertyTax.pug
@@ -1,0 +1,22 @@
+extends ../base
+include ../_includes/yesNoRadios
+
+block variables
+  -var title = __('Deduct your property tax')
+  -var trilliumPropertyTaxClaim = hasData(data, 'deductions.trilliumPropertyTaxClaim') ? data.deductions.trilliumPropertyTaxClaim : ''
+
+block content
+
+  h1 #{title}
+
+  include ../_includes/backButton
+
+  div
+    p #{__('If you paid property tax in 2018, you may be entitled to receive credits from your')} <strong>#{__('Ontario Trillium Benefit')}</strong>.
+
+  form.cra-form(method='post')
+    +yesNoRadios('trilliumPropertyTaxClaim', trilliumPropertyTaxClaim, 'Did you pay property tax in 2018?', errors)
+
+    input#redirect(name='redirect', type='hidden', value='/trillium/studentResidence')
+
+    +formButtons()

--- a/views/deductions/trillium-rent-amount.pug
+++ b/views/deductions/trillium-rent-amount.pug
@@ -18,6 +18,6 @@ block content
   form.cra-form(method='post')
     +textInput('Total annual rent in 2018')(class='w-1-2 input-with-unit' name='trilliumRentAmount' placeholder='0.00' aria-labelledby='trilliumRentAmount__unit trilliumRentAmount__label' value=trilliumRentAmount)
 
-    input#redirect(name='redirect', type='hidden', value='/trillium/propertyTax/amount')
+    input#redirect(name='redirect', type='hidden', value='/trillium/propertyTax')
 
     +formButtons('Continue')

--- a/views/deductions/trillium-rent-amount.pug
+++ b/views/deductions/trillium-rent-amount.pug
@@ -2,7 +2,7 @@ extends ../base
 
 block variables
   -var title = __('Enter rent paid in 2018')
-  -var trilliumRentAmount = hasData(data, 'deductions.trilliumRentAmount') ? data.deductions.trilliumRentAmount : '0'
+  -var trilliumRentAmount = hasData(data, 'deductions.trilliumRentAmount') && data.deductions.trilliumRentAmount !== 0 ? data.deductions.trilliumRentAmount : ''
 
 block content
 

--- a/views/deductions/trillium-rent.pug
+++ b/views/deductions/trillium-rent.pug
@@ -3,7 +3,7 @@ include ../_includes/yesNoRadios
 
 block variables
   -var title = __('Deduct your rent payments')
-  -var trilliumRentClaim = hasData(data, 'deductions.trilliumRentClaim') ? data.deductions.rrspClaim : ''
+  -var trilliumRentClaim = hasData(data, 'deductions.trilliumRentClaim') ? data.deductions.trilliumRentClaim : ''
 
 block content
 
@@ -17,6 +17,6 @@ block content
   form.cra-form(method='post')
     +yesNoRadios('trilliumRentClaim', trilliumRentClaim, 'Did you pay rent in 2018?', errors)
 
-    input#redirect(name='redirect', type='hidden', value='/trillium/propertyTax/amount')
+    input#redirect(name='redirect', type='hidden', value='/trillium/propertyTax')
 
     +formButtons()

--- a/views/deductions/trillium-rent.pug
+++ b/views/deductions/trillium-rent.pug
@@ -3,7 +3,7 @@ include ../_includes/yesNoRadios
 
 block variables
   -var title = __('Deduct your rent payments')
-  -var trilliumRentClaim = hasData(data, 'deductions.trilliumRentClaim') ? data.deductions.trilliumRentClaim : ''
+  -var trilliumRentClaim = !hasData(data, 'deductions.trilliumRentClaim') ? '' : data.deductions.trilliumRentClaim ? 'Yes' : 'No'
 
 block content
 

--- a/views/deductions/trillium-studentResidence.pug
+++ b/views/deductions/trillium-studentResidence.pug
@@ -14,6 +14,6 @@ block content
   form.cra-form(method='post')
     +yesNoRadios('trilliumStudentResidence', trilliumStudentResidence, 'Did you live in a designated student residence in 2018?', errors)
 
-    input#redirect(name='redirect', type='hidden', value='/trillium/energy/amount')
+    input#redirect(name='redirect', type='hidden', value='/trillium/energy')
 
     +formButtons()


### PR DESCRIPTION
This PR does a bunch of things:

### Adds yes/no pages for property tax and energy costs on a reserve

Now you have to say that you have these costs before entering the amount. Once these are in, there is one page left to go. (Also adds unit tests + updates cypress tests)

### Returned stored `true`/`false` values to the "Yes/No" field for the trillium questions

As mentioned [in this story on trello](https://trello.com/c/BsP43ovG/229-%F0%9F%95%B7bug-a-bunch-of-pages-in-the-app-dont-preserve-users-previously-entered-values), lots of pages don't fill the "yes/no" back when you revisit them. It turns out this is because we have "true/false/null" values and we need to explicitly change them into "Yes" or "No".

So I updated them for the trillium questions but not the rest of the app.

Commit: https://github.com/cds-snc/cra-claim-tax-benefits/commit/6809d8ad041c8305eb8f1d7bd4b4545245ab6819

### Don't put a "0" in the trillium amount fields by default

We heard this was a problem during the usability study and it makes more sense to remove the zeros and just show the placeholder text (`0.00`). Since the default value is `0`, I did an explicit check before putting the value into the mixin.

Commit: https://github.com/cds-snc/cra-claim-tax-benefits/commit/b99295dba19678bc16fe6f83b9b70a4fe20e8c4e

### Adds middleware for yes/no questions

After copy+pasting a bunch of similar-looking messages, it seemed like we could write another ✨middleware ✨ to help us out.

[Wrote a function](https://github.com/cds-snc/cra-claim-tax-benefits/pull/142/commits/bae0a9d60364805368ce156c0dbc40501f2e2e7e) that generalises the common pattern, and then [used it for the trillium questions here](https://github.com/cds-snc/cra-claim-tax-benefits/commit/f4fe1b621ef6ac6b4513ad9a1b264c3f2dbb98f2).

@katedee, I was planning to move the charity question etc over to use this middleware (have to change some variable names), but wanted you to have a look before changing a bunch of existing code. I changed the RRSP page question [here](https://github.com/cds-snc/cra-claim-tax-benefits/pull/142/commits/ff24f731e8653c82e68a2fd25deb79cbfeb767aa). See what you think.

### TODO

- Add one more trillium question
- (opt) Get the other `/deduction` yes/no pages using my middleware

### Screenshots

#### Property tax pages

| before | after |
|--------|-------|
|   N/A     |  <img width="1362" alt="Screen Shot 2019-09-17 at 12 32 36 PM" src="https://user-images.githubusercontent.com/2454380/65061202-6c09d580-d947-11e9-9c33-9eb9e73ce444.png">   |
|  <img width="1362" alt="Screen Shot 2019-09-17 at 12 32 55 PM" src="https://user-images.githubusercontent.com/2454380/65061199-6c09d580-d947-11e9-83f7-66a490f59f97.png">  |   <img width="1362" alt="Screen Shot 2019-09-17 at 12 32 45 PM" src="https://user-images.githubusercontent.com/2454380/65061200-6c09d580-d947-11e9-8f9c-1b7b8cec8c4f.png">   |


#### Home energy on a reserve pages
| before | after |
|--------|-------|
|   N/A     |  <img width="1362" alt="Screen Shot 2019-09-17 at 12 33 33 PM" src="https://user-images.githubusercontent.com/2454380/65061196-6c09d580-d947-11e9-90a9-82d850a02532.png">  |
|   <img width="1362" alt="Screen Shot 2019-09-17 at 12 33 18 PM" src="https://user-images.githubusercontent.com/2454380/65061198-6c09d580-d947-11e9-83a1-3e1243d51766.png">   |  <img width="1362" alt="Screen Shot 2019-09-17 at 12 38 45 PM" src="https://user-images.githubusercontent.com/2454380/65061532-24377e00-d948-11e9-896d-5062735e2dec.png">   |








