### PR TITLE
Update to the trillium section

### DIFF
--- a/config/routes.config.js
+++ b/config/routes.config.js
@@ -26,6 +26,7 @@ const routes = [
   { path: '/deductions/political/amount', editInfo: 'deductions.politicalContributionClaim' },
   { path: '/deductions/donations' },
   { path: '/deductions/donations/amount', editInfo: 'deductions.charitableDonationAmount' },
+  { path: '/trillium/start' },
   { path: '/trillium/rent' },
   { path: '/trillium/rent/amount', editInfo: 'deductions.trilliumRentAmount' },
   { path: '/trillium/propertyTax' },

--- a/cypress/integration/full_run_simple.spec.js
+++ b/cypress/integration/full_run_simple.spec.js
@@ -188,7 +188,7 @@ describe('Full run through', function() {
   })
 
   it('navigates the Trillium Start page', function() {
-    //TRILLIUM RENT
+    //TRILLIUM START PAGE
     cy.url().should('contain', '/trillium/start')
     cy.get('h1').should('contain', 'The Ontario Trillium Benefit')
 

--- a/cypress/integration/full_run_simple.spec.js
+++ b/cypress/integration/full_run_simple.spec.js
@@ -187,10 +187,20 @@ describe('Full run through', function() {
       .click()
   })
 
+  it('navigates the Trillium Start page', function() {
+    //TRILLIUM RENT
+    cy.url().should('contain', '/trillium/start')
+    cy.get('h1').should('contain', 'The Ontario Trillium Benefit')
+
+    cy.get(`a[href="/trillium/rent"]`)
+      .should('contain', 'Continue')
+      .click()
+  })
+
   it('navigates the Trillium Rent page', function() {
     //TRILLIUM RENT
     cy.url().should('contain', '/trillium/rent')
-    cy.get('h1').should('contain', 'Deduct your rent payments')
+    cy.get('h1').should('contain', 'Apply for OTB: rent payments')
 
     cy.get('input#trilliumRentClaimNo + label').should('have.attr', 'for', 'trilliumRentClaimNo')
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -348,5 +348,7 @@
   "Marital Status": "Marital Status",
   "Did You Contribute to an RRSP?": "Did You Contribute to an RRSP?",
   "Enter your political contributions": "Enter your political contributions",
-  "Please note you may be asked to provide receipts to verify this information later.": "Please note you may be asked to provide receipts to verify this information later."
+  "Please note you may be asked to provide receipts to verify this information later.": "Please note you may be asked to provide receipts to verify this information later.",
+  "true": true,
+  "https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html": "https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -229,6 +229,9 @@
   "Month": "Month",
   "Year": "Year",
   "Rent paid in 2018": "Rent paid in 2018",
+  "Deduct your property tax": "Deduct your property tax",
+  "If you paid property tax in 2018, you may be entitled to receive credits from your": "If you paid property tax in 2018, you may be entitled to receive credits from your",
+  "Did you pay property tax in 2018?": "Did you pay property tax in 2018?",
   "Deduct your home energy costs on a reserve": "Deduct your home energy costs on a reserve",
   "If you lived on a reserve and had home energy costs in 2018, you may be entitled to receive credits from your": "If you lived on a reserve and had home energy costs in 2018, you may be entitled to receive credits from your",
   "Did you live on a reserve and have home energy costs 2018?": "Did you live on a reserve and have home energy costs 2018?",
@@ -328,5 +331,15 @@
   "How much total property tax did you pay for the place you lived most of 2018?": "How much total property tax did you pay for the place you lived most of 2018?",
   "Deduct your rent payments": "Deduct your rent payments",
   "If you paid rent in 2018, you may be entitled to receive more credits from your": "If you paid rent in 2018, you may be entitled to receive more credits from your",
-  "Did you pay rent in 2018?": "Did you pay rent in 2018?"
+  "Did you pay rent in 2018?": "Did you pay rent in 2018?",
+  "The Ontario Trillium Benefit": "The Ontario Trillium Benefit",
+  "The Ontario Trillium Benefit (OTB) is a government payment that helps with energy, sales and property taxes. You can learn about the OTB at https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html": "The Ontario Trillium Benefit (OTB) is a government payment that helps with energy, sales and property taxes. You can learn about the OTB at https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html",
+  "Apply for the OTB on the pages that follow.": "Apply for OTB on the pages that follow.",
+  "Confirm": "Confirm",
+  "The Ontario Trillium Benefit (OTB) is a government payment that helps with energy, sales and property taxes. You can learn about the OTB at": "The Ontario Trillium Benefit (OTB) is a government payment that helps with energy, sales and property taxes. You can learn about the OTB at",
+  "Apply for the OTB: rent payments": "Apply for OTB:rent payments",
+  "Did you pay rent for the place you lived most of 2018?": "Did you pay rent for the place you lived most of 2018?",
+  "Enter your rent payments to apply for OTB": "Enter your rent payments to apply for OTB",
+  "The government might ask for your rent receipts.": "The government might ask for your rent receipts.",
+  "How much total rent did you pay for the place you lived most of 2018?": "How much total rent did you pay for the place you lived most of 2018?"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -341,5 +341,12 @@
   "Did you pay rent for the place you lived most of 2018?": "Did you pay rent for the place you lived most of 2018?",
   "Enter your rent payments to apply for OTB": "Enter your rent payments to apply for OTB",
   "The government might ask for your rent receipts.": "The government might ask for your rent receipts.",
-  "How much total rent did you pay for the place you lived most of 2018?": "How much total rent did you pay for the place you lived most of 2018?"
+  "How much total rent did you pay for the place you lived most of 2018?": "How much total rent did you pay for the place you lived most of 2018?",
+  "Apply for OTB on the pages that follow.": "Apply for OTB on the pages that follow.",
+  "Apply for OTB: rent payments": "Apply for OTB: rent payments",
+  "Date of Birth": "Date of Birth",
+  "Marital Status": "Marital Status",
+  "Did You Contribute to an RRSP?": "Did You Contribute to an RRSP?",
+  "Enter your political contributions": "Enter your political contributions",
+  "Please note you may be asked to provide receipts to verify this information later.": "Please note you may be asked to provide receipts to verify this information later."
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -211,6 +211,9 @@
   "Day": "Jour",
   "Month": "Mois",
   "Year": "Année",
+  "Deduct your property tax": "Deduct your property tax",
+  "If you paid property tax in 2018, you may be entitled to receive credits from your": "If you paid property tax in 2018, you may be entitled to receive credits from your",
+  "Did you pay property tax in 2018?": "Did you pay property tax in 2018?",
   "Deduct your home energy costs on a reserve": "Deduct your home energy costs on a reserve",
   "If you lived on a reserve and had home energy costs in 2018, you may be entitled to receive credits from your": "If you lived on a reserve and had home energy costs in 2018, you may be entitled to receive credits from your",
   "Did you live on a reserve and have home energy costs 2018?": "Did you live on a reserve and have home energy costs 2018?",
@@ -298,5 +301,13 @@
   "Did you pay property tax for the place you lived most of 2018?": "Did you pay property tax for the place you lived most of 2018?",
   "Enter your property tax payments to apply for OTB": "Enter your property tax payments to apply for OTB",
   "The government might ask for your property tax receipts.": "The government might ask for your property tax receipts.",
-  "How much total property tax did you pay for the place you lived most of 2018?": "How much total property tax did you pay for the place you lived most of 2018?"
+  "How much total property tax did you pay for the place you lived most of 2018?": "How much total property tax did you pay for the place you lived most of 2018?",
+  "The Ontario Trillium Benefit": "The Ontario Trillium Benefit",
+  "The Ontario Trillium Benefit (OTB) is a government payment that helps with energy, sales and property taxes. You can learn about the OTB at": "The Ontario Trillium Benefit (OTB) is a government payment that helps with energy, sales and property taxes. You can learn about the OTB at",
+  "Apply for the OTB on the pages that follow.": "Apply for OTB on the pages that follow.",
+  "Apply for the OTB: rent payments": "Apply for OTB: rent payments",
+  "Did you pay rent for the place you lived most of 2018?": "Did you pay rent for the place you lived most of 2018?",
+  "Enter your rent payments to apply for OTB": "Enter your rent payments to apply for OTB",
+  "The government might ask for your rent receipts.": "The government might ask for your rent receipts.",
+  "How much total rent did you pay for the place you lived most of 2018?": "How much total rent did you pay for the place you lived most of 2018?"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -309,5 +309,7 @@
   "Did you pay rent for the place you lived most of 2018?": "Did you pay rent for the place you lived most of 2018?",
   "Enter your rent payments to apply for OTB": "Enter your rent payments to apply for OTB",
   "The government might ask for your rent receipts.": "The government might ask for your rent receipts.",
-  "How much total rent did you pay for the place you lived most of 2018?": "How much total rent did you pay for the place you lived most of 2018?"
+  "How much total rent did you pay for the place you lived most of 2018?": "How much total rent did you pay for the place you lived most of 2018?",
+  "https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html": "https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html",
+  "Apply for OTB on the pages that follow.": "Apply for OTB on the pages that follow."
 }

--- a/routes/deductions/deductions.controller.js
+++ b/routes/deductions/deductions.controller.js
@@ -119,6 +119,9 @@ module.exports = function(app) {
   //End of Charitable Donations Section
 
   //Start of Trillum Section
+
+  app.get('/trillium/start', renderWithData('deductions/trillium-start'))
+
   app.get('/trillium/rent', renderWithData('deductions/trillium-rent'))
   app.post(
     '/trillium/rent',

--- a/routes/deductions/deductions.spec.js
+++ b/routes/deductions/deductions.spec.js
@@ -67,6 +67,13 @@ describe('Test /deductions responses', () => {
     })
   })
 
+  describe('It returns a 200 response for /trillium/start', () => {
+    test('it returns a 200 response for the /trillium/start path', async () => {
+      const response = await request(app).get('/trillium/start')
+      expect(response.statusCode).toBe(200)
+    })
+  })
+
   describe('Test /deductions/* yesNo responses', () => {
     const yesNoResponses = [
       {

--- a/views/_includes/buttonMixin.pug
+++ b/views/_includes/buttonMixin.pug
@@ -5,9 +5,12 @@ mixin formButtons(submitButtonText = 'Continue', cancelUrl='/clear')
     .buttons--right
       a.transparent.full-width(href=cancelUrl role='button' draggable='false') #{__('Cancel')}
 
-mixin linkButtons(confirmURL)
+mixin linkButtons(confirmURL, continueButton)
   .buttons-row
-    a(href=confirmURL role='button' draggable='false') #{__('Confirm')}
+    if continueButton
+      a(href=confirmURL role='button' draggable='false') #{__('Continue')}
+    else
+      a(href=confirmURL role='button' draggable='false') #{__('Confirm')}
     if block
         block
     a.transparent(href='/clear' role='button' draggable='false') #{__('Cancel')}

--- a/views/_includes/buttonMixin.pug
+++ b/views/_includes/buttonMixin.pug
@@ -5,12 +5,9 @@ mixin formButtons(submitButtonText = 'Continue', cancelUrl='/clear')
     .buttons--right
       a.transparent.full-width(href=cancelUrl role='button' draggable='false') #{__('Cancel')}
 
-mixin linkButtons(confirmURL, continueButton)
+mixin linkButtons(confirmURL, linkButtonText = 'Confirm')
   .buttons-row
-    if continueButton
-      a(href=confirmURL role='button' draggable='false') #{__('Continue')}
-    else
-      a(href=confirmURL role='button' draggable='false') #{__('Confirm')}
+    a(href=confirmURL role='button' draggable='false') #{__(linkButtonText)}
     if block
         block
     a.transparent(href='/clear' role='button' draggable='false') #{__('Cancel')}

--- a/views/deductions/donations-amount.pug
+++ b/views/deductions/donations-amount.pug
@@ -11,6 +11,6 @@ block content
   form.cra-form(method='post')
     +textInput('Total donations to registered charities')(class='w-1-2 input-with-unit' name='donationsAmount' placeholder='0.00' aria-labelledby='donationsAmount__unit donationsAmount__label' value=donationsAmount)
 
-    input#redirect(name='redirect', type='hidden', value='/trillium/rent')
+    input#redirect(name='redirect', type='hidden', value='/trillium/start')
 
     +formButtons('Continue', '/deductions/donations')

--- a/views/deductions/donations.pug
+++ b/views/deductions/donations.pug
@@ -15,6 +15,6 @@ block content
   form.cra-form(method='post')
     +yesNoRadios('charitableDonationClaim', charitableDonationClaim, 'Do you have tax receipts for charitable donations?', errors)
 
-    input#redirect(name='redirect', type='hidden', value='/trillium/rent')
+    input#redirect(name='redirect', type='hidden', value='/trillium/start')
 
     +formButtons()

--- a/views/deductions/trillium-rent-amount.pug
+++ b/views/deductions/trillium-rent-amount.pug
@@ -1,7 +1,7 @@
 extends ../base
 
 block variables
-  -var title = __('Enter rent paid in 2018')
+  -var title = __('Enter your rent payments to apply for OTB')
   -var trilliumRentAmount = hasData(data, 'deductions.trilliumRentAmount') && data.deductions.trilliumRentAmount !== 0 ? data.deductions.trilliumRentAmount : ''
 
 block content
@@ -11,12 +11,10 @@ block content
   
 
   div
-    p #{__('To get the most out of your')} <strong>#{__('Ontario Trillium Benefit')}</strong>, #{__('enter the amount you paid in rent in 2018.')}
-
-    p #{__('Please note you may be asked to provide receipts to verify this information later.')}
+    p #{__('The government might ask for your rent receipts.')}
 
   form.cra-form(method='post')
-    +textInput('Total annual rent in 2018')(class='w-1-2 input-with-unit' name='trilliumRentAmount' placeholder='0.00' aria-labelledby='trilliumRentAmount__unit trilliumRentAmount__label' value=trilliumRentAmount)
+    +textInput('How much total rent did you pay for the place you lived most of 2018?')(class='w-1-2 input-with-unit' name='trilliumRentAmount' placeholder='0.00' aria-labelledby='trilliumRentAmount__unit trilliumRentAmount__label' value=trilliumRentAmount)
 
     input#redirect(name='redirect', type='hidden', value='/trillium/propertyTax')
 

--- a/views/deductions/trillium-rent.pug
+++ b/views/deductions/trillium-rent.pug
@@ -2,20 +2,15 @@ extends ../base
 include ../_includes/yesNoRadios
 
 block variables
-  -var title = __('Deduct your rent payments')
+  -var title = __('Apply for OTB:rent payments')
   -var trilliumRentClaim = !hasData(data, 'deductions.trilliumRentClaim') ? '' : data.deductions.trilliumRentClaim ? 'Yes' : 'No'
 
 block content
 
   h1 #{title}
 
-  
-
-  div
-    p #{__('If you paid rent in 2018, you may be entitled to receive more credits from your')} <strong>#{__('Ontario Trillium Benefit')}</strong>.
-
   form.cra-form(method='post')
-    +yesNoRadios('trilliumRentClaim', trilliumRentClaim, 'Did you pay rent in 2018?', errors)
+    +yesNoRadios('trilliumRentClaim', trilliumRentClaim, 'Did you pay rent for the place you lived most of 2018?', errors)
 
     input#redirect(name='redirect', type='hidden', value='/trillium/propertyTax')
 

--- a/views/deductions/trillium-rent.pug
+++ b/views/deductions/trillium-rent.pug
@@ -2,7 +2,7 @@ extends ../base
 include ../_includes/yesNoRadios
 
 block variables
-  -var title = __('Apply for OTB:rent payments')
+  -var title = __('Apply for OTB: rent payments')
   -var trilliumRentClaim = !hasData(data, 'deductions.trilliumRentClaim') ? '' : data.deductions.trilliumRentClaim ? 'Yes' : 'No'
 
 block content

--- a/views/deductions/trillium-start.pug
+++ b/views/deductions/trillium-start.pug
@@ -2,15 +2,14 @@ extends ../base
 
 block variables
   -var title = __('The Ontario Trillium Benefit')
-  -var trilliumRentClaim = !hasData(data, 'deductions.trilliumRentClaim') ? '' : data.deductions.trilliumRentClaim ? 'Yes' : 'No'
 
 block content
 
   h1 #{title}
 
   div
-    p #{__('The Ontario Trillium Benefit (OTB) is a government payment that helps with energy, sales and property taxes. You can learn about the OTB at')} <a href='https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html'>https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html</a>
+    p #{__('The Ontario Trillium Benefit (OTB) is a government payment that helps with energy, sales and property taxes. You can learn about the OTB at')} <a href=#{__('https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html')}>#{__('https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html')}</a>
 
     p #{__('Apply for OTB on the pages that follow.')}
 
-    +linkButtons('/trillium/rent', true)
+    +linkButtons('/trillium/rent', 'Continue')

--- a/views/deductions/trillium-start.pug
+++ b/views/deductions/trillium-start.pug
@@ -1,0 +1,16 @@
+extends ../base
+
+block variables
+  -var title = __('The Ontario Trillium Benefit')
+  -var trilliumRentClaim = !hasData(data, 'deductions.trilliumRentClaim') ? '' : data.deductions.trilliumRentClaim ? 'Yes' : 'No'
+
+block content
+
+  h1 #{title}
+
+  div
+    p #{__('The Ontario Trillium Benefit (OTB) is a government payment that helps with energy, sales and property taxes. You can learn about the OTB at')} <a href='https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html'>https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html</a>
+
+    p #{__('Apply for OTB on the pages that follow.')}
+
+    +linkButtons('/trillium/rent', true)


### PR DESCRIPTION
## This PR consists of the following:

### 1) `/trillium/start` page and route created based on [Issue 166](https://github.com/cds-snc/cra-claim-tax-benefits/issues/166)

### `/trillium/start` page

<img width="1361" alt="Screen Shot 2019-09-27 at 18 36 57" src="https://user-images.githubusercontent.com/30609058/65806025-ce3bb500-e155-11e9-91ed-9adea5316737.png">

### 2) Content update to the `/trillium/rent` and `/trillium/rent/amount` pages based on [Issue 166](https://github.com/cds-snc/cra-claim-tax-benefits/issues/166)

### `/trillium/rent` page

| Before | After |
|--------|-------|
|  <img width="1361" alt="Screen Shot 2019-09-27 at 18 32 30" src="https://user-images.githubusercontent.com/30609058/65805855-376ef880-e155-11e9-9d2d-7fb4247e646d.png"> | <img width="1361" alt="Screen Shot 2019-09-27 at 18 32 37" src="https://user-images.githubusercontent.com/30609058/65805853-376ef880-e155-11e9-8686-c4643955016a.png"> |

### `/trillium/rent/amount` page

| Before | After |
|--------|-------|
| <img width="1361" alt="Screen Shot 2019-09-27 at 18 33 30" src="https://user-images.githubusercontent.com/30609058/65805890-5c636b80-e155-11e9-8075-3de7ce3dbe60.png">| <img width="1361" alt="Screen Shot 2019-09-27 at 18 33 37" src="https://user-images.githubusercontent.com/30609058/65805889-5bcad500-e155-11e9-8423-a24a7e558fc0.png">  |

- content was swapped in from [Issue 166](https://github.com/cds-snc/cra-claim-tax-benefits/issues/166)