### PR TITLE
copy update- have the link on /trillium/studentResidence open in a new tab

### DIFF
--- a/views/deductions/trillium-studentResidence.pug
+++ b/views/deductions/trillium-studentResidence.pug
@@ -13,7 +13,7 @@ block content
 
     div
       p
-        <a href=#{__('https://www.ontario.ca/data/designated-postsecondary-residences')}>#{__('Check if you live in a student residence')}</a> 
+        <a href=#{__('https://www.ontario.ca/data/designated-postsecondary-residences')} target="_blank">#{__('Check if you live in a student residence')}</a> 
 
     input#redirect(name='redirect', type='hidden', value='/trillium/energy')
 


### PR DESCRIPTION
## Updating the content on the `/trillium/studentResidence` page

Resolves #257 
- Make sure the link for "Check if you live in a student residence" opens in a new tab (add a `target="_blank"`)