### PR TITLE
Add cypress test instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a small frontend to trial user flows for a future CRA service that will help Canadians receive the benefits to which they are entitled.
 
-It’s a server-side [express](https://expressjs.com/) application using [Pug](https://pugjs.org/api/getting-started.html) templating on the server and a dash of [Pure CSS](https://purecss.io/).
+It’s a server-side [express](https://expressjs.com/) application using [Pug](https://pugjs.org/api/getting-started.html) templating on the server and schnazzy [SCSS](https://sass-lang.com/) stylesheets.
 
 ## Getting started (npm)
 
@@ -69,6 +69,10 @@ npm test
 
 # run linting
 npm run lint
+
+# run end-to-end tests
+npm run cypress
+npm run cypress:cli # these don't open a browser
 ```
 
 ## Using Docker

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ npm run cypress
 npm run cypress:cli # these don't open a browser
 ```
 
+#### Using Cypress
+
+[Cypress](https://www.cypress.io/) is what we use to write our end-to-end tests. It can run in a browser or in headless mode (ie, on the command line) to step through one or more flows. By running our end-to-end tests frequently, we are making sure sure that new changes to the code don't existing user journies.
+
 ## Using Docker
 
 ### [Install `docker`](https://docs.docker.com/install/)


### PR DESCRIPTION
Also removed an outdated reference to PureCSS, which we ditched ages ago.