### PR TITLE
Remove the aria-expanded JS that we don't use anymore

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -14,21 +14,3 @@ for (var i = 0, len = elements.length; i < len; i++) {
     }
   })
 }
-
-// Add aria labels to the revealing/concealing content underneath "yes/no" radios
-var noInfoBox = document.getElementsByClassName('no-info')[0]
-if (noInfoBox) {
-  var yesNoRadios = document.querySelectorAll('div.multiple-choice__item')
-
-  var noInput = yesNoRadios[1]
-
-  for (var i = 0, len = yesNoRadios.length; i < len; i++) {
-    yesNoRadios[i].addEventListener('click', function(e) {
-      if (e.target.value === 'No') {
-        noInput.setAttribute('aria-expanded', 'true')
-      } else {
-        noInput.setAttribute('aria-expanded', 'false')
-      }
-    })
-  }
-}


### PR DESCRIPTION
We were using this previously when selecting "No" in a Yes/No button situation would reveal extra information.

We're not doing that anymore, so let's delete.