### PR TITLE
Update /personal/address content

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -314,7 +314,6 @@
   "letter.": "letter.",
   "Enter your province or territory": "Enter your province or territory",
   "On December 31, 2018, what was the province or territory of your home address?": "On December 31, 2018, what was the province or territory of your home address?",
-  "Province or territory": "Province or territory",
   "Province or territory of your home address": "Province or territory of your home address",
   "Check your income information for the 2018 tax year": "Check your income information for the 2018 tax year",
   "CRA has information about your 2018 income. Please check this information. Later you will be able to enter more information to claim credits and deduct costs.": "CRA has information about your 2018 income. Please check this information. Later you will be able to enter more information to claim credits and deduct costs.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -65,7 +65,6 @@
   "Thanks,": "Thanks,",
   "Social Insurance Number": "Social Insurance Number",
   "Error:": "Error:",
-  "Confirm your mailing address": "Confirm your mailing address",
   "Full name": "Full name",
   "Help with name confirmation": "Help with name confirmation",
   "If you have changed your name since the last time you filed your taxes,": "If you have changed your name since the last time you filed your taxes,",
@@ -79,7 +78,6 @@
   "Please choose the correct status from the options listed below.": "Please choose the correct status from the options listed below.",
   "Yes": "Yes",
   "No": "No",
-  "Please review the address details closely to make sure they’re correct. You can change your address to update our records—this is important for making sure you receive your benefits and tax refund (if applicable).": "Please review the address details closely to make sure they’re correct. You can change your address to update our records—this is important for making sure you receive your benefits and tax refund (if applicable).",
   "Mailing address": "Mailing address",
   "Change your mailing address": "Change your mailing address",
   "Please enter the correct mailing address information below. If a letter is sent to this address, you must be able to receive it.": "Please enter the correct mailing address information below. If a letter is sent to this address, you must be able to receive it.",
@@ -166,7 +164,6 @@
   "CPP deduction": "CPP deduction",
   "Total tax paid for 2018": "Total tax paid for 2018",
   "Is this information correct?": "Is this information correct?",
-  "If this information doesn’t match your records, you can’t change it here.": "If this information doesn’t match your records, you can’t change it here.",
   "You should not use this service to file income information you believe to be incorrect.": "You should not use this service to file income information you believe to be incorrect.",
   "Language Selection": "Language Selection",
   "Language selection: French": "Language selection: French",
@@ -254,7 +251,6 @@
   "Day": "Day",
   "Month": "Month",
   "Year": "Year",
-  "You should not use this service to file information you believe to be incorrect.": "You should not use this service to file information you believe to be incorrect.",
   "enter the amount you paid in rent in 2018.": "enter the amount you paid in rent in 2018.",
   "Please note you may be asked to provide receipts to verify this information later.": "Please note you may be asked to provide receipts to verify this information later.",
   "Rent paid in 2018": "Rent paid in 2018",
@@ -322,5 +318,7 @@
   "Province or territory of your home address": "Province or territory of your home address",
   "Check your income information for the 2018 tax year": "Check your income information for the 2018 tax year",
   "CRA has information about your 2018 income. Please check this information. Later you will be able to enter more information to claim credits and deduct costs.": "CRA has information about your 2018 income. Please check this information. Later you will be able to enter more information to claim credits and deduct costs.",
-  "Is all of this information correct?": "Is all of this information correct?"
+  "Is all of this information correct?": "Is all of this information correct?",
+  "Check your mailing address": "Check your mailing address",
+  "Is this your correct address?": "Is this your correct address?"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -77,7 +77,6 @@
   "Marital Status": "État matrimonial",
   "Change your marital status": "Modifier votre état matrimonial",
   "Please choose the correct status from the options listed below.": "Veuillez choisir le bon état matrimonial parmi les options qui suivent.",
-  "Confirm your mailing address": "Confirmez votre adresse postale",
   "Change your mailing address": "Modifier votre adresse postale",
   "Please enter the correct mailing address information below. If a letter is sent to this address, you must be able to receive it.": "Veuillez inscrire l’adresse postale exacte ci-dessous. Vous devez être capable de recevoir une lettre envoyée à cette adresse.",
   "Mailing address": "Adresse postale",
@@ -222,7 +221,6 @@
   "I confirm that, as far as I know, all the information in this tax return is accurate": "Je confirme que, à ma connaissance, tous les renseignements contenus dans cette déclaration de revenus sont exacts.",
   "Ontario Trillium Benefit": "Prestation Trillium de l’Ontario",
   "Please enter the total amount paid for accommodation in a public or non-profit long-term care home in 2018.": "Veuillez inscrire le montant total payé pour un hébergement dans un foyer de soins de longue durée public ou sans but lucratif en 2018.",
-  "Please review the address details closely to make sure they’re correct. You can change your address to update our records—this is important for making sure you receive your benefits and tax refund (if applicable).": "Veuillez examiner attentivement votre adresse postale pour vous assurer qu’elle est correcte. Vous pouvez modifier votre adresse postale pour mettre à jour nos dossiers. Il est important que cette adresse soit à jour pour que vous puissiez recevoir vos prestations et votre remboursement (le cas échéant).",
   "Visit a free tax clinic near you. ": "Vous rendre à une clinique d’impôts gratuits. ",
   "You can have a volunteer help you submit your taxes.": "Vous pourrez obtenir l’aide d’une personne bénévole pour produire votre déclaration.",
   "File your taxes with": "Produire une déclaration de revenus ",
@@ -292,5 +290,7 @@
   "Province or territory of your home address": "Province or territory of your home address",
   "Check your income information for the 2018 tax year": "Check your income information for the 2018 tax year",
   "CRA has information about your 2018 income. Please check this information. Later you will be able to enter more information to claim credits and deduct costs.": "CRA has information about your 2018 income. Please check this information. Later you will be able to enter more information to claim credits and deduct costs.",
-  "Is all of this information correct?": "Is all of this information correct?"
+  "Is all of this information correct?": "Is all of this information correct?",
+  "Check your mailing address": "Check your mailing address",
+  "Is this your correct address?": "Is this your correct address?"
 }

--- a/views/personal/address.pug
+++ b/views/personal/address.pug
@@ -2,16 +2,11 @@ extends ../base
 include ../_includes/yesNoRadios
 
 block variables
-  -var title = __('Confirm your mailing address')
+  -var title = __('Check your mailing address')
 
 block content
 
   h1 #{title}
-
-  
-
-  div
-    p #{__('Please review the address details closely to make sure they’re correct. You can change your address to update our records—this is important for making sure you receive your benefits and tax refund (if applicable).')}
 
   div
     table.pure-table
@@ -30,11 +25,7 @@ block content
               div #{data.personal.address.postalCode}
   
   form.cra-form(method='post')
-    +yesNoRadios('confirmAddress', null, 'Is this information correct?', errors)
-      .no-info#noInfo
-        .no-info__wrapper
-          p #{__('If this information doesn’t match your records, you can’t change it here.')}
-          p #{__('You should not use this service to file information you believe to be incorrect.')}
+    +yesNoRadios('confirmAddress', null, 'Is this your correct address?', errors)
 
     input#redirect(name='redirect', type='hidden', value='/financial/income')
 


### PR DESCRIPTION
## This PR consists of the following:

### 1) Content update to the `/personal/address` page based on [Issue 154](https://github.com/cds-snc/cra-claim-tax-benefits/issues/154)

| Before | After |
|--------|-------|
| <img width="1353" alt="Screen Shot 2019-09-26 at 15 42 21" src="https://user-images.githubusercontent.com/30609058/65719696-55186100-e074-11e9-9afe-8b4c3d8fa4a4.png"> | <img width="1353" alt="Screen Shot 2019-09-26 at 15 41 45" src="https://user-images.githubusercontent.com/30609058/65719697-55186100-e074-11e9-9659-97157cf7b0ec.png"> |

- content was swapped in from [Issue 154](https://github.com/cds-snc/cra-claim-tax-benefits/issues/154)