### PR TITLE
Add robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Disallow all pages from being indexed.

At this point, we're not public, so no crawlers. 🕷

The reason for this is that our error logs keep picking up a "not found" error for `/robots.txt` that chrome appears to be doing automatically. Not a big deal to add one, so let's just do it.