### PR TITLE
Dollar sign switches from left-side to right-side on french toggle

### DIFF
--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -146,7 +146,7 @@ form.cra-form {
     &.fr {
       padding-left: 0;
       margin-left: 0;
-      padding-right: $space-xl;
+      padding-right: $space-xl + $space-xs;
       margin-right: -$space-xl;
     }
   }

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -142,6 +142,13 @@ form.cra-form {
       margin-left: -$space-xl;
       z-index: 20;
     }
+
+    &.fr {
+      padding-left: 0;
+      margin-left: 0;
+      padding-right: $space-xl;
+      margin-right: -$space-xl;
+    }
   }
 
   span.input-with-unit__unit {

--- a/views/_includes/input-text.pug
+++ b/views/_includes/input-text.pug
@@ -20,15 +20,21 @@ mixin textInput(label, divClasses, hintText)
         errors[attributes.name].msg,
         attributes.name
       )
-    if attributes.class && attributes.class.includes('input-with-unit')
+    if attributes.class && attributes.class.includes('input-with-unit') && getLocale() === 'en'
       span.input-with-unit__unit(
         id!=attributes.name+'__unit'
       ) $
 
     input(
+      class=getLocale()    
       autocomplete='off',
       type='text',
       id=(attributes.id || attributes.name)
       aria-describedby=(errors && errors[attributes.name] ? attributes.name + '-error' : false)
       autofocus=(errors && firstError.param === attributes.name ? true : false)
     )&attributes(attributes)
+
+    if attributes.class && attributes.class.includes('input-with-unit') && getLocale() === 'fr'
+      span.input-with-unit__unit(
+        id!=attributes.name+'__unit'
+      ) $


### PR DESCRIPTION
## This PR consists of the following:

### Dollar sign on french inputs
- English formatting for dollar amounts is as follows $0.00, and French formatting of dollar amounts is 0,00$ (the dollar sign is fixed to the right side of the number and not the left)
- The dollar sign now flips sides on language toggle
- I added a `&.fr` css rule to the `input` class on `forms.scss`
- This rule is toggled by adding `class=getLocale()` to the `textInput()` mixin

### GIF 
![frInputs](https://user-images.githubusercontent.com/30609058/67974929-a4a8fa00-fbe9-11e9-97b4-dcda40dc454d.gif)

### Based on this [trello card](https://trello.com/c/iaDfs0wk)