### PR TITLE
copy update for property tax pages

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -192,7 +192,6 @@
   "Month": "Month",
   "Year": "Year",
   "Rent paid in 2018": "Rent paid in 2018",
-  "Deduct your property tax": "Deduct your property tax",
   "If you paid property tax in 2018, you may be entitled to receive credits from your": "If you paid property tax in 2018, you may be entitled to receive credits from your",
   "Did you pay property tax in 2018?": "Did you pay property tax in 2018?",
   "Deduct your home energy costs on a reserve": "Deduct your home energy costs on a reserve",
@@ -277,7 +276,6 @@
   "Your child’s date of birth": "Your child’s date of birth",
   "Apply for the OTB: property tax": "Apply for OTB: property tax",
   "Did you pay property tax for the place you lived most of 2018?": "Did you pay property tax for the place you lived most of 2018?",
-  "Enter your property tax payments to apply for OTB": "Enter your property tax payments to apply for OTB",
   "The government might ask for your property tax receipts.": "The government might ask for your property tax receipts.",
   "How much total property tax did you pay for the place you lived most of 2018?": "How much total property tax did you pay for the place you lived most of 2018?",
   "Deduct your rent payments": "Deduct your rent payments",
@@ -301,7 +299,6 @@
   "Enter your political contributions": "Enter your political contributions",
   "true": true,
   "https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html": "https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/ontario-trillium-benefit-questions-answers.html",
-  "Apply for OTB: property tax": "Apply for OTB: property tax",
   "Your last two mailing addresses before your current address": "Your last two mailing addresses before your current address",
   "Enter the last two mailing addresses before your current address": "Enter the last two mailing addresses before your current address",
   "You must have used both addresses to file taxes. Choose a different question if you haven’t filed taxes from at least two other addresses.": "You must have used both addresses to file taxes. Choose a different question if you haven’t filed taxes from at least two other addresses.",
@@ -427,5 +424,7 @@
   "You agree that CRA can use this information to file your 2018 taxes.": "You agree that CRA can use this information to file your 2018 taxes.",
   "Registered Retirement Savings Plan (RRSP) contributions": "Registered Retirement Savings Plan (RRSP) contributions",
   "Learn about RRSPs": "Learn about RRSPs",
-  "Political contributions": "Political contributions"
+  "Political contributions": "Political contributions",
+  "Property tax": "Property tax",
+  "Enter your property tax": "Enter your property tax"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -175,7 +175,6 @@
   "Day": "Jour",
   "Month": "Mois",
   "Year": "Année",
-  "Deduct your property tax": "Deduct your property tax",
   "If you paid property tax in 2018, you may be entitled to receive credits from your": "If you paid property tax in 2018, you may be entitled to receive credits from your",
   "Did you pay property tax in 2018?": "Did you pay property tax in 2018?",
   "Deduct your home energy costs on a reserve": "Deduct your home energy costs on a reserve",
@@ -250,7 +249,6 @@
   "I can’t answer these questions": "Je ne peux pas répondre à ces questions",
   "Apply for the OTB: property tax": "Apply for OTB: property tax",
   "Did you pay property tax for the place you lived most of 2018?": "Did you pay property tax for the place you lived most of 2018?",
-  "Enter your property tax payments to apply for OTB": "Enter your property tax payments to apply for OTB",
   "The government might ask for your property tax receipts.": "The government might ask for your property tax receipts.",
   "How much total property tax did you pay for the place you lived most of 2018?": "How much total property tax did you pay for the place you lived most of 2018?",
   "The Ontario Trillium Benefit": "The Ontario Trillium Benefit",
@@ -382,5 +380,7 @@
   "You agree that CRA can use this information to file your 2018 taxes.": "You agree that CRA can use this information to file your 2018 taxes.",
   "Registered Retirement Savings Plan (RRSP) contributions": "Registered Retirement Savings Plan (RRSP) contributions",
   "Learn about RRSPs": "Learn about RRSPs",
-  "Political contributions": "Political contributions"
+  "Political contributions": "Political contributions",
+  "Property tax": "Property tax",
+  "Enter your property tax": "Enter your property tax"
 }

--- a/views/deductions/trillium-propertyTax-amount.pug
+++ b/views/deductions/trillium-propertyTax-amount.pug
@@ -1,7 +1,7 @@
 extends ../base
 
 block variables
-  -var title = __('Enter your property tax payments to apply for OTB')
+  -var title = __('Enter your property tax')
   -var trilliumPropertyTaxAmount = hasData(data, 'deductions.trilliumPropertyTaxAmount') &&  data.deductions.trilliumPropertyTaxAmount !== 0 ? data.deductions.trilliumPropertyTaxAmount : ''
 
 block content

--- a/views/deductions/trillium-propertyTax.pug
+++ b/views/deductions/trillium-propertyTax.pug
@@ -1,7 +1,7 @@
 extends ../base
 
 block variables
-  -var title = __('Apply for OTB: property tax')
+  -var title = __('Property tax')
   -var trilliumPropertyTaxClaim = !hasData(data, 'deductions.trilliumPropertyTaxClaim') ? '' : data.deductions.trilliumPropertyTaxClaim ? 'Yes' : 'No'
 
 block content


### PR DESCRIPTION
## Updating the content on the `/trillium/propertyTax` and `/trillium/propertyTax/amount` pages

Resolves #246 , resolves #247    
- Updated page content based on issues above
- Deleted unused translation keys
- make sure new translation keys are added

![localhost_3005_trillium_propertyTax](https://user-images.githubusercontent.com/6607541/67122796-9f48ba00-f1bc-11e9-8a5b-d878afc57a75.png)
![localhost_3005_trillium_propertyTax_amount_lang=en](https://user-images.githubusercontent.com/6607541/67122799-a079e700-f1bc-11e9-9317-9e1010dead0b.png)
