### PR TITLE
Task/Preserve query params between `/` and `/start`

### DIFF
--- a/config/morgan.config.js
+++ b/config/morgan.config.js
@@ -1,10 +1,6 @@
 var morgan = require('morgan')
 
-morgan.token('sessionId', function getSessionId(req) {
-  return req.sessionId
-})
-
-morgan.token('err', function getSessionId(req, res) {
+morgan.token('err', function getErr(req, res) {
   return res.locals.err
 })
 
@@ -31,7 +27,6 @@ function jsonFormatProduction(tokens, req, res) {
     'content-length': tokens['res'](req, res, 'content-length'),
     referrer: tokens['referrer'](req, res),
     'user-agent': tokens['user-agent'](req, res),
-    sessionId: tokens['sessionId'](req, res),
     err: tokens['err'](req, res),
   })
 }

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -113,7 +113,7 @@ const postLoginCode = async (req, res, next) => {
 
   if (!errors.isEmpty()) {
     // clear session
-    req.session = null
+    req.session.destroy()
 
     return res.status(422).render('login/code', {
       prevRoute: getPreviousRoute(req),

--- a/routes/start/start.controller.js
+++ b/routes/start/start.controller.js
@@ -1,6 +1,11 @@
+const url = require('url')
+
 module.exports = function(app) {
   // redirect from "/" → "/start"
-  app.get('/', (req, res) => res.redirect('/start'))
+  // preserve query params
+  app.get('/', (req, res) => {
+    return res.redirect(url.format({ pathname: '/start', query: req.query }))
+  })
   app.get('/start', (req, res) => res.render('start/index'))
 
   // loads the site in french from the get-go

--- a/routes/start/start.spec.js
+++ b/routes/start/start.spec.js
@@ -9,6 +9,12 @@ describe('Test server responses', () => {
     expect(response.headers.location).toEqual('/start')
   })
 
+  test('it redirects to /start and saves query parameters for the root path', async () => {
+    const response = await request(app).get('/?dinosaur=albertosaurus')
+    expect(response.statusCode).toBe(302)
+    expect(response.headers.location).toEqual('/start?dinosaur=albertosaurus')
+  })
+
   test('it returns a 200 response for the /start path', async () => {
     const response = await request(app).get('/start')
     expect(response.statusCode).toBe(200)


### PR DESCRIPTION
Keep the query params intact between / and /start

Also removed the session id stuff in our logging code, since we don't need it.