### PR TITLE
Content update to /deductions/climate-action-incentive

### DIFF
--- a/cypress/integration/full_run_simple.spec.js
+++ b/cypress/integration/full_run_simple.spec.js
@@ -273,10 +273,10 @@ describe('Full run through', function() {
       .click()
   })
 
-  it('navigates the Climate Action Incentive page', function() {
+  it('navigates  Incentive page', function() {
     //CLIMATE ACTION INCENTIVE
     cy.url().should('contain', '/deductions/climate-action-incentive')
-    cy.get('h1').should('contain', 'Climate Action Incentive')
+    cy.get('h1').should('contain', 'The Climate Action Incentive')
 
     cy.get('input#climateActionIncentiveIsRural1 + label').should(
       'have.attr',

--- a/locales/en.json
+++ b/locales/en.json
@@ -131,14 +131,6 @@
   "You should not use this service to file income information you believe to be incorrect.": "You should not use this service to file income information you believe to be incorrect.",
   "Language Selection": "Language Selection",
   "Language selection: French": "Language selection: French",
-  "Climate Action Incentive": "Climate Action Incentive",
-  "You’re eligible for the Climate Action Incentive, which you will receive automatically.": "You’re eligible for the Climate Action Incentive, which you will receive automatically.",
-  "There is an additional 10% credit for residents of small and rural communities": "There is an additional 10% credit for residents of small and rural communities",
-  "Did you live in a small and rural community in December 2018?": "Did you live in a small and rural community in December 2018?",
-  "How do I know if I live in a small and rural community": "How do I know if I live in a small and rural community",
-  "You live in a small or rural community if you": "You live in a small or rural community if you",
-  "do not": "do not",
-  "live in these areas: Ottawa, Kingston, Belleville, Peterborough, Oshawa, Toronto, Hamilton, St. Catharines-Niagara, Kitchener-Cambridge-Waterloo, Brantford, Guelph, London, Windsor, Barrie, Sudbury, or Thunder Bay.": "live in these areas: Ottawa, Kingston, Belleville, Peterborough, Oshawa, Toronto, Hamilton, St. Catharines-Niagara, Kitchener-Cambridge-Waterloo, Brantford, Guelph, London, Windsor, Barrie, Sudbury, or Thunder Bay.",
   "Net Federal tax deduction": "Net Federal tax deduction",
   "Net Provincial tax deduction": "Net Provincial tax deduction",
   "EI deduction": "EI deduction",
@@ -423,5 +415,10 @@
   "The government might ask for your long-term care receipts.": "The government might ask for your long-term care receipts.",
   "How much were your total long-term care costs in 2018?": "How much were your total long-term care costs in 2018?",
   "Please note you may be asked to provide receipts to verify this information later.": "Please note you may be asked to provide receipts to verify this information later.",
-  "Enter your long-term care home costs": "Enter your long-term care home costs"
+  "Enter your long-term care home costs": "Enter your long-term care home costs",
+  "The Climate Action Incentive": "The Climate Action Incentive",
+  "The Climate Action Incentive (CAI) lowers the amount of tax you pay. It could also increase the money you get back from filing taxes.": "The Climate Action Incentive (CAI) lowers the amount of tax you pay. It could also increase the money you get back from filing taxes.",
+  "You live in a small and rural community if you don’t live in:": "You live in a small and rural community if you don’t live in:",
+  "Ottawa, Kingston, Belleville, Peterborough, Oshawa, Toronto, Hamilton, St. Catharines-Niagara, Kitchener-Cambridge-Waterloo, Brantford, Guelph, London, Windsor, Barrie, Sudbury, or Thunder Bay.": "Ottawa, Kingston, Belleville, Peterborough, Oshawa, Toronto, Hamilton, St. Catharines-Niagara, Kitchener-Cambridge-Waterloo, Brantford, Guelph, London, Windsor, Barrie, Sudbury, or Thunder Bay.",
+  "Did you live in a small and rural community in 2018?": "Did you live in a small and rural community in 2018?"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -417,8 +417,9 @@
   "Please note you may be asked to provide receipts to verify this information later.": "Please note you may be asked to provide receipts to verify this information later.",
   "Enter your long-term care home costs": "Enter your long-term care home costs",
   "The Climate Action Incentive": "The Climate Action Incentive",
-  "The Climate Action Incentive (CAI) lowers the amount of tax you pay. It could also increase the money you get back from filing taxes.": "The Climate Action Incentive (CAI) lowers the amount of tax you pay. It could also increase the money you get back from filing taxes.",
   "You live in a small and rural community if you don’t live in:": "You live in a small and rural community if you don’t live in:",
   "Ottawa, Kingston, Belleville, Peterborough, Oshawa, Toronto, Hamilton, St. Catharines-Niagara, Kitchener-Cambridge-Waterloo, Brantford, Guelph, London, Windsor, Barrie, Sudbury, or Thunder Bay.": "Ottawa, Kingston, Belleville, Peterborough, Oshawa, Toronto, Hamilton, St. Catharines-Niagara, Kitchener-Cambridge-Waterloo, Brantford, Guelph, London, Windsor, Barrie, Sudbury, or Thunder Bay.",
-  "Did you live in a small and rural community in 2018?": "Did you live in a small and rural community in 2018?"
+  "Did you live in a small and rural community in 2018?": "Did you live in a small and rural community in 2018?",
+  "The Climate Action Incentive (CAI) lowers the amount of tax you pay. And you may get money back from the CAI.": "The Climate Action Incentive (CAI) lowers the amount of tax you pay. And you may get money back from the CAI.",
+  "Your CAI is greater if you live in a small and rural community.": "Your CAI is greater if you live in a small and rural community."
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -138,14 +138,6 @@
   "Medical expenses": "Frais médicaux",
   "Would you like to claim medical expenses?": "Souhaitez-vous demander des frais médicaux?",
   "the CRA's guide to eligible medical expenses": "guide des frais médicaux admissibles de l’ARC ",
-  "Climate Action Incentive": "Incitatif à agir pour le climat",
-  "You’re eligible for the Climate Action Incentive, which you will receive automatically.": "Vous êtes admissible à l’Incitatif à agir pour le climat, que vous recevrez automatiquement.",
-  "There is an additional 10% credit for residents of small and rural communities": "Il y a un crédit supplémentaire de 10 % pour les résidents des petites collectivités et des régions rurales.",
-  "Did you live in a small and rural community in December 2018?": "Habitiez-vous dans une petite collectivité rurale en décembre 2018?",
-  "How do I know if I live in a small and rural community": "Comment puis-je savoir si j’habite dans une petite collectivité rurale?",
-  "You live in a small or rural community if you": "Vous habitez dans une petite collectivité rurale si vous",
-  "do not": "ne",
-  "live in these areas: Ottawa, Kingston, Belleville, Peterborough, Oshawa, Toronto, Hamilton, St. Catharines-Niagara, Kitchener-Cambridge-Waterloo, Brantford, Guelph, London, Windsor, Barrie, Sudbury, or Thunder Bay.": "vivez pas dans ces régions : Ottawa, Kingston, Belleville, Peterborough, Oshawa, Toronto, Hamilton, St. Catharines-Niagara, Kitchener-Cambridge-Waterloo, Brantford, Guelph, London, Windsor, Barrie, Sudbury, or Thunder Bay.",
   "Review and file tax return": "Révisez et produisez votre déclaration",
   "This is an overview of your projected tax return, and all the benefits you will receive when you file for the current tax year.": "Voici la prévision de votre déclaration de revenus et de tous les avantages fiscaux que vous recevrez lorsque vous produirez votre déclaration pour l’année d’imposition courante.",
   "Take one final look before continuing. If something looks incorrect, please": "Jetez un dernier coup d’œil avant de produire votre déclaration. S’il semble y avoir des éléments inexacts, veuillez",
@@ -376,5 +368,10 @@
   "Did you live in a public or non-profit long-term care home in 2018?": "Did you live in a public or non-profit long-term care home in 2018?",
   "The government might ask for your long-term care receipts.": "The government might ask for your long-term care receipts.",
   "How much were your total long-term care costs in 2018?": "How much were your total long-term care costs in 2018?",
-  "Enter your long-term care home costs": "Enter your long-term care home costs"
+  "Enter your long-term care home costs": "Enter your long-term care home costs",
+  "The Climate Action Incentive": "The Climate Action Incentive",
+  "The Climate Action Incentive (CAI) lowers the amount of tax you pay. It could also increase the money you get back from filing taxes.": "The Climate Action Incentive (CAI) lowers the amount of tax you pay. It could also increase the money you get back from filing taxes.",
+  "You live in a small and rural community if you don’t live in:": "You live in a small and rural community if you don’t live in:",
+  "Ottawa, Kingston, Belleville, Peterborough, Oshawa, Toronto, Hamilton, St. Catharines-Niagara, Kitchener-Cambridge-Waterloo, Brantford, Guelph, London, Windsor, Barrie, Sudbury, or Thunder Bay.": "Ottawa, Kingston, Belleville, Peterborough, Oshawa, Toronto, Hamilton, St. Catharines-Niagara, Kitchener-Cambridge-Waterloo, Brantford, Guelph, London, Windsor, Barrie, Sudbury, or Thunder Bay.",
+  "Did you live in a small and rural community in 2018?": "Did you live in a small and rural community in 2018?"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -370,8 +370,9 @@
   "How much were your total long-term care costs in 2018?": "How much were your total long-term care costs in 2018?",
   "Enter your long-term care home costs": "Enter your long-term care home costs",
   "The Climate Action Incentive": "The Climate Action Incentive",
-  "The Climate Action Incentive (CAI) lowers the amount of tax you pay. It could also increase the money you get back from filing taxes.": "The Climate Action Incentive (CAI) lowers the amount of tax you pay. It could also increase the money you get back from filing taxes.",
   "You live in a small and rural community if you don’t live in:": "You live in a small and rural community if you don’t live in:",
   "Ottawa, Kingston, Belleville, Peterborough, Oshawa, Toronto, Hamilton, St. Catharines-Niagara, Kitchener-Cambridge-Waterloo, Brantford, Guelph, London, Windsor, Barrie, Sudbury, or Thunder Bay.": "Ottawa, Kingston, Belleville, Peterborough, Oshawa, Toronto, Hamilton, St. Catharines-Niagara, Kitchener-Cambridge-Waterloo, Brantford, Guelph, London, Windsor, Barrie, Sudbury, or Thunder Bay.",
-  "Did you live in a small and rural community in 2018?": "Did you live in a small and rural community in 2018?"
+  "Did you live in a small and rural community in 2018?": "Did you live in a small and rural community in 2018?",
+  "The Climate Action Incentive (CAI) lowers the amount of tax you pay. And you may get money back from the CAI.": "The Climate Action Incentive (CAI) lowers the amount of tax you pay. And you may get money back from the CAI.",
+  "Your CAI is greater if you live in a small and rural community.": "Your CAI is greater if you live in a small and rural community."
 }

--- a/views/deductions/climate-action-incentive.pug
+++ b/views/deductions/climate-action-incentive.pug
@@ -1,7 +1,7 @@
 extends ../base
 
 block variables
-  -var title = __('Climate Action Incentive')
+  -var title = __('The Climate Action Incentive')
   -var climateActionIncentiveIsRural = hasData(data, 'deductions.climateActionIncentiveIsRural') ? data.deductions.climateActionIncentiveIsRural : ''
 
 block content
@@ -9,16 +9,14 @@ block content
   h1 #{title}
 
   div
-    p #{__('You’re eligible for the Climate Action Incentive, which you will receive automatically.')}
-    p #{__('There is an additional 10% credit for residents of small and rural communities')}
-
-  form.cra-form(method='post')
-    +radiosYesNo('climateActionIncentiveIsRural', 'Did you live in a small and rural community in December 2018?', climateActionIncentiveIsRural)
-
+    p #{__('The Climate Action Incentive (CAI) lowers the amount of tax you pay. It could also increase the money you get back from filing taxes.')}
     div
       details.
-        <summary><span>#{__('How do I know if I live in a small and rural community')}</span></summary>
-        <p>#{__('You live in a small or rural community if you')} <strong>#{__('do not')}</strong> #{__('live in these areas: Ottawa, Kingston, Belleville, Peterborough, Oshawa, Toronto, Hamilton, St. Catharines-Niagara, Kitchener-Cambridge-Waterloo, Brantford, Guelph, London, Windsor, Barrie, Sudbury, or Thunder Bay.')}</p>
+        <summary><span>#{__('You live in a small and rural community if you don’t live in:')}</span></summary>
+        <p>#{__('Ottawa, Kingston, Belleville, Peterborough, Oshawa, Toronto, Hamilton, St. Catharines-Niagara, Kitchener-Cambridge-Waterloo, Brantford, Guelph, London, Windsor, Barrie, Sudbury, or Thunder Bay.')}</p>
+
+  form.cra-form(method='post')
+    +radiosYesNo('climateActionIncentiveIsRural', 'Did you live in a small and rural community in 2018?', climateActionIncentiveIsRural)
 
     input#redirect(name='redirect', type='hidden', value='/checkAnswers')
 

--- a/views/deductions/climate-action-incentive.pug
+++ b/views/deductions/climate-action-incentive.pug
@@ -9,7 +9,9 @@ block content
   h1 #{title}
 
   div
-    p #{__('The Climate Action Incentive (CAI) lowers the amount of tax you pay. It could also increase the money you get back from filing taxes.')}
+    p #{__('The Climate Action Incentive (CAI) lowers the amount of tax you pay. And you may get money back from the CAI.')}
+
+        p #{__('Your CAI is greater if you live in a small and rural community.')}
     div
       details.
         <summary><span>#{__('You live in a small and rural community if you don’t live in:')}</span></summary>


### PR DESCRIPTION
## This PR consists of the following:

### Updating the content on the `/deductions/climate-action-incentive` page
- Updated page content based on [this github issue](https://github.com/cds-snc/cra-claim-tax-benefits/issues/174)
- Updated translations
- Deleted unused translation keys

| Before | After |
|--------|-------|
|  <img width="1392" alt="Screen Shot 2019-10-08 at 13 45 01" src="https://user-images.githubusercontent.com/30609058/66419889-e1ab1380-e9d2-11e9-871a-d1b5c5212376.png"> | <img width="1392" alt="Screen Shot 2019-10-08 at 13 44 49" src="https://user-images.githubusercontent.com/30609058/66419890-e1ab1380-e9d2-11e9-9f0f-4488bfe01667.png">  |
