### PR TITLE
Don't run jest coverage for /cypress, /coverage, or /public folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "collectCoverage": true,
     "collectCoverageFrom": [
       "**/*.js",
-      "!**/node_modules/**"
+      "!**/coverage/**",
+      "!**/cypress/**",
+      "!**/node_modules/**",
+      "!**/public/**"
     ],
     "coverageReporters": [
       "json",


### PR DESCRIPTION
We've turned test coverage on, but it's looking in some folders that don't make sense, so let's turn that off.