### PR TITLE
Fix/Format of Filing code or SIN are changed if answer is wrong

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -4,14 +4,14 @@ var API = (function(userFound) {
   const _user = userFound
 
   const getUser = code => {
-    if (code === _user.login.code) {
+    if (code && code.toUpperCase() === _user.login.code) {
       return _user
     }
 
     return null
   }
 
-  const getMatches = () => [_user.login.code]
+  const getMatches = () => [_user.login.code.toLowerCase(), _user.login.code.toUpperCase()]
 
   return {
     getUser,

--- a/api/index.spec.js
+++ b/api/index.spec.js
@@ -3,8 +3,15 @@ const API = require('./index')
 test('returns expected user with correct login.code', () => {
   const user = API.getUser('A5G98S4K1')
   expect(user).not.toBe(null)
-  expect(user.personal.firstName).toBe('Gabrielle')
-  expect(user.personal.lastName).toBe('Roy')
+  expect(user.personal.firstName).toEqual('Gabrielle')
+  expect(user.personal.lastName).toEqual('Roy')
+})
+
+test('returns expected user with correct login.code lowercased', () => {
+  const user = API.getUser('a5g98s4k1')
+  expect(user).not.toBe(null)
+  expect(user.personal.firstName).toEqual('Gabrielle')
+  expect(user.personal.lastName).toEqual('Roy')
 })
 
 test('returns null with a nonexistent login.code', () => {
@@ -15,5 +22,11 @@ test('returns null with a nonexistent login.code', () => {
 test('returns matching login code as an array', () => {
   const codes = API.getMatches()
   expect(codes).toBeInstanceOf(Array)
-  expect(codes.length).toBe(1)
+  expect(codes.length).toBe(2)
+})
+
+test('returns matching login codes as uppercase and lowercase', () => {
+  const codes = API.getMatches()
+  expect(codes[0]).toEqual('a5g98s4k1')
+  expect(codes[1]).toEqual('A5G98S4K1')
 })

--- a/locales/en.json
+++ b/locales/en.json
@@ -5,7 +5,7 @@
   "errors.login.numericSIN": "Your SIN should only be numbers",
   "errors.login.lengthSIN": "Your SIN should have 9 numbers",
   "errors.maritalStatus.maritalStatus": "Please select one of the options",
-  "errors.login.sin": "SIN does not match access code",
+  "errors.login.matchingSIN": "SIN does not match access code",
   "errors.login.dateOfBirth": "Please enter a valid birth date",
   "errors.login.dateOfBirth.match": "Date of birth does not match access code",
   "errors.login.dateOfBirth.format": "Make sure the date is formatted as yyyy/mm/dd",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -5,7 +5,7 @@
   "errors.login.numericSIN": "Votre numéro d’assurance sociale devrait être composé de 9 chiffres",
   "errors.login.lengthSIN": "Votre numéro d’assurance sociale doit contenir 9 chiffres",
   "errors.maritalStatus.maritalStatus": "Vous devez choisir l’une des options",
-  "errors.login.sin": "Le NAS ne correspond pas au code d’accès",
+  "errors.login.matchingSIN": "Le NAS ne correspond pas au code d’accès",
   "errors.login.dateOfBirth": "Veuillez inscrire une date de naissance valide",
   "errors.login.dateOfBirth.match": "La date de naissance ne correspond pas au code d’accès",
   "errors.login.dateOfBirth.format": "Assurez-vous que la date respecte le format aaaa/mm/jj",

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -106,7 +106,14 @@ describe('Test /login responses', () => {
     expect(response.statusCode).toBe(422)
   })
 
-  const codes = ['A5G98S4K1', 'a5g98S4K1', 'a5g98s4k1'] //check uppercase, lowercase and mixedcase
+  test('it does not allow a mixed-case code', async () => {
+    const response = await request(app)
+      .post('/login/code')
+      .send({ code: 'a5G98s4K1', redirect: '/start' })
+    expect(response.statusCode).toBe(422)
+  })
+
+  const codes = ['A5G98S4K1', 'a5g98s4k1'] //check uppercase, lowercase
   codes.map(code => {
     test(`it redirects if a valid code is provided: "${code}"`, async () => {
       const response = await request(app)

--- a/schemas/login.schema.js
+++ b/schemas/login.schema.js
@@ -11,11 +11,6 @@ const loginSchema = {
     isAlphanumeric: {
       errorMessage: 'errors.login.alphanumeric',
     },
-    customSanitizer: {
-      options: value => {
-        return value ? value.toUpperCase() : value
-      },
-    },
     isIn: {
       options: [API.getMatches()],
       errorMessage: 'errors.login.code',

--- a/schemas/login.schema.test.js
+++ b/schemas/login.schema.test.js
@@ -1,25 +1,57 @@
-const { lastDayInMonth, toISOFormat } = require('./index')
+const { _toISOFormat, _getSinErrorMessage } = require('./index')
 
-describe('Test toISOFormat', () => {
+describe('Test _toISOFormat', () => {
   const _date = { dobYear: '1957', dobMonth: '12', dobDay: '05' }
 
   test('converts standard date to ISO date', () => {
     let date = _date
-    expect(toISOFormat(date)).toEqual('1957-12-05')
+    expect(_toISOFormat(date)).toEqual('1957-12-05')
   })
 
   test('converts date with one digit month to ISO date', () => {
     let date = { ..._date, ...{ dobMonth: '1' } }
-    expect(toISOFormat(date)).toEqual('1957-01-05')
+    expect(_toISOFormat(date)).toEqual('1957-01-05')
   })
 
   test('converts date with one digit day to ISO date', () => {
     let date = { ..._date, ...{ dobDay: '1' } }
-    expect(toISOFormat(date)).toEqual('1957-12-01')
+    expect(_toISOFormat(date)).toEqual('1957-12-01')
   })
 
   test('converts date with one digit day and one digit month to ISO date', () => {
     let date = { ..._date, ...{ dobMonth: '2', dobDay: '1' } }
-    expect(toISOFormat(date)).toEqual('1957-02-01')
+    expect(_toISOFormat(date)).toEqual('1957-02-01')
+  })
+})
+
+describe('Test _getSinErrorMessage', () => {
+  test('returns error message for no SIN', () => {
+    expect(_getSinErrorMessage()).toEqual('errors.login.lengthSIN')
+  })
+
+  test('returns error message for empty string', () => {
+    expect(_getSinErrorMessage('')).toEqual('errors.login.lengthSIN')
+  })
+
+  test('returns error message for non-numeric SIN', () => {
+    expect(_getSinErrorMessage('123 456 AAA')).toEqual('errors.login.numericSIN')
+  })
+
+  const badLengthSins = ['1', '123 456 789 0', '123-456-78']
+  badLengthSins.map(badLengthSin => {
+    test(`returns error message for a SIN that’s more than 9 chars: ${badLengthSin}`, () => {
+      expect(_getSinErrorMessage(badLengthSin)).toEqual('errors.login.lengthSIN')
+    })
+  })
+
+  test('returns error message for a SIN that doesn’t match the expected SIN', () => {
+    expect(_getSinErrorMessage('123 456 789', '111 111 111')).toEqual('errors.login.matchingSIN')
+  })
+
+  const matchingSins = ['123456789', '123 456 789', '123-456-789', '  1-2-3 4 5 6 7_8_9  ']
+  matchingSins.map(matchingSin => {
+    test(`returns no error message for a matching SIN: ${matchingSin}`, () => {
+      expect(_getSinErrorMessage(matchingSin, '123456789')).toBe(false)
+    })
   })
 })


### PR DESCRIPTION
As a tax filer entering my SIN or my Filing code, I want to see the same thing I typed when I get a validation error.

Up to now, we have been sanitizing the passed-in value before validating it.

- with the filing code, we would uppercase everything
- with the SIN, we would remove spaces and hyphens and underscores

Unfortunately, sanitizing it would also mutate the submitted value, so repopulating the form would show an error but then display back to the user something they probably never typed in.

Like if I submitted "123 456 78", it would come back as "12345678".

So it's telling you you're wrong, but it also rewrote what you sent in. That's not really fair.

This PR changes the schema logic so that you will see the same error messages as before, but you will see the values you typed in. Only new behaviour is that we don't allow mixed-case access codes anymore, but other than that, the functionality and error messages are meant to be identical. 

## gifs

### Access code would always be uppercased
| before | after |
|--------|-------|
| ![Screen Recording 2019-10-28 at 12 48 31 PM](https://user-images.githubusercontent.com/2454380/67700260-06682a80-f984-11e9-99fd-a87468a56c6b.gif)   |  ![Screen Recording 2019-10-28 at 12 51 47 PM](https://user-images.githubusercontent.com/2454380/67700261-06682a80-f984-11e9-9fad-d16478e2ea41.gif)    |

### SIN would be cleared of spaces, hyphens, underscores

| before | after |
|--------|-------|
|   ![Screen Recording 2019-10-28 at 12 54 03 PM](https://user-images.githubusercontent.com/2454380/67700273-0e27cf00-f984-11e9-9d39-1c842241c446.gif)  |  ![Screen Recording 2019-10-28 at 12 53 11 PM](https://user-images.githubusercontent.com/2454380/67700274-0e27cf00-f984-11e9-8679-1ce2d39d9d98.gif)    |



