### PR TITLE
Add Azure Application Insights for telemetry purposes

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -127,7 +127,7 @@ You can then find the URL in the JSON response or in the Azure portal. URL shoul
 
 When finished testing, you can delete the Azure App Service webapp using the following command:
 
-`az webapp delete --resource-group cracdscollaborationrg --name claim-tax-benefits-{tag_name}`
+`az webapp delete --resource-group cdscracollab-innovation-rg --name claim-tax-benefits-{tag_name}`
 
 ### All done!
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -42,7 +42,7 @@ Make sure you have the [docker command line interface](https://docs.docker.com/e
 First, run `docker build` and pass in an optional `GITHUB_SHA_ARG`.
 
 ```
-build -t base --build-arg GITHUB_SHA_ARG=codename_cobra .
+docker build -t base --build-arg GITHUB_SHA_ARG=codename_cobra .
 ```
 
 #### Optional env var
@@ -116,6 +116,18 @@ You can also update the app by using the user interface. For a one-off update, t
 8. Wait for it to say `Settings updated successfully`
 
 Usually takes about 2-4 minutes for the live app to switch over. If you built the container with a `GITHUB_SHA_ARG`, you can check the page `<head>` to see the currently running version. If you didn’t — well, you should have.
+
+### Creating a new Azure App Service for testing purposes
+
+In case you don't want to override the live version of the app, you can spin a new instance of App Service for testing purposes by using the following command:
+
+`az webapp create --resource-group cdscracollab-innovation-rg --plan alphaPlan --name claim-tax-benefits-{tag_name} --deployment-container-image-name cdssnc/cra-claim-tax-benefits:{tag_name}`
+
+You can then find the URL in the JSON response or in the Azure portal. URL should nornmally be `https://claim-tax-benefits-{tag_name}.azurewebsites.net`
+
+When finished testing, you can delete the Azure App Service webapp using the following command:
+
+`az webapp delete --resource-group cracdscollaborationrg --name claim-tax-benefits-{tag_name}`
 
 ### All done!
 

--- a/app.js
+++ b/app.js
@@ -1,4 +1,3 @@
- 
 // import environment variables.
 require('dotenv').config()
 const globalError = require('http-errors')
@@ -30,13 +29,14 @@ const express = require('express'),
 // initialize application.
 var app = express()
 
-if (process.env.NODE_ENV !== 'test') {
+if (process.env.NODE_ENV === 'production' && process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
   // register to Azure Application Insights service for telemetry purposes
   // instrumention key is provisioned from Azure App Service application setting (env variable)
   azureApplicationInsights.setup(process.env.APPINSIGHTS_INSTRUMENTATIONKEY).start()
-  // add a request logger
-  app.use(morgan('combined', { stream: winston.stream }))
 }
+
+// add a request logger
+app.use(morgan('combined', { stream: winston.stream }))
 
 // view engine setup
 app.set('views', path.join(__dirname, './views'))

--- a/app.js
+++ b/app.js
@@ -1,9 +1,11 @@
+ 
 // import environment variables.
 require('dotenv').config()
 const globalError = require('http-errors')
 
 // import node modules.
 const express = require('express'),
+  azureApplicationInsights = require('applicationinsights'),
   cookieParser = require('cookie-parser'),
   trimRequest = require('trim-request'),
   compression = require('compression'),
@@ -28,12 +30,17 @@ const express = require('express'),
 // initialize application.
 var app = express()
 
+if (process.env.NODE_ENV !== 'test') {
+  // register to Azure Application Insights service for telemetry purposes
+  // instrumention key is provisioned from Azure App Service application setting (env variable)
+  azureApplicationInsights.setup(process.env.APPINSIGHTS_INSTRUMENTATIONKEY).start()
+  // add a request logger
+  app.use(morgan('combined', { stream: winston.stream }))
+}
+
 // view engine setup
 app.set('views', path.join(__dirname, './views'))
 app.set('view engine', 'pug')
-
-// if NODE_ENV does not equal 'test', add a request logger
-process.env.NODE_ENV !== 'test' && app.use(morgan('combined', { stream: winston.stream }))
 
 // general app configuration.
 app.use(express.json())

--- a/package-lock.json
+++ b/package-lock.json
@@ -996,6 +996,17 @@
       "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.2.1.tgz",
       "integrity": "sha512-91IFKeKk7FjfmezPKkwtaRvSpnUc4gDwPAjA1YZ9Gn0q0PPeW+vbeUsZuyDwjI7+QTHhcLen2v25fi/AmhvbJA=="
     },
+    "applicationinsights": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.4.2.tgz",
+      "integrity": "sha512-1wE37G9zEMZTsPJVQ8BDrQtsGgG3DGMActLHwPAF8TYHAXkfqqpeZYCH0XV4lUZ7H4MffRMwN2Ln2nEtUmT8HQ==",
+      "requires": {
+        "cls-hooked": "^4.2.2",
+        "continuation-local-storage": "^3.2.1",
+        "diagnostic-channel": "0.2.0",
+        "diagnostic-channel-publishers": "^0.3.3"
+      }
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -1119,11 +1130,35 @@
       "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
       "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
     },
+    "async-hook-jl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+      "requires": {
+        "stack-chain": "^1.3.7"
+      }
+    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
+    },
+    "async-listener": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
+      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
+      "requires": {
+        "semver": "^5.3.0",
+        "shimmer": "^1.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1845,6 +1880,23 @@
         "wrap-ansi": "^2.0.0"
       }
     },
+    "cls-hooked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+      "requires": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2055,6 +2107,15 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "continuation-local-storage": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
+      "requires": {
+        "async-listener": "^0.6.0",
+        "emitter-listener": "^1.1.1"
+      }
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -2463,6 +2524,26 @@
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
     },
+    "diagnostic-channel": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
+      "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
+      "requires": {
+        "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "diagnostic-channel-publishers": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.3.tgz",
+      "integrity": "sha512-qIocRYU5TrGUkBlDDxaziAK1+squ8Yf2Ls4HldL3xxb/jzmWO2Enux7CvevNKYmF2kDXZ9HiRqwjPsjk8L+i2Q=="
+    },
     "diagnostics": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
@@ -2605,6 +2686,14 @@
       "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
+    },
+    "emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "requires": {
+        "shimmer": "^1.2.0"
+      }
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -8862,6 +8951,11 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -9128,6 +9222,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
+    },
+    "stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
     },
     "stack-trace": {
       "version": "0.0.10",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "app-root-path": "^2.2.1",
+    "applicationinsights": "^1.4.2",
     "compression": "^1.7.4",
     "cookie-parser": "~1.4.4",
     "cookie-session": "^1.3.3",


### PR DESCRIPTION
### This PR consists in
- adding Azure App Insights dependency to gather metrics and tracing logs.
- register the App Insights through an instrumentation key that is defined in Azure and injected as an environment variable only when live (will not register when deploying locally).
- added documentation as for deploying to a new custom Azure App Service for testing purposes.