### PR TITLE
Feature/Add second page of security questions

### DIFF
--- a/config/routes.config.js
+++ b/config/routes.config.js
@@ -5,6 +5,8 @@ const securityQuestionUrls = [
   '/login/questions/prison',
   '/login/questions/bankruptcy',
   '/login/questions/trillium',
+  // TODO: remove this
+  '/login/questions/temp',
 ]
 
 //list our routes in the flow order in the app
@@ -15,6 +17,7 @@ const routes = [
   { path: '/login/sin' },
   { path: '/login/dateOfBirth' },
   { path: '/login/securityQuestion' },
+  { path: '/login/questions', options: ['/login/securityQuestion2'] },
   { path: '/login/questions', options: securityQuestionUrls },
   { path: '/personal/name' },
   { path: '/offramp/name', editInfo: 'skip' },

--- a/locales/en.json
+++ b/locales/en.json
@@ -310,7 +310,6 @@
   "Do you have tax receipts for charitable donations?": "Do you have tax receipts for charitable donations?",
   "Total donations to registered charities": "Total donations to registered charities",
   "Choose a security question": "Choose a security question",
-  "Answer a question from the list below:": "Answer a question from the list below:",
   "Select 1 question to answer from the list below": "Select 1 question to answer from the list below",
   "Your child’s name and birthdate": "Your child’s name and birthdate",
   "Your Ontario Trillium Benefit amount and payment type": "Your Ontario Trillium Benefit amount and payment type",
@@ -369,5 +368,13 @@
   "Entry to prison": "Entry to prison",
   "Release from prison": "Release from prison",
   "Give the date": "Give the date",
-  "Your date of entry or release from prison": "Your date of entry or release from prison"
+  "Your date of entry or release from prison": "Your date of entry or release from prison",
+  "Your bank or credit union account information": "Your bank or credit union account information",
+  "Details of your contribution to a Registered Retirement Savings Plan (RRSP)": "Details of your contribution to a Registered Retirement Savings Plan (RRSP)",
+  "Details of your contribution to a Tax Free Savings Account (TFSA)": "Details of your contribution to a Tax Free Savings Account (TFSA)",
+  "Details of your Canada Child Benefit (CCB)": "Details of your Canada Child Benefit (CCB)",
+  "Date and amount of your most recent payment to CRA": "Date and amount of your most recent payment to CRA",
+  "If you can’t answer these questions, yer done boi.": "If you can’t answer these questions, yer done boi.",
+  "I can’t answer these questions either": "I can’t answer these questions either",
+  "Answer a question from the list below": "Answer a question from the list below"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -330,5 +330,7 @@
   "Which date do you want to give?": "Which date do you want to give?",
   "Entry to prison": "Entry to prison",
   "Release from prison": "Release from prison",
-  "Give the date": "Give the date"
+  "Give the date": "Give the date",
+  "Your bank or credit union account information": "Your bank or credit union account information",
+  "If you can’t answer these questions, yer done boi.": "If you can’t answer these questions, yer done boi."
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -294,7 +294,6 @@
   "Direct deposit": "Direct deposit",
   "How much did you get each month from your Ontario Trillium Benefit?": "How much did you get each month from your Ontario Trillium Benefit?",
   "Choose a security question": "Choose a security question",
-  "Answer a question from the list below:": "Answer a question from the list below:",
   "Select 1 question to answer from the list below": "Select 1 question to answer from the list below",
   "Your child’s name and birthdate": "Your child’s name and birthdate",
   "Your Ontario Trillium Benefit amount and payment type": "Your Ontario Trillium Benefit amount and payment type",
@@ -332,5 +331,11 @@
   "Release from prison": "Release from prison",
   "Give the date": "Give the date",
   "Your bank or credit union account information": "Your bank or credit union account information",
-  "If you can’t answer these questions, yer done boi.": "If you can’t answer these questions, yer done boi."
+  "If you can’t answer these questions, yer done boi.": "If you can’t answer these questions, yer done boi.",
+  "Details of your contribution to a Registered Retirement Savings Plan (RRSP)": "Details of your contribution to a Registered Retirement Savings Plan (RRSP)",
+  "Details of your contribution to a Tax Free Savings Account (TFSA)": "Details of your contribution to a Tax Free Savings Account (TFSA)",
+  "Details of your Canada Child Benefit (CCB)": "Details of your Canada Child Benefit (CCB)",
+  "Date and amount of your most recent payment to CRA": "Date and amount of your most recent payment to CRA",
+  "I can’t answer these questions either": "I can’t answer these questions either",
+  "Answer a question from the list below": "Answer a question from the list below"
 }

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -44,6 +44,15 @@ module.exports = function(app) {
     postSecurityQuestion,
   )
 
+  // Alternate security question page
+  app.get('/login/securityQuestion2', renderWithData('login/securityQuestion2'))
+  app.post(
+    '/login/securityQuestion2',
+    checkSchema(securityQuestionSchema),
+    checkErrors('login/securityQuestion2'),
+    postSecurityQuestion,
+  )
+
   app.get('/login/questions', (req, res) => res.redirect('/login/securityQuestion'))
 
   // Security questions

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -572,22 +572,26 @@ questionsAmounts.map(amountResponse => {
   })
 })
 
-describe('Test /login/securityQuestion responses', () => {
-  test('it returns a 422 response when posting a bad value', async () => {
-    const response = await request(app)
-      .post('/login/securityQuestion')
-      .send({ securityQuestion: '/login/question/who-let-the-dogs-out' })
-    expect(response.statusCode).toBe(422)
-  })
+describe('Test securityQuestion responses', () => {
+  const securityQuestionPages = ['/login/securityQuestion', '/login/securityQuestion2']
 
-  const securityQuestionUrls = ['/login/questions/child', '/login/questions/trillium']
-  securityQuestionUrls.map(url => {
-    test(`it returns a 302 response when posting a good value: ${url}`, async () => {
+  securityQuestionPages.map(securityQuestionPage => {
+    test('it returns a 422 response when posting a bad value', async () => {
       const response = await request(app)
-        .post('/login/securityQuestion')
-        .send({ securityQuestion: url })
-      expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toEqual(url)
+        .post(securityQuestionPage)
+        .send({ securityQuestion: '/login/question/who-let-the-dogs-out' })
+      expect(response.statusCode).toBe(422)
+    })
+
+    const securityQuestionUrls = ['/login/questions/child', '/login/questions/trillium']
+    securityQuestionUrls.map(url => {
+      test(`it returns a 302 response when posting a good value: ${url}`, async () => {
+        const response = await request(app)
+          .post(securityQuestionPage)
+          .send({ securityQuestion: url })
+        expect(response.statusCode).toBe(302)
+        expect(response.headers.location).toEqual(url)
+      })
     })
   })
 })

--- a/views/login/securityQuestion.pug
+++ b/views/login/securityQuestion.pug
@@ -8,11 +8,8 @@ block content
 
   h1 #{title}
 
-  div
-    p #{__('Answer a question from the list below:')}
-
   form.cra-form.cra-form--lg(method='post')
-    +radios('securityQuestion', 'Select 1 question to answer from the list below', securityQuestion,[
+    +radios('securityQuestion', 'Answer a question from the list below', securityQuestion,[
       {value: "/login/questions/child", label: "Your child’s name and birthdate"},
       {value: "/login/questions/addresses", label: "Your last two mailing addresses before your current address"},
       {value: "/login/questions/prison", label: "Your date of entry or release from prison"},
@@ -21,8 +18,7 @@ block content
     ])
 
     div
-      details.
-        <summary><span>#{__('I can’t answer these questions')}</span></summary>
-        <p>#{__('If you can’t answer these questions, continue to the next page for different questions.')}</p>
+      p
+        a(href="/login/securityQuestion2") #{__('I can’t answer these questions')}
 
     +formButtons()

--- a/views/login/securityQuestion2.pug
+++ b/views/login/securityQuestion2.pug
@@ -9,7 +9,7 @@ block content
   h1 #{title}
 
   form.cra-form.cra-form--lg(method='post')
-    +radios('securityQuestion', 'Answer a question from the list below:', securityQuestion,[
+    +radios('securityQuestion', 'Answer a question from the list below', securityQuestion,[
       {value: "/login/questions/temp", label: "Your bank or credit union account information"},
       {value: "/login/questions/temp", label: "Details of your contribution to a Registered Retirement Savings Plan (RRSP)"},
       {value: "/login/questions/temp", label: "Details of your contribution to a Tax Free Savings Account (TFSA)"},
@@ -19,8 +19,7 @@ block content
     ])
 
     div
-      details.
-        <summary><span>#{__('I can’t answer these questions')}</span></summary>
-        <p>#{__('If you can’t answer these questions, yer done boi.')}</p>
+      p
+        a(href="/offramp") #{__('I can’t answer these questions either')}
 
     +formButtons()

--- a/views/login/securityQuestion2.pug
+++ b/views/login/securityQuestion2.pug
@@ -1,0 +1,26 @@
+extends ../base
+
+block variables
+  -var title = __('Choose a security question')
+  -var securityQuestion = hasData(data, 'login.securityQuestion') ? data.login.securityQuestion : ''
+
+block content
+
+  h1 #{title}
+
+  form.cra-form.cra-form--lg(method='post')
+    +radios('securityQuestion', 'Answer a question from the list below:', securityQuestion,[
+      {value: "/login/questions/temp", label: "Your bank or credit union account information"},
+      {value: "/login/questions/temp", label: "Details of your contribution to a Registered Retirement Savings Plan (RRSP)"},
+      {value: "/login/questions/temp", label: "Details of your contribution to a Tax Free Savings Account (TFSA)"},
+      {value: "/login/questions/temp", label: "Details of your Canada Child Benefit (CCB)"},
+      {value: "/login/questions/temp", label: "Date and amount of your most recent payment to CRA"},
+      {value: "/login/questions/trillium", label: "Your Ontario Trillium Benefit amount and payment type"}
+    ])
+
+    div
+      details.
+        <summary><span>#{__('I can’t answer these questions')}</span></summary>
+        <p>#{__('If you can’t answer these questions, yer done boi.')}</p>
+
+    +formButtons()


### PR DESCRIPTION
If users can't answer the first page of questions, we will show them a second set of questions.

We need to be able to link to the second set of questions, so adding the link on the page. If they can't answer those either, we will point them towards an offramp page, currently the default offramp page.

New questions point to a `/login/questions/temp` url which is currently a 404 error.

## Screenshot

<img width="1469" alt="Screen Shot 2019-10-02 at 3 46 25 PM" src="https://user-images.githubusercontent.com/2454380/66076448-d1ef8300-e52b-11e9-9dbb-99b9041cc36e.png">
