### PR TITLE
Update content on /financial/income

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -96,7 +96,6 @@
   "Deduct your RRSP contributions": "Deduct your RRSP contributions",
   "Did you contribute to an RRSP?": "Did you contribute to an RRSP?",
   "Children stub page": "Children stub page",
-  "Confirm your income information": "Confirm your income information",
   "Your taxes can’t be completed using this service": "Your taxes can’t be completed using this service",
   "Review your estimated benefits": "Review your estimated benefits",
   "Change Marital Status": "Change Marital Status",
@@ -155,7 +154,6 @@
   "Please enter your political contributions into the fields below.": "Please enter your political contributions into the fields below.",
   "Total federal contributions": "Total federal contributions",
   "Total provincial contributions": "Total provincial contributions",
-  "Here’s what CRA knows about your income for the current tax year (filing for 2018). Additional claims and deductions can be made afterwards.": "Here’s what CRA knows about your income for the current tax year (filing for 2018). Additional claims and deductions can be made afterwards.",
   "Total income earned in 2018": "Total income earned in 2018",
   "Detailed breakdown of income earned in 2018": "Detailed breakdown of income earned in 2018",
   "Employer 1 Total Income": "Employer 1 Total Income",
@@ -321,5 +319,8 @@
   "Enter your province or territory": "Enter your province or territory",
   "On December 31, 2018, what was the province or territory of your home address?": "On December 31, 2018, what was the province or territory of your home address?",
   "Province or territory": "Province or territory",
-  "Province or territory of your home address": "Province or territory of your home address"
+  "Province or territory of your home address": "Province or territory of your home address",
+  "Check your income information for the 2018 tax year": "Check your income information for the 2018 tax year",
+  "CRA has information about your 2018 income. Please check this information. Later you will be able to enter more information to claim credits and deduct costs.": "CRA has information about your 2018 income. Please check this information. Later you will be able to enter more information to claim credits and deduct costs.",
+  "Is all of this information correct?": "Is all of this information correct?"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -143,8 +143,6 @@
   "Saskatchewan": "Saskatchewan",
   "Yukon": "Yukon",
   "Non Resident": "Non-résident",
-  "Confirm your income information": "Confirmez les renseignements sur votre revenu",
-  "Here’s what CRA knows about your income for the current tax year (filing for 2018). Additional claims and deductions can be made afterwards.": "Voici ce que l’ARC connaît sur votre revenu pour l’année d’imposition courante (2018). Vous pourrez faire des réclamations et des demande de déductions additionnelles après votre confirmation.",
   "Total income earned in 2018": "Revenu total gagné en 2018",
   "Detailed breakdown of income earned in 2018": "Répartition détaillée du revenu gagné en 2018",
   "Employer 1 Total Income": "Employeur 1 Revenu total",
@@ -157,8 +155,6 @@
   "CPP deduction": "Déduction du RPC",
   "Total tax paid for 2018": "Total des impôts payés en 2018",
   "Is this information correct?": "Ces renseignements sont-ils exacts?",
-  "If this information doesn’t match your records, you can’t change it here.": "Si ces renseignements ne correspondent à ceux de vos dossiers, vous ne pouvez pas les modifier ici.",
-  "You should not use this service to file income information you believe to be incorrect.": "Vous ne devriez pas utiliser ce service pour déclarer un revenu qui vous paraît incorrect.",
   "Political contributions": "Contributions politiques",
   "Did you make any political contributions in 2018?": "Avez-vous fait des contributions politiques pendant l’année 2018?",
   "Deduct political contributions?": "Voulez-vous déduire vos contributions politiques?",
@@ -293,5 +289,8 @@
   "letter.": "letter.",
   "Enter your province or territory": "Enter your province or territory",
   "On December 31, 2018, what was the province or territory of your home address?": "On December 31, 2018, what was the province or territory of your home address?",
-  "Province or territory of your home address": "Province or territory of your home address"
+  "Province or territory of your home address": "Province or territory of your home address",
+  "Check your income information for the 2018 tax year": "Check your income information for the 2018 tax year",
+  "CRA has information about your 2018 income. Please check this information. Later you will be able to enter more information to claim credits and deduct costs.": "CRA has information about your 2018 income. Please check this information. Later you will be able to enter more information to claim credits and deduct costs.",
+  "Is all of this information correct?": "Is all of this information correct?"
 }

--- a/views/financial/income.pug
+++ b/views/financial/income.pug
@@ -2,7 +2,7 @@ extends ../base
 include ../_includes/yesNoRadios
 
 block variables
-  -var title = __('Confirm your income information')
+  -var title = __('Check your income information for the 2018 tax year')
   -var incomeSources = hasData(data, 'financial.incomeSources') ? data.financial.incomeSources : {}
   -var taxes = hasData(data, 'financial.taxes') ? data.financial.taxes : {}
   -var totalIncome = hasData(data, 'financial.incomes.totalIncome') ? data.financial.incomes.totalIncome : 0
@@ -16,13 +16,13 @@ block content
   
 
   div
-    p #{__(`Here’s what CRA knows about your income for the current tax year (filing for ${year}). Additional claims and deductions can be made afterwards.`)}
+    p #{__(`CRA has information about your ${year} income. Please check this information. Later you will be able to enter more information to claim credits and deduct costs.`)}
 
   if incomeSources
     .breakdown-table
       h2.breakdown-table__heading
         span #{__(`Total income earned in ${year}`)} 
-        span $#{currencyFilter(totalIncome.amount, 0)}
+        span $#{currencyFilter(totalIncome.amount, 2)}
   
       p.breakdown-table__subheading #{__(`Detailed breakdown of income earned in ${year}`)}
 
@@ -39,7 +39,7 @@ block content
   .breakdown-table
       h2.breakdown-table__heading 
         span #{__('Total tax')}
-        span.breakdown-table__heading $#{currencyFilter(totalTax, 0)}
+        span.breakdown-table__heading $#{currencyFilter(totalTax, 2)}
 
       p.breakdown-table__subheading #{__(`Detailed breakdown of taxes paid in ${year}`)}
 
@@ -54,11 +54,7 @@ block content
           dd.breakdown-table__row-value $#{currencyFilter(totalTax)}
 
   form.cra-form(method='post')
-    +yesNoRadios('confirmIncome', null, 'Is this information correct?', errors)
-      .no-info#noInfo
-        .no-info__wrapper
-          p #{__('If this information doesn’t match your records, you can’t change it here.')}
-          p #{__('You should not use this service to file income information you believe to be incorrect.')}
+    +yesNoRadios('confirmIncome', null, 'Is all of this information correct?', errors)
 
     input#redirect(name='redirect', type='hidden', value='/deductions/rrsp')
 


### PR DESCRIPTION
## This PR consists of the following:

### 1) Content update to the `/financial/income` page based on [Issue 155](https://github.com/cds-snc/cra-claim-tax-benefits/issues/155)

| Before | After |
|--------|-------|
| <img width="1353" alt="Screen Shot 2019-09-26 at 16 47 35" src="https://user-images.githubusercontent.com/30609058/65723930-61ed8280-e07d-11e9-8f69-c8ff0355dde5.png">  | <img width="1353" alt="Screen Shot 2019-09-26 at 16 47 25" src="https://user-images.githubusercontent.com/30609058/65723932-61ed8280-e07d-11e9-836e-3b7938ac7d8a.png">|

- content was swapped in from [Issue 155](https://github.com/cds-snc/cra-claim-tax-benefits/issues/155)