### PR TITLE
Fix/Whitelist Redirects

### DIFF
--- a/routes/confirmation/confirmation.spec.js
+++ b/routes/confirmation/confirmation.spec.js
@@ -22,7 +22,7 @@ describe('Test /review', () => {
     test('it returns a 422 response for no posted value', async () => {
       const response = await request(app)
         .post('/review')
-        .send({ redirect: '/' })
+        .send({ redirect: '/confirmation' })
       expect(response.statusCode).toBe(422)
     })
 
@@ -36,16 +36,16 @@ describe('Test /review', () => {
     test('it returns a 422 response for the wrong value', async () => {
       const response = await request(app)
         .post('/review')
-        .send({ review: 'get er done', redirect: '/' })
+        .send({ review: 'get er done', redirect: '/confirmation' })
       expect(response.statusCode).toBe(422)
     })
 
     test('it returns a 302 response for the right value', async () => {
       const response = await request(app)
         .post('/review')
-        .send({ review: 'review', redirect: '/' })
+        .send({ review: 'review', redirect: '/confirmation' })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toEqual('/')
+      expect(response.headers.location).toEqual('/confirmation')
     })
   })
 })

--- a/routes/deductions/deductions.spec.js
+++ b/routes/deductions/deductions.spec.js
@@ -14,7 +14,7 @@ describe('Test /deductions responses', () => {
           .send({
             politicalFederalAmount,
             politicalProvincialAmount,
-            redirect: '/',
+            redirect: '/start',
           })
         expect(response.statusCode).toBe(422)
       })
@@ -30,7 +30,7 @@ describe('Test /deductions responses', () => {
           .send({
             politicalFederalAmount,
             politicalProvincialAmount,
-            redirect: '/',
+            redirect: '/start',
           })
         expect(response.statusCode).toBe(422)
       })
@@ -45,7 +45,7 @@ describe('Test /deductions responses', () => {
           .send({
             politicalFederalAmount: politicalAmount,
             politicalProvincialAmount: politicalAmount,
-            redirect: '/',
+            redirect: '/start',
           })
         expect(response.statusCode).toBe(422)
       })
@@ -60,7 +60,7 @@ describe('Test /deductions responses', () => {
           .send({
             politicalFederalAmount: politicalAmount,
             politicalProvincialAmount: politicalAmount,
-            redirect: '/',
+            redirect: '/start',
           })
         expect(response.statusCode).toBe(302)
       })
@@ -103,7 +103,7 @@ describe('Test /deductions responses', () => {
       {
         url: '/trillium/studentResidence',
         key: 'trilliumStudentResidence',
-        yesRedir: '/success',
+        yesRedir: '/start',
       },
       {
         url: '/trillium/energy',
@@ -116,7 +116,7 @@ describe('Test /deductions responses', () => {
       {
         url: '/deductions/climate-action-incentive',
         key: 'climateActionIncentiveIsRural',
-        yesRedir: '/success',
+        yesRedir: '/start',
       },
     ]
 
@@ -130,7 +130,7 @@ describe('Test /deductions responses', () => {
         test('it returns a 422 response for no posted value', async () => {
           const response = await request(app)
             .post(yesNoResponse.url)
-            .send({ redirect: '/' })
+            .send({ redirect: '/start' })
           expect(response.statusCode).toBe(422)
         })
 
@@ -139,7 +139,7 @@ describe('Test /deductions responses', () => {
           test(`it returns a 422 for a bad posted value: "${badValue}"`, async () => {
             const response = await request(app)
               .post(yesNoResponse.url)
-              .send({ [yesNoResponse.key]: badValue, redirect: '/' })
+              .send({ [yesNoResponse.key]: badValue, redirect: '/start' })
             expect(response.statusCode).toBe(422)
           })
         })
@@ -147,16 +147,16 @@ describe('Test /deductions responses', () => {
         test('it redirects to the posted redirect url when posting "No"', async () => {
           const response = await request(app)
             .post(yesNoResponse.url)
-            .send({ [yesNoResponse.key]: 'No', redirect: '/' })
+            .send({ [yesNoResponse.key]: 'No', redirect: '/start' })
           expect(response.statusCode).toBe(302)
-          expect(response.headers.location).toEqual('/')
+          expect(response.headers.location).toEqual('/start')
         })
 
         test('it redirects to the checkAnswers when posting "No" and having come from the checkAnswers page', async () => {
           const response = await request(app)
             .post(`${yesNoResponse.url}`)
             .query({ ref: 'checkAnswers' })
-            .send({ [yesNoResponse.key]: 'No', redirect: '/' })
+            .send({ [yesNoResponse.key]: 'No', redirect: '/start' })
           expect(response.statusCode).toBe(302)
           expect(response.headers.location).toEqual('/checkAnswers')
         })
@@ -165,7 +165,7 @@ describe('Test /deductions responses', () => {
           const response = await request(app)
             .post(yesNoResponse.url)
             .query({ ref: 'checkAnswers' })
-            .send({ [yesNoResponse.key]: 'Yes', redirect: '/' })
+            .send({ [yesNoResponse.key]: 'Yes', redirect: '/start' })
           expect(response.statusCode).toBe(302)
           if ('yesRedir' in yesNoResponse) {
             expect(response.headers.location).toEqual('/checkAnswers')
@@ -236,8 +236,9 @@ describe('Test /deductions responses', () => {
         test('it returns a 302 response for no posted value', async () => {
           const response = await request(app)
             .post(amountResponse.url)
-            .send({ redirect: '/' })
+            .send({ redirect: '/start' })
           expect(response.statusCode).toBe(302)
+          expect(response.headers.location).toEqual('/start')
         })
 
         const badAmounts = ['dinosaur', '10.0', '10.000', '-10', '.1']
@@ -245,7 +246,7 @@ describe('Test /deductions responses', () => {
           test(`it returns a 422 for a bad posted value: "${badAmount}"`, async () => {
             const response = await request(app)
               .post(amountResponse.url)
-              .send({ [amountResponse.key]: badAmount, redirect: '/' })
+              .send({ [amountResponse.key]: badAmount, redirect: '/start' })
             expect(response.statusCode).toBe(422)
           })
         })
@@ -255,9 +256,9 @@ describe('Test /deductions responses', () => {
           test(`it returns a 302 for a good posted value: "${goodAmount}"`, async () => {
             const response = await request(app)
               .post(amountResponse.url)
-              .send({ [amountResponse.key]: goodAmount, redirect: '/' })
+              .send({ [amountResponse.key]: goodAmount, redirect: '/start' })
             expect(response.statusCode).toBe(302)
-            expect(response.headers.location).toEqual('/')
+            expect(response.headers.location).toEqual('/start')
           })
         })
       })

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -29,7 +29,7 @@ describe('Test /login responses', () => {
     test(`it returns a 422 response for ${url} if only a redirect is posted`, async () => {
       const response = await request(app)
         .post(url)
-        .send({ redirect: '/' })
+        .send({ redirect: '/start' })
       expect(response.statusCode).toBe(422)
     })
   })
@@ -65,7 +65,7 @@ describe('Test /login responses', () => {
     test('it renders the error-list for /login/code', async () => {
       const response = await request(app)
         .post('/login/code')
-        .send({ redirect: '/' })
+        .send({ redirect: '/start' })
       const $ = cheerio.load(response.text)
       expect($('title').text()).toMatch(/^Error:/)
       expect($('.error-list__header').text()).toEqual('Please correct the errors on the page')
@@ -78,7 +78,7 @@ describe('Test /login responses', () => {
     test('it renders an inline error for /login/code with appropriate describedby', async () => {
       const response = await request(app)
         .post('/login/code')
-        .send({ redirect: '/' })
+        .send({ redirect: '/start' })
       const $ = cheerio.load(response.text)
       expect($('.validation-message').text()).toEqual('Error: Access code must be 9 characters')
       expect($('#code').attr('aria-describedby')).toEqual('code-error')
@@ -88,21 +88,21 @@ describe('Test /login responses', () => {
   test('it does not allow a code more than 9 characters', async () => {
     const response = await request(app)
       .post('/login/code')
-      .send({ code: '23XGY12111', redirect: '/' })
+      .send({ code: '23XGY12111', redirect: '/start' })
     expect(response.statusCode).toBe(422)
   })
 
   test('it does not allow a code less than 8 characters', async () => {
     const response = await request(app)
       .post('/login/code')
-      .send({ code: 'A23X', redirect: '/' })
+      .send({ code: 'A23X', redirect: '/start' })
     expect(response.statusCode).toBe(422)
   })
 
   test('it does not allow non-alphanumeric characters', async () => {
     const response = await request(app)
       .post('/login/code')
-      .send({ code: 'A23X456@', redirect: '/' })
+      .send({ code: 'A23X456@', redirect: '/start' })
     expect(response.statusCode).toBe(422)
   })
 
@@ -111,9 +111,9 @@ describe('Test /login responses', () => {
     test(`it redirects if a valid code is provided: "${code}"`, async () => {
       const response = await request(app)
         .post('/login/code')
-        .send({ code, redirect: '/' })
+        .send({ code, redirect: '/start' })
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toEqual('/')
+      expect(response.headers.location).toEqual('/start')
     })
   })
 
@@ -136,7 +136,7 @@ describe('Test /login responses', () => {
     test('it reloads /login/sin with a 422 status if no sin is provided', async () => {
       const response = await request(app)
         .post('/login/sin')
-        .send({ redirect: '/' })
+        .send({ redirect: '/start' })
       expect(response.statusCode).toBe(422)
       const $ = cheerio.load(response.text)
       expect($('title').text()).toMatch(/^Error:/)
@@ -150,7 +150,7 @@ describe('Test /login responses', () => {
       test('it renders the error-list for /login/sin', async () => {
         const response = await request(app)
           .post('/login/sin')
-          .send({ redirect: '/' })
+          .send({ redirect: '/start' })
         const $ = cheerio.load(response.text)
         expect($('title').text()).toMatch(/^Error:/)
         expect($('.error-list__header').text()).toEqual('Please correct the errors on the page')
@@ -163,14 +163,14 @@ describe('Test /login responses', () => {
     test('it does not allow a code more than 9 characters', async () => {
       const response = await request(app)
         .post('/login/sin')
-        .send({ code: '12345678910', redirect: '/' })
+        .send({ code: '12345678910', redirect: '/start' })
       expect(response.statusCode).toBe(422)
     })
 
     test('it does not allow a code less than 9 characters', async () => {
       const response = await request(app)
         .post('/login/sin')
-        .send({ code: '12345678', redirect: '/' })
+        .send({ code: '12345678', redirect: '/start' })
       expect(response.statusCode).toBe(422)
     })
 
@@ -214,7 +214,7 @@ describe('Test /login responses', () => {
       dobDay: '09',
       dobMonth: '09',
       dobYear: '1977',
-      redirect: '/login/success',
+      redirect: '/personal/name',
     }
 
     const currentDate = new Date()
@@ -331,7 +331,7 @@ describe('Test /login responses', () => {
             dobDay: ' 9 ',
             dobMonth: ' 9 ',
             dobYear: ' 1977 ',
-            redirect: '/login/success',
+            redirect: '/personal/name',
           })
         expect(response.statusCode).toBe(302)
       })
@@ -366,7 +366,7 @@ describe('Test /login responses', () => {
           .post('/login/questions/child')
           .send({ ...goodDoBRequest, ...{ childLastName: 'Laika' } })
         expect(response.statusCode).toBe(302)
-        expect(response.headers.location).toEqual('/login/success')
+        expect(response.headers.location).toEqual('/personal/name')
       })
     })
 
@@ -406,7 +406,7 @@ describe('Test /login responses', () => {
           .post('/login/questions/prison')
           .send({ ...goodDoBRequest, ...{ prisonDate: 'release' } })
         expect(response.statusCode).toBe(302)
-        expect(response.headers.location).toEqual('/login/success')
+        expect(response.headers.location).toEqual('/personal/name')
       })
     })
 
@@ -487,14 +487,14 @@ describe('Test /login responses', () => {
     it('it should return 422 for the wrong DoB', async () => {
       const response = await authSession
         .post('/login/dateOfBirth')
-        .send({ dobDay: '23', dobMonth: '03', dobYear: '1909', redirect: '/login/success' })
+        .send({ dobDay: '23', dobMonth: '03', dobYear: '1909', redirect: '/personal/name' })
       expect(response.statusCode).toBe(422)
     })
 
     it('it should return 302 for the right DoB', async () => {
       const response = await authSession
         .post('/login/dateOfBirth')
-        .send({ dobDay: '09', dobMonth: '09', dobYear: '1977', redirect: '/login/success' })
+        .send({ dobDay: '09', dobMonth: '09', dobYear: '1977', redirect: '/personal/name' })
       expect(response.statusCode).toBe(302)
     })
   })
@@ -522,7 +522,7 @@ questionsAmounts.map(amountResponse => {
     test('it returns a 422 response for no posted values', async () => {
       const response = await request(app)
         .post(amountResponse.url)
-        .send({ redirect: '/' })
+        .send({ redirect: '/start' })
       expect(response.statusCode).toBe(422)
     })
 
@@ -534,7 +534,7 @@ questionsAmounts.map(amountResponse => {
           .send({
             [`${amountResponse.key}Amount`]: badAmount,
             [`${amountResponse.key}PaymentMethod`]: 'cheque',
-            redirect: '/',
+            redirect: '/start',
           })
         expect(response.statusCode).toBe(422)
       })
@@ -545,7 +545,7 @@ questionsAmounts.map(amountResponse => {
         .post(amountResponse.url)
         .send({
           [`${amountResponse.key}Amount`]: '10',
-          redirect: '/',
+          redirect: '/start',
         })
       expect(response.statusCode).toBe(422)
     })
@@ -558,10 +558,10 @@ questionsAmounts.map(amountResponse => {
           .send({
             [`${amountResponse.key}Amount`]: goodAmount,
             [`${amountResponse.key}PaymentMethod`]: 'cheque',
-            redirect: '/',
+            redirect: '/start',
           })
         expect(response.statusCode).toBe(302)
-        expect(response.headers.location).toEqual('/')
+        expect(response.headers.location).toEqual('/start')
       })
     })
 
@@ -570,7 +570,7 @@ questionsAmounts.map(amountResponse => {
         .post(amountResponse.url)
         .send({
           [`${amountResponse.key}PaymentMethod`]: 'cheque',
-          redirect: '/',
+          redirect: '/start',
         })
       expect(response.statusCode).toBe(302)
     })
@@ -581,7 +581,7 @@ questionsAmounts.map(amountResponse => {
         .send({
           [`${amountResponse.key}Amount`]: '10',
           [`${amountResponse.key}PaymentMethod`]: 'bitcoin',
-          redirect: '/',
+          redirect: '/start',
         })
       expect(response.statusCode).toBe(422)
     })
@@ -594,10 +594,10 @@ questionsAmounts.map(amountResponse => {
           .send({
             [`${amountResponse.key}Amount`]: '10',
             [`${amountResponse.key}PaymentMethod`]: paymentMethod,
-            redirect: '/',
+            redirect: '/start',
           })
         expect(response.statusCode).toBe(302)
-        expect(response.headers.location).toEqual('/')
+        expect(response.headers.location).toEqual('/start')
       })
     })
   })

--- a/routes/personal/personal.spec.js
+++ b/routes/personal/personal.spec.js
@@ -35,16 +35,16 @@ describe('Test /personal responses', () => {
     test('it redirects to the provided redirect value when selecting Yes', async () => {
       const response = await request(app)
         .post('/personal/name')
-        .send({ redirect: '/success', name: 'Yes' })
-      expect(response.headers.location).toEqual('/success')
+        .send({ redirect: '/start', name: 'Yes' })
+      expect(response.headers.location).toEqual('/start')
       expect(response.statusCode).toBe(302)
     })
 
     test('it redirects to the checkAnswers when posting Yes and having come from the checkAnswers page', async () => {
       const response = await request(app)
         .post('/personal/name')
-        .query({ref: 'checkAnswers'})
-        .send({ redirect: '/', name: 'Yes' })
+        .query({ ref: 'checkAnswers' })
+        .send({ redirect: '/start', name: 'Yes' })
       expect(response.statusCode).toBe(302)
       expect(response.headers.location).toEqual('/checkAnswers')
     })
@@ -62,11 +62,11 @@ describe('Test /personal responses', () => {
     test('it redirects to the checkAnswers when posting Yes and having come from the checkAnswers page', async () => {
       const response = await request(app)
         .post('/personal/maritalStatus')
-        .query({ref: 'checkAnswers'})
-        .send({ redirect: '/', confirmMaritalStatus: 'Yes' })
+        .query({ ref: 'checkAnswers' })
+        .send({ redirect: '/start', confirmMaritalStatus: 'Yes' })
       expect(response.statusCode).toBe(302)
       expect(response.headers.location).toEqual('/checkAnswers')
-    })  
+    })
   })
 
   describe('Test /personal/residence responses', () => {
@@ -96,8 +96,8 @@ describe('Test /personal responses', () => {
     test('it redirects to the checkAnswers when posting Yes and having come from the checkAnswers page', async () => {
       const response = await request(app)
         .post('/personal/residence')
-        .query({ref: 'checkAnswers'})
-        .send({ redirect: '/', residence: 'Ontario' })
+        .query({ ref: 'checkAnswers' })
+        .send({ redirect: '/start', residence: 'Ontario' })
       expect(response.statusCode).toBe(302)
       expect(response.headers.location).toEqual('/checkAnswers')
     })
@@ -115,10 +115,10 @@ describe('Test /personal responses', () => {
     test('it redirects to the checkAnswers when posting Yes and having come from the checkAnswers page', async () => {
       const response = await request(app)
         .post('/personal/address')
-        .query({ref: 'checkAnswers'})
-        .send({ redirect: '/', confirmAddress: 'Yes' })
+        .query({ ref: 'checkAnswers' })
+        .send({ redirect: '/start', confirmAddress: 'Yes' })
       expect(response.statusCode).toBe(302)
       expect(response.headers.location).toEqual('/checkAnswers')
-    }) 
+    })
   })
 })

--- a/utils/index.js
+++ b/utils/index.js
@@ -109,7 +109,7 @@ const checkErrors = template => {
 // POST functions that handle setting the login data in the session and will redirecting to the next page or send back an error to the client.
 // Note that this is not the only error validation, see routes defined above.
 const doRedirect = (req, res) => {
-  let redirect = req.body.redirect || null
+  const redirect = req.body.redirect || null
   if (!redirect) {
     throw new Error(`[POST ${req.path}] 'redirect' parameter missing`)
   }
@@ -118,7 +118,15 @@ const doRedirect = (req, res) => {
     return returnToCheckAnswers(req, res)
   }
 
-  return res.redirect(redirect)
+  const { route: { path } = {} } = getRouteWithIndexByPath(redirect)
+
+  if (!path) {
+    throw new Error(
+      `[POST ${req.path}] 'redirect' parameter ${path} not a whitelisted URL. Check the routes config.`,
+    )
+  }
+
+  return res.redirect(path)
 }
 
 // Render a passed-in template and pass in session data under the "data" key
@@ -317,7 +325,7 @@ const returnToCheckAnswers = (req, res, claimYes = false) => {
 /**
  * @param {String} path the current path being visited
  * @param {Array} routes array of route objects { path: "/start" }
- * @returns { index: "1", route: { path: "/start" } }
+ * @returns {Object} { index: "1", route: { path: "/start" } }
  */
 const getRouteWithIndexByPath = (path, routes = defaultRoutes) => {
   let routeWithIndex = null


### PR DESCRIPTION
Whitelist redirect URLs in `doRedirect` middleware. 

@obrien-j's LGTM thing was warning us that redirecting to whatever was posted in the form was not super safe. I get it, fair enough. 

So, since we now have a list of all the paths we use in the application, let's match the redirect to a specific path. 

The first commit is the actual change. The second commit is updating the 90 unit tests or so that were broken. (Lots of our redirect tests were using `/` or `/success`, so I've mostly changed them to `/start`.)

@katedee, you're probably the best one to review this.