### PR TITLE
Feature/dob mixin

### DIFF
--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -182,7 +182,7 @@ form.cra-form.cra-form--lg {
 }
 
 form.cra-form {
-  .dob-container {
+  .date-container {
     @include sm {
       width: 90%;
     }

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -60,6 +60,18 @@ form.cra-form {
     select {
       border: 2px solid $color-red;
     }
+
+    &--container {
+      padding-left: $space-sm;
+      border-left: $space-xxs solid $color-red;
+    }
+  }
+
+  .has-error--inline {
+    input,
+    select {
+      border: 2px solid $color-red;
+    }
   }
 
   label,

--- a/schemas/login.schema.js
+++ b/schemas/login.schema.js
@@ -58,24 +58,13 @@ const lastDayInMonth = (year, month) => {
   return new Date(year, month + 1, 0).getDate()
 }
 
-const isValidDay = {
-  errorMessage: 'errors.login.dateOfBirth.validDay',
-  validate: (value, req) => {
-    const yearKey = Object.keys(req.body).filter((key) => /Year/.test(key))
-    const monthKey = Object.keys(req.body).filter((key) => /Month/.test(key))
-
-    const year = parseInt(req.body[yearKey], 10)
-    let month = parseInt(req.body[monthKey], 10)
-    const day = parseInt(value, 10)
-
-    if (!day || !month || !year) {
-      return false
-    }
-
-    //subtract one because Date for months starts at a 0 index for Jan 🤓
-    month -= 1
-    return day >= 1 && day <= lastDayInMonth(year, month)
-  },
+const isValidDay = (errorMessageString = 'errors.login.dateOfBirth.validDay') => {
+  return {
+    isInt: {
+      errorMessage: errorMessageString,
+      options: { min: 1, max: 31 },
+    },
+  }
 }
 
 const toISOFormat = ({ dobYear, dobMonth, dobDay }) => {
@@ -98,7 +87,8 @@ const isMatchingDoB = {
 
 const dobSchema = {
   dobDay: {
-    ...validationArray([isValidDay, isMatchingDoB]),
+    ...isValidDay(),
+    ...validationArray([isMatchingDoB]),
   },
   dobMonth: {
     isInt: {
@@ -130,9 +120,7 @@ const childSchema = {
       negated: true,
     },
   },
-  dobDay: {
-    ...validationArray([isValidDay]),
-  },
+  dobDay: isValidDay(),
   dobMonth: {
     isInt: {
       errorMessage: 'errors.login.dateOfBirth.validMonth',
@@ -148,9 +136,7 @@ const childSchema = {
 }
 
 const dateOfResidenceSchema = {
-  dobDay: {
-    ...validationArray([isValidDay]),
-  },
+  dobDay: isValidDay(),
   dobMonth: {
     isInt: {
       errorMessage: 'errors.login.dateOfBirth.validMonth',
@@ -166,9 +152,7 @@ const dateOfResidenceSchema = {
 }
 
 const bankruptcySchema = {
-  dobDay: {
-    ...validationArray([isValidDay]),
-  },
+  dobDay: isValidDay(),
   dobMonth: {
     isInt: {
       errorMessage: 'errors.login.dateOfBirth.validMonth',
@@ -275,9 +259,7 @@ const prisonSchema = {
       options: [['entry', 'release']],
     },
   },
-  dobDay: {
-    ...validationArray([isValidDay]),
-  },
+  dobDay: isValidDay(),
   dobMonth: {
     isInt: {
       errorMessage: 'errors.login.dateOfBirth.validMonth',

--- a/schemas/login.schema.js
+++ b/schemas/login.schema.js
@@ -54,10 +54,6 @@ const sinSchema = {
 
 const currentDate = new Date()
 
-const lastDayInMonth = (year, month) => {
-  return new Date(year, month + 1, 0).getDate()
-}
-
 const isValidDay = (errorMessageString = 'errors.login.dateOfBirth.validDay') => {
   return {
     isInt: {
@@ -285,6 +281,5 @@ module.exports = {
   trilliumAmountSchema,
   addressesSchema,
   prisonSchema,
-  lastDayInMonth,
   toISOFormat,
 }

--- a/schemas/login.schema.js
+++ b/schemas/login.schema.js
@@ -61,8 +61,11 @@ const lastDayInMonth = (year, month) => {
 const isValidDay = {
   errorMessage: 'errors.login.dateOfBirth.validDay',
   validate: (value, req) => {
-    const year = parseInt(req.body.dobYear, 10)
-    let month = parseInt(req.body.dobMonth, 10)
+    const yearKey = Object.keys(req.body).filter((key) => /Year/.test(key))
+    const monthKey = Object.keys(req.body).filter((key) => /Month/.test(key))
+
+    const year = parseInt(req.body[yearKey], 10)
+    let month = parseInt(req.body[monthKey], 10)
     const day = parseInt(value, 10)
 
     if (!day || !month || !year) {

--- a/schemas/login.schema.js
+++ b/schemas/login.schema.js
@@ -95,7 +95,7 @@ const dobSchema = {
   dobYear: {
     isInt: {
       errorMessage: 'errors.login.dateOfBirth.validYear',
-      options: { min: currentDate.getFullYear() - 200, max: currentDate.getFullYear() - 1 },
+      options: { min: currentDate.getFullYear() - 200, max: currentDate.getFullYear() },
     },
   },
 }

--- a/schemas/login.schema.test.js
+++ b/schemas/login.schema.test.js
@@ -1,39 +1,5 @@
 const { lastDayInMonth, toISOFormat } = require('./index')
 
-describe('Test lastDayInMonth', () => {
-  const monthLengths = [
-    ['january', 31],
-    ['february', 28],
-    ['march', 31],
-    ['april', 30],
-    ['may', 31],
-    ['june', 30],
-    ['july', 31],
-    ['august', 31],
-    ['september', 30],
-    ['october', 31],
-    ['november', 30],
-    ['december', 31],
-  ]
-
-  monthLengths.map((v, index) => {
-    test(`returns ${v[1]} days for ${v[0]}`, () => {
-      expect(lastDayInMonth('2019', index)).toEqual(v[1])
-    })
-  })
-
-  describe('knows about leap years', () => {
-    const february = 1
-    const daysInFeb = [['2020', 29], ['2019', 28], ['2018', 28], ['2017', 28], ['2016', 29]]
-
-    daysInFeb.map(v => {
-      test(`returns ${v[1]} days in February in ${v[0]}`, () => {
-        expect(lastDayInMonth(v[0], february)).toEqual(v[1])
-      })
-    })
-  })
-})
-
 describe('Test toISOFormat', () => {
   const _date = { dobYear: '1957', dobMonth: '12', dobDay: '05' }
 

--- a/views/_includes/input-dates.pug
+++ b/views/_includes/input-dates.pug
@@ -9,7 +9,7 @@ mixin dateInputs(idPrefix, legendText, isoHintText, values)
 
       span#dobHint.cra-form-message #{__('For Example:')} #{isoDateHintText(isoHintText)}
 
-      if errors[`${idPrefix}Day`] || errors[`${idPrefix}Month`] || errors[`${idPrefix}Day`]
+      if errors && errors[`${idPrefix}Day`] || errors && errors[`${idPrefix}Month`] || errors && errors[`${idPrefix}Day`]
         ul
           each err in errors
             if err.param.includes(idPrefix)

--- a/views/_includes/input-dates.pug
+++ b/views/_includes/input-dates.pug
@@ -1,8 +1,8 @@
-mixin dateInputs(idPrefix, label, isoHintText, values)
+mixin dateInputs(idPrefix, legendText, isoHintText, values)
   div.date-container(class={['has-error']: errors && errors[`${idPrefix}Day`]})
     fieldset.fieldset(role="group", aria-describedby=`${idPrefix}Hint`,)
       legend
-        h2 #{__(label)}
+        h2 #{__(legendText)}
 
       span#dobHint.cra-form-message #{__('For Example:')} #{isoDateHintText(isoHintText)}
 

--- a/views/_includes/input-dates.pug
+++ b/views/_includes/input-dates.pug
@@ -1,0 +1,24 @@
+mixin dateInputs(idPrefix, label, isoHintText, values)
+  div.date-container(class={['has-error']: errors && errors[`${idPrefix}Day`]})
+    fieldset.fieldset(role="group", aria-describedby=`${idPrefix}Hint`,)
+      legend
+        h2 #{__(label)}
+
+      span#dobHint.cra-form-message #{__('For Example:')} #{isoDateHintText(isoHintText)}
+
+      if errors
+        ul
+          each err in errors
+            li
+              +validationMessage(err.msg, err.param)
+      div.w-1-4.d--ib
+        label(for=`${idPrefix}Day`) #{__('Day')}
+        input#dobDay(name=`${idPrefix}Day`, autofocus, type='text', value=values[0], autocomplete=`${idPrefix}-day`, aria-describedby=(errors && errors[`${idPrefix}Day`] ? `${idPrefix}Day-error` : false))
+
+      div.w-1-4.d--ib
+        label(for=`${idPrefix}Month`) #{__('Month')}
+        input#dobMonth(name=`${idPrefix}Month`, type='text', value=values[1], autocomplete=`${idPrefix}-month`, aria-describedby=(errors && errors[`${idPrefix}Month`] ? `${idPrefix}Month-error` : false))
+
+      div.w-1-2.d--ib
+        label(for=`${idPrefix}Year`) #{__('Year')}
+        input#dobYear(name=`${idPrefix}Year`, type='text', value=values[2], autocomplete=`${idPrefix}-year`, aria-describedby=(errors && errors[`${idPrefix}Year`] ? `${idPrefix}Year-error` : false))

--- a/views/_includes/input-dates.pug
+++ b/views/_includes/input-dates.pug
@@ -1,5 +1,5 @@
 mixin dateInputs(idPrefix, legendText, isoHintText, values)
-  div.date-container(class={['has-error']: errors && errors[`${idPrefix}Day`]})
+  div.date-container(class={['has-error--container']: errors})
     fieldset.fieldset(role="group", aria-describedby=`${idPrefix}Hint`,)
       legend
         h2 #{__(legendText)}
@@ -11,14 +11,14 @@ mixin dateInputs(idPrefix, legendText, isoHintText, values)
           each err in errors
             li
               +validationMessage(err.msg, err.param)
-      div.w-1-4.d--ib
+      div.w-1-4.d--ib(class={['has-error--inline']: errors && errors[`${idPrefix}Day`]})
         label(for=`${idPrefix}Day`) #{__('Day')}
         input#dobDay(name=`${idPrefix}Day`, autofocus, type='text', value=values[0], autocomplete=`${idPrefix}-day`, aria-describedby=(errors && errors[`${idPrefix}Day`] ? `${idPrefix}Day-error` : false))
 
-      div.w-1-4.d--ib
+      div.w-1-4.d--ib(class={['has-error--inline']: errors && errors[`${idPrefix}Month`]})
         label(for=`${idPrefix}Month`) #{__('Month')}
         input#dobMonth(name=`${idPrefix}Month`, type='text', value=values[1], autocomplete=`${idPrefix}-month`, aria-describedby=(errors && errors[`${idPrefix}Month`] ? `${idPrefix}Month-error` : false))
 
-      div.w-1-2.d--ib
+      div.w-1-2.d--ib(class={['has-error--inline']: errors && errors[`${idPrefix}Year`]})
         label(for=`${idPrefix}Year`) #{__('Year')}
         input#dobYear(name=`${idPrefix}Year`, type='text', value=values[2], autocomplete=`${idPrefix}-year`, aria-describedby=(errors && errors[`${idPrefix}Year`] ? `${idPrefix}Year-error` : false))

--- a/views/_includes/input-dates.pug
+++ b/views/_includes/input-dates.pug
@@ -1,4 +1,4 @@
-mixin dateInputs(idPrefix, legendText, isoHintText, values)
+mixin dateInputs(idPrefix, legendText, isoHintText, values, bday = false)
   div.date-container(class={
     ['has-error--container']: errors,
     ['has-error']: errors && errors[`${idPrefix}Day`] && errors[`${idPrefix}Day`].msg === 'errors.login.dateOfBirth.match'
@@ -17,12 +17,12 @@ mixin dateInputs(idPrefix, legendText, isoHintText, values)
                 +validationMessage(err.msg, err.param)
       div.w-1-4.d--ib(class={['has-error--inline']: errors && errors[`${idPrefix}Day`]})
         label(for=`${idPrefix}Day`) #{__('Day')}
-        input#dobDay(name=`${idPrefix}Day`, autofocus, type='text', value=values[0], autocomplete=`${idPrefix}-day`, aria-describedby=(errors && errors[`${idPrefix}Day`] ? `${idPrefix}Day-error` : false))
+        input#dobDay(name=`${idPrefix}Day`, autofocus=(!errors || errors && errors[`${idPrefix}Day`]), type='text', value=values[0], autocomplete=(bday ? 'bday-day' : null), aria-describedby=(errors && errors[`${idPrefix}Day`] ? `${idPrefix}Day-error` : false))
 
       div.w-1-4.d--ib(class={['has-error--inline']: errors && errors[`${idPrefix}Month`]})
         label(for=`${idPrefix}Month`) #{__('Month')}
-        input#dobMonth(name=`${idPrefix}Month`, type='text', value=values[1], autocomplete=`${idPrefix}-month`, aria-describedby=(errors && errors[`${idPrefix}Month`] ? `${idPrefix}Month-error` : false))
+        input#dobMonth(name=`${idPrefix}Month`, type='text', value=values[1], autofocus=(errors && errors[`${idPrefix}Month`] && !errors[`${idPrefix}Day`]), autocomplete=(bday ? 'bday-month' : null), aria-describedby=(errors && errors[`${idPrefix}Month`] ? `${idPrefix}Month-error` : false))
 
       div.w-1-2.d--ib(class={['has-error--inline']: errors && errors[`${idPrefix}Year`]})
         label(for=`${idPrefix}Year`) #{__('Year')}
-        input#dobYear(name=`${idPrefix}Year`, type='text', value=values[2], autocomplete=`${idPrefix}-year`, aria-describedby=(errors && errors[`${idPrefix}Year`] ? `${idPrefix}Year-error` : false))
+        input#dobYear(name=`${idPrefix}Year`, type='text', value=values[2], autofocus=(errors && errors[`${idPrefix}Year`] && !errors[`${idPrefix}Day`] && !errors[`${idPrefix}Month`] ), autocomplete=(bday ? 'bday-year' : null), aria-describedby=(errors && errors[`${idPrefix}Year`] ? `${idPrefix}Year-error` : false))

--- a/views/_includes/input-dates.pug
+++ b/views/_includes/input-dates.pug
@@ -1,16 +1,20 @@
 mixin dateInputs(idPrefix, legendText, isoHintText, values)
-  div.date-container(class={['has-error--container']: errors})
+  div.date-container(class={
+    ['has-error--container']: errors,
+    ['has-error']: errors && errors[`${idPrefix}Day`] && errors[`${idPrefix}Day`].msg === 'errors.login.dateOfBirth.match'
+    })
     fieldset.fieldset(role="group", aria-describedby=`${idPrefix}Hint`,)
       legend
         h2 #{__(legendText)}
 
       span#dobHint.cra-form-message #{__('For Example:')} #{isoDateHintText(isoHintText)}
 
-      if errors
+      if errors[`${idPrefix}Day`] || errors[`${idPrefix}Month`] || errors[`${idPrefix}Day`]
         ul
           each err in errors
-            li
-              +validationMessage(err.msg, err.param)
+            if err.param.includes(idPrefix)
+              li
+                +validationMessage(err.msg, err.param)
       div.w-1-4.d--ib(class={['has-error--inline']: errors && errors[`${idPrefix}Day`]})
         label(for=`${idPrefix}Day`) #{__('Day')}
         input#dobDay(name=`${idPrefix}Day`, autofocus, type='text', value=values[0], autocomplete=`${idPrefix}-day`, aria-describedby=(errors && errors[`${idPrefix}Day`] ? `${idPrefix}Day-error` : false))

--- a/views/login/dateOfBirth.pug
+++ b/views/login/dateOfBirth.pug
@@ -15,7 +15,7 @@ block content
   div
     form.cra-form(method='post')
 
-      +dateInputs('dob', 'Date of birth', data.personal.dateOfBirth, [dobDay, dobMonth, dobYear])
+      +dateInputs('dob', 'Date of birth', data.personal.dateOfBirth, [dobDay, dobMonth, dobYear], true)
 
       input#redirect(name='redirect', type='hidden', value='/login/securityQuestion')
 

--- a/views/login/dateOfBirth.pug
+++ b/views/login/dateOfBirth.pug
@@ -1,4 +1,5 @@
 extends ../base
+include ../_includes/input-dates
 
 block variables
   -var title = __('Enter your date of birth')
@@ -14,31 +15,8 @@ block content
   div
     form.cra-form(method='post')
 
-      div.dob-container(class={['has-error']: errors && errors.dobDay})
-        fieldset.fieldset(role="group", aria-describedby="dobHint",)
-          legend
-            h2 #{__('Date of birth')}
+      +dateInputs('dob', 'Date of birth', data.personal.dateOfBirth, [dobDay, dobMonth, dobYear])
 
-          span#dobHint.cra-form-message #{__('For Example:')} #{isoDateHintText(data.personal.dateOfBirth)}
-
-          if errors
-            ul
-              each err in errors
-                li
-                  +validationMessage(err.msg, err.param)
-
-          div.w-1-4.d--ib
-            label(for='dobDay') #{__('Day')}
-            input#dobDay(name='dobDay', autofocus, type='text', value=dobDay, autocomplete='bday-day', aria-describedby=(errors && errors.dobDay ? 'dobDay-error' : false))
-
-          div.w-1-4.d--ib
-            label(for='dobMonth') #{__('Month')}
-            input#dobMonth(name='dobMonth', type='text', value=dobMonth, autocomplete='bday-month', aria-describedby=(errors && errors.dobMonth ? 'dobMonth-error' : false))
-
-          div.w-1-2.d--ib
-            label(for='dobYear') #{__('Year')}
-            input#dobYear(name='dobYear', type='text', value=dobYear, autocomplete='bday-year', aria-describedby=(errors && errors.dobYear ? 'dobYear-error' : false))
-
-          input#redirect(name='redirect', type='hidden', value='/login/securityQuestion')
+      input#redirect(name='redirect', type='hidden', value='/login/securityQuestion')
 
       +formButtons()


### PR DESCRIPTION
Debated a few ways of doing this (container mixin, with then mixins for the individual date inputs, so we could leverage `&attributes`), but ended up settling on this way of handling it, which allows for passing in the fewest things in the mixin. Might want to add something to make autocomplete option though.


- `idPrefix` - since each input will end with day/month/year, we're just taking and (ideally short) id prefix to append

- `legendText` - the text for the legend

- `isoHintText` - the iso value for the hint text that comes along with the date fields

- `values` - I decided to let passing in the values in case we have multiple date fields on the page (as I believe we will). However, right now it's such that it assumes it will be passed in as day, month, year. Open to changing this and running a check to make sure we match correctly, but I also think we should keep date fields order consistent in the app. Though I'm curious as to what others think!

## Edits
- change `isValidDay` to just check for an int between 1-31, since in all our cases we're comparing against an existing date, we don't need to go wild here
- only put a red border on the field that has the error, or on all of them if the date does not match
- make sure that the inline error list, only lists the associated date errors (and not any others present on the entire form)

<img width="730" alt="Screen Shot 2019-10-10 at 3 37 12 PM" src="https://user-images.githubusercontent.com/6607541/66602847-f1fcf300-eb78-11e9-8a4e-55b0f3189e06.png">

---

![image](https://user-images.githubusercontent.com/6607541/66602884-02ad6900-eb79-11e9-803b-92adf017f16a.png)

---

![image](https://user-images.githubusercontent.com/6607541/66602934-18229300-eb79-11e9-97df-90e1ec21fdcc.png)
