### PR TITLE
Task/sin lowercase

### DIFF
--- a/cypress/utils.js
+++ b/cypress/utils.js
@@ -94,8 +94,8 @@ const logIn = (cy, user) => {
   // LOGIN SIN
   cy.injectAxe().checkA11y()
   cy.url().should('contain', '/login/sin')
-  cy.get('h1').should('contain', 'Enter your Social Insurance Number (SIN)')
-  cy.get('h2').should('contain', `Thanks, ${user.personal.firstName} ${user.personal.lastName}!`)
+  cy.get('h1').should('contain', 'Enter your Social insurance number (SIN)')
+  cy.get('h2').should('contain', `${user.personal.firstName}, thanks for your filing code.`)
   cy.get('form label').should('have.attr', 'for', 'sin')
   cy.get('form input#sin')
     .type(user.personal.sin)

--- a/locales/en.json
+++ b/locales/en.json
@@ -419,5 +419,6 @@
   "Property tax": "Property tax",
   "Enter your property tax": "Enter your property tax",
   "Your code has 9-characters and you can find it on the CRA": "Your code has 9-characters and you can find it on the CRA",
-  " letter. The letter has your name and address at the top.": " letter. The letter has your name and address at the top."
+  " letter. The letter has your name and address at the top.": " letter. The letter has your name and address at the top.",
+  "Confirm": "Confirm"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -40,7 +40,7 @@
   "start.p2": "You will need your:",
   "start.li4.1": "Personal filing code. You can find this code in the CRA letter about this new",
   "start.li4.2": " service.",
-  "start.li5": "Social Insurance Number (SIN).",
+  "start.li5": "Social insurance number (SIN).",
   "start.li6": "Income information.",
   "button.start": "Start now",
   "Please correct the errors on the page": "Please correct the errors on the page",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -384,5 +384,6 @@
   "Property tax": "Property tax",
   "Enter your property tax": "Enter your property tax",
   "Your code has 9-characters and you can find it on the CRA": "Your code has 9-characters and you can find it on the CRA",
-  " letter. The letter has your name and address at the top.": " letter. The letter has your name and address at the top."
+  " letter. The letter has your name and address at the top.": " letter. The letter has your name and address at the top.",
+  "Confirm": "Confirmer"
 }


### PR DESCRIPTION
Update to "Social insurance number" on first page.

This is how CRA refers to it: https://www.canada.ca/en/revenue-agency/services/tax/individuals/topics/about-your-tax-return/tax-return/completing-a-tax-return/personal-address-information/social-insurance-number.html

Resolves #272 


(Also updated the cypress tests)

## Screenshot

<img width="1527" alt="Screen Shot 2019-10-21 at 4 43 19 PM" src="https://user-images.githubusercontent.com/2454380/67241768-0ca95480-f422-11e9-8ecb-209671c6eaed.png">
