### PR TITLE
Survey: Don't set the sameSite cookie attribute

### DIFF
--- a/config/session.config.js
+++ b/config/session.config.js
@@ -8,7 +8,7 @@ const sessionName = `ctb-${process.env.SESSION_SECRET ||
 // default setup: https://github.com/roccomuso/memorystore#setup
 // options: https://github.com/expressjs/session#options
 module.exports = session({
-  cookie: { httpOnly: true, maxAge: oneHour, sameSite: 'strict' },
+  cookie: { httpOnly: true, maxAge: oneHour, sameSite: 'none' },
   store: new MemoryStore({
     checkPeriod: oneHour, // prune expired entries every hour
   }),


### PR DESCRIPTION
The same site cookie attribute means that cookies are only kept for
the same URL. Since we're doing the survey in an iframe on another
URL, all our sessions (and request IDs) are getting dropped.

Setting this to none is less safe but it actually works so 🤷‍♀️