### PR TITLE
Task/App version in prod logs 🌲

### DIFF
--- a/config/morgan.config.js
+++ b/config/morgan.config.js
@@ -1,5 +1,9 @@
 var morgan = require('morgan')
 
+morgan.token('version', function getSha() {
+  return process.env.GITHUB_SHA
+})
+
 morgan.token('err', function getErr(req, res) {
   return res.locals.err
 })
@@ -28,5 +32,6 @@ function jsonFormatProduction(tokens, req, res) {
     referrer: tokens['referrer'](req, res),
     'user-agent': tokens['user-agent'](req, res),
     err: tokens['err'](req, res),
+    version: tokens['version'](),
   })
 }


### PR DESCRIPTION
## Add version number to production logs

Since we're putting the github sha in the <head> of the app, this is effectively the version we're running.

Let's stick it in the prod logs if it exists so that we can debug more effectively.