### PR TITLE
Add blue banner for confirmation code

### DIFF
--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -128,6 +128,31 @@ li:not(:last-of-type) {
   }
 }
 
+.confirmation-table {
+  width: 100%;
+  margin-bottom: $space-sm;
+  color: white;
+  background-color: $color-blue-light;
+  border: 3px solid $color-solid-blue;
+  text-align: center;
+  font-size: 24pt;
+  margin-bottom: 1.5em;
+
+  @include sm {
+    width: 80%;
+  }
+
+  thead th {
+    padding-top: 1em;
+    font-weight: normal;
+  }
+
+  tbody td {
+    padding-bottom: 1em;
+    font-weight: bold;
+  }
+}
+
 .buttons-row {
   a,
   button {

--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -133,7 +133,7 @@ li:not(:last-of-type) {
   margin-bottom: $space-sm;
   color: white;
   background-color: $color-blue-light;
-  border: 3px solid $color-solid-blue;
+  border: 3px solid $color-blue-solid;
   text-align: center;
   font-size: 24pt;
   margin-bottom: 1.5em;

--- a/public/scss/_variables.scss
+++ b/public/scss/_variables.scss
@@ -4,7 +4,7 @@ $color-blue-dark: #284162;
 $color-blue-light: #335075;
 $color-banner-blue: #4B98B2;
 $color-banner-blue-light: #DFF8FD;
-$color-solid-blue: #0078FB;
+$color-blue-solid: #0078FB;
 $color-yellow: #ffbf47;
 $color-white: #ffffff;
 $color-black: #000000;

--- a/public/scss/_variables.scss
+++ b/public/scss/_variables.scss
@@ -4,6 +4,7 @@ $color-blue-dark: #284162;
 $color-blue-light: #335075;
 $color-banner-blue: #4B98B2;
 $color-banner-blue-light: #DFF8FD;
+$color-solid-blue: #0078FB;
 $color-yellow: #ffbf47;
 $color-white: #ffffff;
 $color-black: #000000;

--- a/views/confirmation/confirmation.pug
+++ b/views/confirmation/confirmation.pug
@@ -8,7 +8,7 @@ block content
   h1 #{title}
 
   div
-    table.pure-table
+    table.confirmation-table
       thead
         tr
           th #{__('Your 2018 filing code is')}


### PR DESCRIPTION
Addresses the other half of #340 , implementing the banner shown in https://trello.com/c/i1twNn0Q/371-updates-to-confirmation-page