### PR TITLE
Ignore non-production directories when building container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 node_modules
+scripts
+cypress
+coverage
 .git
 .gitignore
+.vscode


### PR DESCRIPTION
There're a few directories that we don't need for the production application but that are getting copied over anyway. Removing these should reduce the size of the container somewhat (and they do!).

This is what happened when I built locally before vs after these changes 👇 

![image](https://user-images.githubusercontent.com/2454380/67598384-661fc500-f73b-11e9-8763-a36a3e0e4fab.png)
