### PR TITLE
fix/Remove node max header size

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
   },
   "scripts": {
     "dev": "nodemon --max-http-header-size=40000 ./bin/www",
-    "lint": "node_modules/eslint/bin/eslint.js config routes bin/www app.js",
-    "start": "NODE_ENV=production node --max-http-header-size=40000 ./bin/www",
+    "lint": "node ./node_modules/eslint/bin/eslint.js config routes bin/www app.js",
+    "start": "NODE_ENV=production node ./bin/www",
+    "start:cypress": "NODE_ENV=test node ./bin/www",
     "test": "node node_modules/jest/bin/jest.js",
     "cypress:open": "./node_modules/.bin/cypress open",
     "cypress": "start-server-and-test start:cypress http://localhost:3005 cypress:open",
     "cypress:run": "./node_modules/.bin/cypress run",
     "cypress:cli": "start-server-and-test start:cypress http://localhost:3005 cypress:run",
-    "start:cypress": "NODE_ENV=test node ./bin/www",    
     "sonar": "sonar-scanner"
   },
   "dependencies": {


### PR DESCRIPTION
Removed the max header size flag from the `npm start` command.

When we were using cookie session previously, we started to get weird 400-level errors because our headers were getting huge because we were storing so much information in the cookies.

Bumping the header size resolved this for us, but it's caused problems running the app cross-platform (for example, on github actions or on windows).

Now that we've moved away from cookie session, we don't need this instruction anymore because we don't have very large headers, so let's get rid of it.

Also added "node" command to the 'eslint' script so that it's more resilient.

Sources:
- Adding the option: https://github.com/cds-snc/cra-claim-tax-benefits/pull/92
- Removing cookie-session: https://github.com/cds-snc/cra-claim-tax-benefits/pull/292