### PR TITLE
Add new content to the `login/code` page

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -322,5 +322,10 @@
   "Amount donated": "Amount donated",
   "Rent paid": "Rent paid",
   "Yearly energy costs": "Yearly energy costs",
-  "Acommodation cost": "Acommodation cost"
+  "Acommodation cost": "Acommodation cost",
+  "Personal security code": "Personal security code",
+  "You can find your personal filing code in the CRA letter about this new Claim Tax Benefits service.": "You can find your personal filing code in the CRA letter about this new Claim Tax Benefits service.",
+  "Personal filing code": "Personal filing code",
+  "Enter your personal filing code": "Enter your personal filing code",
+  "Help with personal filing code": "Help with personal filing code"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -330,5 +330,8 @@
   "Help with personal filing code": "Help with personal filing code",
   "You can find your personal filing code in the CRA letter about this new": "You can find your personal filing code in the CRA letter about this new",
   "Claim Tax Benefits": "Claim Tax Benefits",
-  "service.": "service."
+  "service.": "service.",
+  " service.": " service.",
+  "You can find your personal filing code in the CRA letter about this new ": "You can find your personal filing code in the CRA letter about this new ",
+  "service.name ": "service.name "
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -328,10 +328,8 @@
   "Personal filing code": "Personal filing code",
   "Enter your personal filing code": "Enter your personal filing code",
   "Help with personal filing code": "Help with personal filing code",
-  "You can find your personal filing code in the CRA letter about this new": "You can find your personal filing code in the CRA letter about this new",
-  "Claim Tax Benefits": "Claim Tax Benefits",
-  "service.": "service.",
   " service.": " service.",
   "You can find your personal filing code in the CRA letter about this new ": "You can find your personal filing code in the CRA letter about this new ",
-  "service.name ": "service.name "
+  "service.name ": "service.name ",
+  "Your code has 9-characters and you can find it on the CRA letter about the Claim Tax Benefits service. The letter has your name and address at the top.": "Your code has 9-characters and you can find it on the CRA letter about the Claim Tax Benefits service. The letter has your name and address at the top."
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -327,5 +327,8 @@
   "You can find your personal filing code in the CRA letter about this new Claim Tax Benefits service.": "You can find your personal filing code in the CRA letter about this new Claim Tax Benefits service.",
   "Personal filing code": "Personal filing code",
   "Enter your personal filing code": "Enter your personal filing code",
-  "Help with personal filing code": "Help with personal filing code"
+  "Help with personal filing code": "Help with personal filing code",
+  "You can find your personal filing code in the CRA letter about this new": "You can find your personal filing code in the CRA letter about this new",
+  "Claim Tax Benefits": "Claim Tax Benefits",
+  "service.": "service."
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -308,5 +308,7 @@
   "Help with personal filing code": "Help with personal filing code",
   "You can find your personal filing code in the CRA letter about this new": "You can find your personal filing code in the CRA letter about this new",
   "Claim Tax Benefits": "Claim Tax Benefits",
-  "service.": "service."
+  "service.": "service.",
+  "You can find your personal filing code in the CRA letter about this new ": "You can find your personal filing code in the CRA letter about this new ",
+  " service.": " service."
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -299,5 +299,11 @@
   "Did you pay rent?": "Did you pay rent?",
   "Student residence": "Student residence",
   "Public long-term care home": "Public long-term care home",
-  "Small or rural community": "Small or rural community"
+  "Small or rural community": "Small or rural community",
+  "For Example: A5G98S4K1": "For Example: A5G98S4K1",
+  "Your code has 9-characters and you can find it on the CRA letter about the Claim Tax Benefits service. The letter has your name and address at the top.": "Your code has 9-characters and you can find it on the CRA letter about the Claim Tax Benefits service. The letter has your name and address at the top.",
+  "Enter your personal filing code": "Enter your personal filing code",
+  "You can find your personal filing code in the CRA letter about this new Claim Tax Benefits service.": "You can find your personal filing code in the CRA letter about this new Claim Tax Benefits service.",
+  "Personal filing code": "Personal filing code",
+  "Help with personal filing code": "Help with personal filing code"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -305,5 +305,8 @@
   "Enter your personal filing code": "Enter your personal filing code",
   "You can find your personal filing code in the CRA letter about this new Claim Tax Benefits service.": "You can find your personal filing code in the CRA letter about this new Claim Tax Benefits service.",
   "Personal filing code": "Personal filing code",
-  "Help with personal filing code": "Help with personal filing code"
+  "Help with personal filing code": "Help with personal filing code",
+  "You can find your personal filing code in the CRA letter about this new": "You can find your personal filing code in the CRA letter about this new",
+  "Claim Tax Benefits": "Claim Tax Benefits",
+  "service.": "service."
 }

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -35,7 +35,7 @@ describe('Test /login responses', () => {
     const response = await request(app).get('/login/code')
 
     const $ = cheerio.load(response.text)
-    expect($('h1').text()).toEqual('Enter your personal security code')
+    expect($('h1').text()).toEqual('Enter your personal filing code')
   })
 
   test('it returns a 500 response if no redirect is provided', async () => {

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -35,7 +35,7 @@ describe('Test /login responses', () => {
     const response = await request(app).get('/login/code')
 
     const $ = cheerio.load(response.text)
-    expect($('h1').text()).toEqual('Enter your personal access code')
+    expect($('h1').text()).toEqual('Enter your personal security code')
   })
 
   test('it returns a 500 response if no redirect is provided', async () => {

--- a/views/login/code.pug
+++ b/views/login/code.pug
@@ -1,23 +1,23 @@
 extends ../base
 
 block variables
-  -var title = __('Enter your personal access code')
+  -var title = __('Enter your personal security code')
 
 block content
 
   h1 #{title}
 
   div
-    p #{__('Your personal access code is the the 9-character code at the bottom of your notification letter.')}
+    p #{__('You can find your personal security code in the CRA letter about this new Claim Tax Benefits service.')}
 
   div
     form.cra-form(method='post')
-      +textInput('Personal access code', null, 'For Example: A5G98S4K1')(class='w-3-4', id='code' name='code', autofocus, value=data.code)
+      +textInput('Personal security code', null, 'For Example: A5G98S4K1')(class='w-3-4', id='code' name='code', autofocus, value=data.code)
 
       div
         details.
           <summary><span>#{__('Help with personal access code')}</span></summary>
-          <p>#{__('Your code is on the personally-addressed letter.')}</p>
+          <p>#{__('Your code has 9-characters and you can find it on the CRA letter about the Claim Tax Benefits service. The letter has your name and address at the top.')}</p>
 
       input#redirect(name='redirect', type='hidden', value='/login/sin')
 

--- a/views/login/code.pug
+++ b/views/login/code.pug
@@ -8,7 +8,9 @@ block content
   h1 #{title}
 
   div
-    <p>#{__('You can find your personal filing code in the CRA letter about this new')} <i>#{__('Claim Tax Benefits')} </i>#{__('service.')}</p>
+    p #{__('You can find your personal filing code in the CRA letter about this new ')}
+      i #{__('service.name')}
+      | #{__(' service.')}
 
   div
     form.cra-form(method='post')

--- a/views/login/code.pug
+++ b/views/login/code.pug
@@ -8,7 +8,7 @@ block content
   h1 #{title}
 
   div
-    p #{__('You can find your personal filing code in the CRA letter about this new Claim Tax Benefits service.')}
+    <p>#{__('You can find your personal filing code in the CRA letter about this new')} <i>#{__('Claim Tax Benefits')} </i>#{__('service.')}</p>
 
   div
     form.cra-form(method='post')

--- a/views/login/code.pug
+++ b/views/login/code.pug
@@ -1,22 +1,22 @@
 extends ../base
 
 block variables
-  -var title = __('Enter your personal security code')
+  -var title = __('Enter your personal filing code')
 
 block content
 
   h1 #{title}
 
   div
-    p #{__('You can find your personal security code in the CRA letter about this new Claim Tax Benefits service.')}
+    p #{__('You can find your personal filing code in the CRA letter about this new Claim Tax Benefits service.')}
 
   div
     form.cra-form(method='post')
-      +textInput('Personal security code', null, 'For Example: A5G98S4K1')(class='w-3-4', id='code' name='code', autofocus, value=data.code)
+      +textInput('Personal filing code', null, 'For Example: A5G98S4K1')(class='w-3-4', id='code' name='code', autofocus, value=data.code)
 
       div
         details.
-          <summary><span>#{__('Help with personal access code')}</span></summary>
+          <summary><span>#{__('Help with personal filing code')}</span></summary>
           <p>#{__('Your code has 9-characters and you can find it on the CRA letter about the Claim Tax Benefits service. The letter has your name and address at the top.')}</p>
 
       input#redirect(name='redirect', type='hidden', value='/login/sin')


### PR DESCRIPTION
## This PR consists of the following:

### 1) Content update to the `login/code` page based on [Issue 149](https://github.com/cds-snc/cra-claim-tax-benefits/issues/149)

| Before | After |
|--------|-------|
| <img width="1336" alt="Screen Shot 2019-09-24 at 10 35 54" src="https://user-images.githubusercontent.com/30609058/65521365-1ee1b280-deb7-11e9-8f16-9fc219afee50.png"> | <img width="1336" alt="Screen Shot 2019-09-24 at 10 35 46" src="https://user-images.githubusercontent.com/30609058/65521367-1ee1b280-deb7-11e9-8009-8a1724a9e9e0.png">  |

- content was swapped in from [Issue 149](https://github.com/cds-snc/cra-claim-tax-benefits/issues/149)

### 2) Test update
- Update to page heading broke page tests
- Test updated to reflect this