### PR TITLE
Content update on /trillium /longTermCare/amount

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -182,7 +182,6 @@
   "Total Credits (482)": "Total Credits (482)",
   "Total Refund (484)": "Total Refund (484)",
   "I confirm that, as far as I know, all the information in this tax return is accurate": "I confirm that, as far as I know, all the information in this tax return is accurate",
-  "Please enter the total amount paid for accommodation in a public or non-profit long-term care home in 2018.": "Please enter the total amount paid for accommodation in a public or non-profit long-term care home in 2018.",
   "Ontario Trillium Benefit": "Ontario Trillium Benefit",
   "you paid for your main residence (including a private long-term care home) in 2018.": "you paid for your main residence (including a private long-term care home) in 2018.",
   "Visit a free tax clinic near you. ": "Visit a free tax clinic near you. ",
@@ -421,5 +420,8 @@
   "What were your total home energy costs on reserve in 2018?": "What were your total home energy costs on reserve in 2018?",
   "You may live in a long-term care home or facility if costs such as nursing or personal support are combined with your rent. The home must be public or non-profit. This means that a charity, city, First Nations, or similar organization manages the home.": "You may live in a long-term care home or facility if costs such as nursing or personal support are combined with your rent. The home must be public or non-profit. This means that a charity, city, First Nations, or similar organization manages the home.",
   "Public long-term care home costs": "Public long-term care home costs",
-  "Did you live in a public or non-profit long-term care home in 2018?": "Did you live in a public or non-profit long-term care home in 2018?"
+  "Did you live in a public or non-profit long-term care home in 2018?": "Did you live in a public or non-profit long-term care home in 2018?",
+  "The government might ask for your long-term care receipts.": "The government might ask for your long-term care receipts.",
+  "How much were your total long-term care costs in 2018?": "How much were your total long-term care costs in 2018?",
+  "Please note you may be asked to provide receipts to verify this information later.": "Please note you may be asked to provide receipts to verify this information later."
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -423,5 +423,6 @@
   "Did you live in a public or non-profit long-term care home in 2018?": "Did you live in a public or non-profit long-term care home in 2018?",
   "The government might ask for your long-term care receipts.": "The government might ask for your long-term care receipts.",
   "How much were your total long-term care costs in 2018?": "How much were your total long-term care costs in 2018?",
-  "Please note you may be asked to provide receipts to verify this information later.": "Please note you may be asked to provide receipts to verify this information later."
+  "Please note you may be asked to provide receipts to verify this information later.": "Please note you may be asked to provide receipts to verify this information later.",
+  "Enter your long-term care home costs": "Enter your long-term care home costs"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -415,7 +415,6 @@
   "Claim medical expenses": "Claim medical expenses",
   "Check if you live in a student residence": "Check if you live in a student residence",
   "The government might ask for receipts later. The receipts must cover energy costs for a home on reserve where you lived most of 2018.": "The government might ask for receipts later. The receipts must cover energy costs for a home on reserve where you lived most of 2018.",
-  "Please note you may be asked to provide receipts to verify this information later.": "Please note you may be asked to provide receipts to verify this information later.",
   "Enter your home energy costs": "Enter your home energy costs",
   "What were your total home energy costs on reserve in 2018?": "What were your total home energy costs on reserve in 2018?",
   "You may live in a long-term care home or facility if costs such as nursing or personal support are combined with your rent. The home must be public or non-profit. This means that a charity, city, First Nations, or similar organization manages the home.": "You may live in a long-term care home or facility if costs such as nursing or personal support are combined with your rent. The home must be public or non-profit. This means that a charity, city, First Nations, or similar organization manages the home.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -200,16 +200,7 @@
   "Did you live on a reserve and have home energy costs 2018?": "Did you live on a reserve and have home energy costs 2018?",
   "Enter home energy costs on a reserve in 2018": "Enter home energy costs on a reserve in 2018",
   "Please enter your home energy costs for your principal residence on a reserve in 2018.": "Please enter your home energy costs for your principal residence on a reserve in 2018.",
-<<<<<<< HEAD
   "Long-term care costs in 2018": "Long-term care costs in 2018",
-=======
-  "Deduct your long-term care home costs": "Deduct your long-term care home costs",
-  "A": "A",
-  "long-term care home": "long-term care home",
-  "can include a nursing home or a municipal, First Nations, or charitable home for the aged.": "can include a nursing home or a municipal, First Nations, or charitable home for the aged.",
-  "If you lived in a nursing home or another public long-term care facility in 2018, you may be entitled to receive credits from your": "If you lived in a nursing home or another public long-term care facility in 2018, you may be entitled to receive credits from your",
-  "Did you live in a public long-term care home in 2018?": "Did you live in a public long-term care home in 2018?",
->>>>>>> update content on longTermCare/amount
   "Go back": "Page précédente",
   "Check Your Answers Before Filing Your Return": "Check Your Answers Before Filing Your Return",
   "Personal Information": "Personal Information",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -341,7 +341,7 @@
   "You have filed your 2018 taxes": "You have filed your 2018 taxes",
   "Your 2018 filing number is": "Your 2018 filing number is",
   "Give CRA this number if you need help or information. You can contact CRA by:": "Give CRA this number if you need help or information. You can contact CRA by:",
-  "TTY: 1-800-665-0354": "TTY: 1-800-665-0354",
+  "TTY: 1-800-665-0354": "TTY : 1-800-665-0354",
   "You can also get help at a free tax clinic. Visit": "You can also get help at a free tax clinic. Visit",
   "Print summary of your 2018 tax return": "Print summary of your 2018 tax return",
   "It is important to read your Notice of Assessment which shows:": "It is important to read your Notice of Assessment which shows:",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -177,7 +177,6 @@
   "Total Refund (484)": "Remboursement total (484)",
   "I confirm that, as far as I know, all the information in this tax return is accurate": "Je confirme que, à ma connaissance, tous les renseignements contenus dans cette déclaration de revenus sont exacts.",
   "Ontario Trillium Benefit": "Prestation Trillium de l’Ontario",
-  "Please enter the total amount paid for accommodation in a public or non-profit long-term care home in 2018.": "Veuillez inscrire le montant total payé pour un hébergement dans un foyer de soins de longue durée public ou sans but lucratif en 2018.",
   "Visit a free tax clinic near you. ": "Vous rendre à une clinique d’impôts gratuits. ",
   "You can have a volunteer help you submit your taxes.": "Vous pourrez obtenir l’aide d’une personne bénévole pour produire votre déclaration.",
   "File your taxes with": "Produire une déclaration de revenus ",
@@ -201,7 +200,16 @@
   "Did you live on a reserve and have home energy costs 2018?": "Did you live on a reserve and have home energy costs 2018?",
   "Enter home energy costs on a reserve in 2018": "Enter home energy costs on a reserve in 2018",
   "Please enter your home energy costs for your principal residence on a reserve in 2018.": "Please enter your home energy costs for your principal residence on a reserve in 2018.",
+<<<<<<< HEAD
   "Long-term care costs in 2018": "Long-term care costs in 2018",
+=======
+  "Deduct your long-term care home costs": "Deduct your long-term care home costs",
+  "A": "A",
+  "long-term care home": "long-term care home",
+  "can include a nursing home or a municipal, First Nations, or charitable home for the aged.": "can include a nursing home or a municipal, First Nations, or charitable home for the aged.",
+  "If you lived in a nursing home or another public long-term care facility in 2018, you may be entitled to receive credits from your": "If you lived in a nursing home or another public long-term care facility in 2018, you may be entitled to receive credits from your",
+  "Did you live in a public long-term care home in 2018?": "Did you live in a public long-term care home in 2018?",
+>>>>>>> update content on longTermCare/amount
   "Go back": "Page précédente",
   "Check Your Answers Before Filing Your Return": "Check Your Answers Before Filing Your Return",
   "Personal Information": "Personal Information",
@@ -374,5 +382,7 @@
   "Please note you may be asked to provide receipts to verify this information later.": "Please note you may be asked to provide receipts to verify this information later.",
   "Public long-term care home costs": "Public long-term care home costs",
   "You may live in a long-term care home or facility if costs such as nursing or personal support are combined with your rent. The home must be public or non-profit. This means that a charity, city, First Nations, or similar organization manages the home.": "You may live in a long-term care home or facility if costs such as nursing or personal support are combined with your rent. The home must be public or non-profit. This means that a charity, city, First Nations, or similar organization manages the home.",
-  "Did you live in a public or non-profit long-term care home in 2018?": "Did you live in a public or non-profit long-term care home in 2018?"
+  "Did you live in a public or non-profit long-term care home in 2018?": "Did you live in a public or non-profit long-term care home in 2018?",
+  "The government might ask for your long-term care receipts.": "The government might ask for your long-term care receipts.",
+  "How much were your total long-term care costs in 2018?": "How much were your total long-term care costs in 2018?"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -384,5 +384,6 @@
   "You may live in a long-term care home or facility if costs such as nursing or personal support are combined with your rent. The home must be public or non-profit. This means that a charity, city, First Nations, or similar organization manages the home.": "You may live in a long-term care home or facility if costs such as nursing or personal support are combined with your rent. The home must be public or non-profit. This means that a charity, city, First Nations, or similar organization manages the home.",
   "Did you live in a public or non-profit long-term care home in 2018?": "Did you live in a public or non-profit long-term care home in 2018?",
   "The government might ask for your long-term care receipts.": "The government might ask for your long-term care receipts.",
-  "How much were your total long-term care costs in 2018?": "How much were your total long-term care costs in 2018?"
+  "How much were your total long-term care costs in 2018?": "How much were your total long-term care costs in 2018?",
+  "Enter your long-term care home costs": "Enter your long-term care home costs"
 }

--- a/views/deductions/trillium-longTermCare-amount.pug
+++ b/views/deductions/trillium-longTermCare-amount.pug
@@ -1,7 +1,7 @@
 extends ../base
 
 block variables
-  -var title = __('Enter your long-term care home costs to apply for OTB')
+  -var title = __('Enter your long-term care home costs')
   -var trilliumLongTermCareAmount = hasData(data, 'deductions.trilliumLongTermCareAmount') && data.deductions.trilliumLongTermCareAmount !== 0 ? data.deductions.trilliumLongTermCareAmount : ''
 
 block content

--- a/views/deductions/trillium-longTermCare-amount.pug
+++ b/views/deductions/trillium-longTermCare-amount.pug
@@ -1,7 +1,7 @@
 extends ../base
 
 block variables
-  -var title = __('Long-term care costs in 2018')
+  -var title = __('Enter your long-term care home costs to apply for OTB')
   -var trilliumLongTermCareAmount = hasData(data, 'deductions.trilliumLongTermCareAmount') && data.deductions.trilliumLongTermCareAmount !== 0 ? data.deductions.trilliumLongTermCareAmount : ''
 
 block content
@@ -11,12 +11,10 @@ block content
   
 
   div
-    p #{__('Please enter the total amount paid for accommodation in a public or non-profit long-term care home in 2018.')}
-
-    p #{__('Please note you may be asked to provide receipts to verify this information later.')}
+    p #{__('The government might ask for your long-term care receipts.')}
 
   form.cra-form(method='post')
-    +textInput('Long-term care costs in 2018')(class='w-1-2 input-with-unit' name='trilliumLongTermCareAmount' placeholder='0.00' aria-labelledby='trilliumLongTermCareAmount__unit trilliumLongTermCareAmount__label' value=trilliumLongTermCareAmount)
+    +textInput('How much were your total long-term care costs in 2018?')(class='w-1-2 input-with-unit' name='trilliumLongTermCareAmount' placeholder='0.00' aria-labelledby='trilliumLongTermCareAmount__unit trilliumLongTermCareAmount__label' value=trilliumLongTermCareAmount)
 
     input#redirect(name='redirect', type='hidden', value='/deductions/climate-action-incentive')
 


### PR DESCRIPTION
## This PR consists of the following:

### Updating the content on the `/trillium/longTermCare/amount` page
- Updated page content based on [this github issue](https://github.com/cds-snc/cra-claim-tax-benefits/issues/173)
- Updated translations
- Deleted unused translation keys

| Before | After |
|--------|-------|
|  <img width="1392" alt="Screen Shot 2019-10-08 at 12 25 54" src="https://user-images.githubusercontent.com/30609058/66414258-09947a00-e9c7-11e9-9faa-319466365b39.png">  | <img width="1392" alt="Screen Shot 2019-10-08 at 12 26 04" src="https://user-images.githubusercontent.com/30609058/66414257-09947a00-e9c7-11e9-880b-9b01e63b685f.png">  |
