### PR TITLE
Content update to Date of Birth Page

### DIFF
--- a/views/login/dateOfBirth.pug
+++ b/views/login/dateOfBirth.pug
@@ -11,21 +11,13 @@ block content
 
   h1 #{title}
 
-  
-
-  div
-    p #{__('Thanks!')} #{__('We just need one more piece of information to authenticate you.')}
-
-    p #{__('Please enter your date of birth in the field below.')}
-
-
   div
     form.cra-form.cra-form--lg.cra-form--dob(method='post')
 
       div.dob-container(class={['has-error']: errors && errors.dobDay})
         fieldset.fieldset(role="group", aria-describedby="dobHint",)
           legend
-            h2 #{__('Your date of birth')}
+            h2 #{__('Date of birth')}
 
           span#dobHint.cra-form-message #{__('For Example:')} #{isoDateHintText(data.personal.dateOfBirth)}
 


### PR DESCRIPTION
## This PR consists of the following:

### 1) Content update to the `login/dateOfBirth` page based on [Issue 151](https://github.com/cds-snc/cra-claim-tax-benefits/issues/151)

| Before | After |
|--------|-------|
| ![Screen Shot 2019-09-25 at 13 09 54](https://user-images.githubusercontent.com/30609058/65623459-d220d900-df95-11e9-9d9f-60c854015667.png) | ![Screen Shot 2019-09-25 at 13 10 00](https://user-images.githubusercontent.com/30609058/65623457-d220d900-df95-11e9-93eb-4c708d69430d.png) |

- content was swapped in from [Issue 151](https://github.com/cds-snc/cra-claim-tax-benefits/issues/151)




