### PR TITLE
Add body trimmer to all form requests

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ const globalError = require('http-errors')
 // import node modules.
 const express = require('express'),
   cookieParser = require('cookie-parser'),
+  trimRequest = require('trim-request'),
   compression = require('compression'),
   helmet = require('helmet'),
   morgan = require('morgan'),
@@ -71,6 +72,7 @@ app.use(helmet.contentSecurityPolicy({ directives: csp }))
 
 // gzip response body compression.
 app.use(compression())
+app.use(trimRequest.all)
 
 app.use(checkPublic)
 app.use(checkLangQuery)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9853,6 +9853,11 @@
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
     },
+    "trim-request": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/trim-request/-/trim-request-1.0.6.tgz",
+      "integrity": "sha1-Za5alOrB1w0AYOQP1xtdnjZaslQ="
+    },
     "triple-beam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "pug": "^2.0.4",
     "purecss": "^1.0.1",
     "request-promise": "^4.2.4",
+    "trim-request": "^1.0.6",
     "validator": "^11.1.0",
     "winston": "^3.2.1"
   },

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -323,6 +323,18 @@ describe('Test /login responses', () => {
           .send(goodDoBRequest)
         expect(response.statusCode).toBe(302)
       })
+
+      test('it returns a 302 with valid dob even with whitespace included', async () => {
+        const response = await request(app)
+          .post('/login/dateOfBirth')
+          .send({
+            dobDay: ' 9 ',
+            dobMonth: ' 9 ',
+            dobYear: ' 1977 ',
+            redirect: '/login/success',
+          })
+        expect(response.statusCode).toBe(302)
+      })
     })
 
     describe('for /login/questions/child', () => {
@@ -696,7 +708,7 @@ describe('Test /login/questions/addresses responses', () => {
     })
   })
 
-  test('it returns a 302 for a good request cheese', async () => {
+  test('it returns a 302 for a good request', async () => {
     const response = await request(app)
       .post('/login/questions/addresses')
       .send(goodRequest)


### PR DESCRIPTION
We pretty much never want whitespace in form requests, so we should trim all inputs by default.

Heard about this happening in usability testing so let's make this change.

Previously, this would fail:

- day: `' 9 '`
- month: `' 9 '`
- year: `' 1977 '`

Now it works.

Added a unit test to confirm behaviour.