### PR TITLE
Feature/Add choose 2 addresses page to the security questions

### DIFF
--- a/config/routes.config.js
+++ b/config/routes.config.js
@@ -1,5 +1,9 @@
 // list the urls for security questions
-const securityQuestionUrls = ['/login/questions/child', '/login/questions/trillium']
+const securityQuestionUrls = [
+  '/login/questions/child',
+  '/login/questions/trillium',
+  '/login/questions/addresses',
+]
 
 //list our routes in the flow order in the app
 const routes = [

--- a/cypress/integration/full_run_simple.spec.js
+++ b/cypress/integration/full_run_simple.spec.js
@@ -214,7 +214,7 @@ describe('Full run through', function() {
   it('navigates the Trillium Property Tax page', function() {
     //TRILLIUM PROPERTY TAX
     cy.url().should('contain', '/trillium/propertyTax')
-    cy.get('h1').should('contain', 'Deduct your property tax')
+    cy.get('h1').should('contain', 'Apply for OTB: property tax')
 
     cy.get('input#trilliumPropertyTaxClaimNo + label').should(
       'have.attr',

--- a/locales/en.json
+++ b/locales/en.json
@@ -15,7 +15,7 @@
   "errors.login.dateOfBirth.validYear": "Please enter a year between 1900 and 2019",
   "errors.login.childLastName": "Please enter your child’s last name",
   "errors.login.paymentMethod": "Please choose how you receive your payments",
-  "errors.address.line1.empty": "Street address can’t be empty",
+  "errors.address.streetAddress.empty": "Street address can’t be empty",
   "errors.address.city.empty": "City can’t be empty",
   "errors.address.postalCode.empty": "Postal code can’t be empty",
   "errors.address.postalCode.format": "Postal code is incorrect format",
@@ -350,5 +350,11 @@
   "Enter your political contributions": "Enter your political contributions",
   "Please note you may be asked to provide receipts to verify this information later.": "Please note you may be asked to provide receipts to verify this information later.",
   "true": true,
-  "https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html": "https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html"
+  "https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html": "https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html",
+  "Apply for OTB: property tax": "Apply for OTB: property tax",
+  "Your last two mailing addresses before your current address": "Your last two mailing addresses before your current address",
+  "Enter the last two mailing addresses before your current address": "Enter the last two mailing addresses before your current address",
+  "You must have used both addresses to file taxes. Choose a different question if you haven’t filed taxes from at least two other addresses.": "You must have used both addresses to file taxes. Choose a different question if you haven’t filed taxes from at least two other addresses.",
+  "Mailing address 1": "Mailing address 1",
+  "Mailing address 2": "Mailing address 2"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -15,7 +15,7 @@
   "errors.login.dateOfBirth.validYear": "Veuillez inscrire une année valide",
   "errors.login.childLastName": "Please enter your child’s last name",
   "errors.login.paymentMethod": "Please choose how you receive your payments",
-  "errors.address.line1.empty": "Le nom de la rue doit être inscrit",
+  "errors.address.streetAddress.empty": "Le nom de la rue doit être inscrit",
   "errors.address.city.empty": "La ville doit être inscrite",
   "errors.address.postalCode.empty": "Le code postal doit être inscrit",
   "errors.address.postalCode.format": "Le format du code postal est incorrect",
@@ -310,6 +310,12 @@
   "Enter your rent payments to apply for OTB": "Enter your rent payments to apply for OTB",
   "The government might ask for your rent receipts.": "The government might ask for your rent receipts.",
   "How much total rent did you pay for the place you lived most of 2018?": "How much total rent did you pay for the place you lived most of 2018?",
-  "https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html": "https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html",
-  "Apply for OTB on the pages that follow.": "Apply for OTB on the pages that follow."
+  "https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html": "https://www.canada.ca/fr/agence-revenu/services/prestations-enfants-familles/programmes-provinciaux-territoriaux/questions-reponses-prestation-trillium-ontario.html",
+  "Apply for OTB on the pages that follow.": "Apply for OTB on the pages that follow.",
+  "Enter the last two mailing addresses before your current address": "Enter the last two mailing addresses before your current address",
+  "You must have used both addresses to file taxes. Choose a different question if you haven’t filed taxes from at least two other addresses.": "You must have used both addresses to file taxes. Choose a different question if you haven’t filed taxes from at least two other addresses.",
+  "Mailing address 1": "Mailing address 1",
+  "Street address": "Street address",
+  "Mailing address 2": "Mailing address 2",
+  "Your last two mailing addresses before your current address": "Your last two mailing addresses before your current address"
 }

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -29,23 +29,17 @@ form.cra-form {
       width: 20%;
     }
   }
-}
 
-form.cra-form.cra-form--lg {
-  @include sm {
-    width: 110%;
-    max-width: 800px;
-  }
-
-  fieldset legend,
-  div:not(.multiple-choice__item) > label {
-    font-size: 1em;
-  }
-}
-
-form.cra-form {
   > div:not(:last-of-type) {
     margin-bottom: $space-xl;
+  }
+
+  .group {
+    margin-bottom: $space-xxl !important;
+
+    > div:not(:last-of-type) {
+      margin-bottom: $space-md;
+    }
   }
 
   div *:last-child {
@@ -171,6 +165,18 @@ form.cra-form {
         margin-left: $space-xs;
       }
     }
+  }
+}
+
+form.cra-form.cra-form--lg {
+  @include sm {
+    width: 110%;
+    max-width: 800px;
+  }
+
+  fieldset legend,
+  div:not(.multiple-choice__item) > label {
+    font-size: 1em;
   }
 }
 

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -14,6 +14,7 @@ const {
   securityQuestionSchema,
   childSchema,
   trilliumAmountSchema,
+  addressesSchema,
 } = require('./../../schemas')
 const API = require('../../api')
 const { securityQuestionUrls } = require('../../config/routes.config')
@@ -41,6 +42,8 @@ module.exports = function(app) {
     postSecurityQuestion,
   )
 
+  app.get('/login/questions', (req, res) => res.redirect('/login/securityQuestion'))
+
   // Security questions
   app.get('/login/questions/child', renderWithData('login/questions/child'))
   app.post(
@@ -58,7 +61,13 @@ module.exports = function(app) {
     doRedirect,
   )
 
-  app.get('/login/questions', (req, res) => res.redirect('/login/securityQuestion'))
+  app.get('/login/questions/addresses', renderWithData('login/questions/addresses'))
+  app.post(
+    '/login/questions/addresses',
+    checkSchema(addressesSchema),
+    checkErrors('login/questions/addresses'),
+    doRedirect,
+  )
 }
 
 const postLoginCode = async (req, res, next) => {

--- a/schemas/login.schema.js
+++ b/schemas/login.schema.js
@@ -154,12 +154,82 @@ const trilliumAmountSchema = {
   },
 }
 
+const _isEmpty = errorMessage => {
+  return {
+    isEmpty: {
+      errorMessage,
+      negated: true,
+    },
+  }
+}
+
+const _customPostalCodeFormat = errorMessage => {
+  return {
+    custom: {
+      options: value => {
+        // Source: https://gist.github.com/nery/9118763
+        var postalCodeRegex = new RegExp(
+          /^\s*[a-ceghj-npr-tvxy]\d[a-ceghj-npr-tv-z][-(\s)]?\d[a-ceghj-npr-tv-z]\d\s*$/i,
+        )
+        return postalCodeRegex.test(value)
+      },
+      errorMessage,
+    },
+  }
+}
+
+const _isInProvinces = errorMessage => {
+  return {
+    isIn: {
+      errorMessage,
+      options: [
+        [
+          'Alberta',
+          'British Columbia',
+          'Manitoba',
+          'New Brunswick',
+          'Newfoundland And Labrador',
+          'Northwest Territories',
+          'Nova Scotia',
+          'Nunavut',
+          'Ontario',
+          'Prince Edward Island',
+          'Quebec',
+          'Saskatchewan',
+          'Yukon',
+        ],
+      ],
+    },
+  }
+}
+
+const addressesSchema = {
+  // fields for first address
+  firstStreetAddress: _isEmpty('errors.address.streetAddress.empty'),
+  firstCity: _isEmpty('errors.address.city.empty'),
+  firstPostalCode: {
+    ..._isEmpty('errors.address.postalCode.empty'),
+    ..._customPostalCodeFormat('errors.address.postalCode.format'),
+  },
+  firstProvince: _isInProvinces('errors.address.province'),
+
+  // fields for second address
+  secondStreetAddress: _isEmpty('errors.address.streetAddress.empty'),
+  secondCity: _isEmpty('errors.address.city.empty'),
+  secondPostalCode: {
+    ..._isEmpty('errors.address.postalCode.empty'),
+    ..._customPostalCodeFormat('errors.address.postalCode.format'),
+  },
+  secondProvince: _isInProvinces('errors.address.province'),
+}
+
 module.exports = {
   loginSchema,
   dobSchema,
   sinSchema,
   childSchema,
   trilliumAmountSchema,
+  addressesSchema,
   securityQuestionSchema,
   lastDayInMonth,
   toISOFormat,

--- a/views/login/questions/addresses.pug
+++ b/views/login/questions/addresses.pug
@@ -1,0 +1,92 @@
+extends ../../base
+
+block variables
+  -var title = __('Enter the last two mailing addresses before your current address')
+  -var firstAptNumber = hasData(body, 'firstAptNumber') ? body.firstAptNumber : ''
+  -var firstStreetAddress = hasData(body, 'firstStreetAddress') ? body.firstStreetAddress : ''
+  -var firstCity = hasData(body, 'firstCity') ? body.firstCity : ''
+  -var firstPostalCode = hasData(body, 'firstPostalCode') ? body.firstPostalCode : ''
+  -var firstProvince = hasData(body, 'firstProvince') ? body.firstProvince : ''
+  -var secondAptNumber = hasData(body, 'secondAptNumber') ? body.secondAptNumber : ''
+  -var secondStreetAddress = hasData(body, 'secondStreetAddress') ? body.secondStreetAddress : ''
+  -var secondCity = hasData(body, 'secondCity') ? body.secondCity : ''
+  -var secondPostalCode = hasData(body, 'secondPostalCode') ? body.secondPostalCode : ''
+  -var secondProvince = hasData(body, 'secondProvince') ? body.secondProvince : ''
+
+
+block content
+
+  h1 #{title}
+
+  div
+    p #{__('You must have used both addresses to file taxes. Choose a different question if you haven’t filed taxes from at least two other addresses.')}
+
+  div
+    form.cra-form.cra-form--lg(method='post')
+      .group
+        h2 #{__('Mailing address 1')}
+
+        +textInput('Street address', ['w-3-4','d--ib'])(class='w-3-4' name='firstStreetAddress' value=firstStreetAddress)
+
+        +textInput('Apartment number', 'w-1-2', 'Optional')(class='w-3-4' name='firstAptNumber' value=firstAptNumber )
+
+        +textInput('City', 'w-1-2')(class='w-3-4' value=firstCity name='firstCity')
+
+        +textInput('Postal Code', ['w-1-2'], 'For Example: K2R 3Z9')(class='w-3-4' name='firstPostalCode' value=firstPostalCode)
+
+        .w-1-2(class={['has-error']: errors && errors.firstProvince})
+          label(for='firstProvince') #{__('Province')}
+          if errors && errors.firstProvince
+            +validationMessage(errors.firstProvince.msg, 'firstProvince')
+          select.w-3-4#firstProvince(name='firstProvince' aria-describedby=(errors && errors.firstProvince ? 'firstProvince-error' : false))
+            if !firstProvince
+              option(disabled='', selected='selected', value='')  -- select a province --
+            option(value='Alberta' selected=firstProvince == 'Alberta') #{__('Alberta')}
+            option(value='British Columbia' selected=firstProvince == 'British Columbia') #{__('British Columbia')}
+            option(value='Manitoba' selected=firstProvince == 'Manitoba') #{__('Manitoba')}
+            option(value='New Brunswick' selected=firstProvince == 'New Brunswick') #{__('New Brunswick')}
+            option(value='Newfoundland And Labrador' selected=firstProvince =='Newfoundland And Labrador') #{__('Newfoundland and Labrador')}
+            option(value='Northwest Territories' selected=firstProvince =='Northwest Territories') #{__('Northwest Territories')}
+            option(value='Nova Scotia' selected=firstProvince =='Nova Scotia') #{__('Nova Scotia')}
+            option(value='Nunavut' selected=firstProvince =='Nunavut') #{__('Nunavut')}
+            option(value='Ontario' selected=firstProvince == 'Ontario') #{__('Ontario')}
+            option(value='Prince Edward Island' selected=firstProvince =='Prince Edward Island') #{__('Prince Edward Island')}
+            option(value='Quebec'  selected=firstProvince =='Quebec') #{__('Quebec')}
+            option(value='Saskatchewan' selected=firstProvince =='Saskatchewan') #{__('Saskatchewan')}
+            option(value='Yukon' selected=firstProvince =='Yukon') #{__('Yukon')}
+
+      .group
+        h2 #{__('Mailing address 2')}
+
+        +textInput('Street address', ['w-3-4','d--ib'])(class='w-3-4' name='secondStreetAddress' value=secondStreetAddress)
+
+        +textInput('Apartment number', 'w-1-2', 'Optional')(class='w-3-4' name='secondAptNumber' value=secondAptNumber)
+
+        +textInput('City', 'w-1-2')(class='w-3-4' name='secondCity' value=secondCity)
+
+        +textInput('Postal Code', ['w-1-2'], 'For Example: K2R 3Z9')(class='w-3-4' name='secondPostalCode' value=secondPostalCode)
+
+        .w-1-2(class={['has-error']: errors && errors.secondProvince})
+          label(for='secondProvince') #{__('Province')}
+          if errors && errors.secondProvince
+            +validationMessage(errors.secondProvince.msg, 'secondProvince')
+          select.w-3-4#secondProvince(name='secondProvince' aria-describedby=(errors && errors.secondProvince ? 'secondProvince-error' : false))
+            if !secondProvince
+              option(disabled='', selected='selected', value='')  -- select a province --
+            option(value='Alberta' selected=secondProvince == 'Alberta') #{__('Alberta')}
+            option(value='British Columbia' selected=secondProvince == 'British Columbia') #{__('British Columbia')}
+            option(value='Manitoba' selected=secondProvince == 'Manitoba') #{__('Manitoba')}
+            option(value='New Brunswick' selected=secondProvince == 'New Brunswick') #{__('New Brunswick')}
+            option(value='Newfoundland And Labrador' selected=secondProvince =='Newfoundland And Labrador') #{__('Newfoundland and Labrador')}
+            option(value='Northwest Territories' selected=secondProvince =='Northwest Territories') #{__('Northwest Territories')}
+            option(value='Nova Scotia' selected=secondProvince =='Nova Scotia') #{__('Nova Scotia')}
+            option(value='Nunavut' selected=secondProvince =='Nunavut') #{__('Nunavut')}
+            option(value='Ontario' selected=secondProvince == 'Ontario') #{__('Ontario')}
+            option(value='Prince Edward Island' selected=secondProvince =='Prince Edward Island') #{__('Prince Edward Island')}
+            option(value='Quebec'  selected=secondProvince =='Quebec') #{__('Quebec')}
+            option(value='Saskatchewan' selected=secondProvince =='Saskatchewan') #{__('Saskatchewan')}
+            option(value='Yukon' selected=secondProvince =='Yukon') #{__('Yukon')}
+
+      input#redirect(name='redirect', type='hidden', value='/personal/name')
+
+      +formButtons()

--- a/views/login/securityQuestion.pug
+++ b/views/login/securityQuestion.pug
@@ -22,8 +22,11 @@ block content
                   input(id="securityQuestion0" name="securityQuestion" type="radio" value="/login/questions/child" aria-describedby=(errors ? 'securityQuestion-error' : false) checked=(securityQuestion && securityQuestion === '/login/questions/child'))
                   label(for="securityQuestion0") #{__('Your child’s name and birthdate')}
               .multiple-choice__item
-                  input(id="securityQuestion1" name="securityQuestion" type="radio" value="/login/questions/trillium" aria-describedby=(errors ? 'securityQuestion-error' : false) checked=(securityQuestion && securityQuestion === '/login/questions/trillium'))
-                  label(for="securityQuestion1") #{__('Your Ontario Trillium Benefit amount and payment type')}
+                  input(id="securityQuestion1" name="securityQuestion" type="radio" value="/login/questions/addresses" aria-describedby=(errors ? 'securityQuestion-error' : false) checked=(securityQuestion && securityQuestion === '/login/questions/addresses'))
+                  label(for="securityQuestion1") #{__('Your last two mailing addresses before your current address')}
+              .multiple-choice__item
+                  input(id="securityQuestion2" name="securityQuestion" type="radio" value="/login/questions/trillium" aria-describedby=(errors ? 'securityQuestion-error' : false) checked=(securityQuestion && securityQuestion === '/login/questions/trillium'))
+                  label(for="securityQuestion2") #{__('Your Ontario Trillium Benefit amount and payment type')}
 
     div
       details.


### PR DESCRIPTION
This pull request adds the address question to the security questions in the app.

We need to ask if you have 2 past addresses, and that kind of sucks, but whatever.

It's not pretty but it works. 

Most of this was pulled straight in from the old "edit address" page we used to have: https://github.com/cds-snc/cra-claim-tax-benefits/pull/30

## Screenshots

![q](https://user-images.githubusercontent.com/2454380/65997533-8ffd0900-e467-11e9-8701-4a3df5722b68.gif)
