### PR TITLE
Removed duplicate line on /deductions/medical

### DIFF
--- a/views/deductions/medical.pug
+++ b/views/deductions/medical.pug
@@ -23,7 +23,6 @@ block content
         </ul>
 
     p #{__('You may be able to enter medical costs for yourself and your children. You may also be able to enter costs for your partner by marriage or common-law, and their children.')}
-    p #{__('To include a child’s medical costs, the child must have been under 18 on December 31, 2018, and:')}
 
     div
       details.


### PR DESCRIPTION
## This PR consists of the following:

### Removing a duplicate line on `/deductions/medical`
- removed duplicated `To include a child’s medical costs, the child must have been under 18 on December 31, 2018, and:` p tag 