### PR TITLE
Refactor the doYesNo middleware

### DIFF
--- a/routes/deductions/deductions.spec.js
+++ b/routes/deductions/deductions.spec.js
@@ -2,7 +2,6 @@ const request = require('supertest')
 const app = require('../../app.js')
 
 describe('Test /deductions responses', () => {
-
   describe('Test /deductions/* yesNo responses', () => {
     const yesNoResponses = [
       {
@@ -108,19 +107,19 @@ describe('Test /deductions responses', () => {
       expect(response.statusCode).toBe(422)
     })
 
-    test('it redirects to the /trillium/longTermCare page when selecting No', async () => {
+    test('it redirects to the provided redirect value page when selecting No', async () => {
       const response = await request(app)
         .post('/trillium/energy/reserve')
-        .send({ trilliumEnergyReserveClaim: 'No' })
-      expect(response.headers.location).toEqual('/trillium/longTermCare')
+        .send({ trilliumEnergyReserveClaim: 'No', redirect: '/start' })
+      expect(response.headers.location).toEqual('/start')
       expect(response.statusCode).toBe(302)
     })
 
-    test('it redirects to the provided redirect value when selecting Yes', async () => {
+    test('it redirects to "/trillium/energy/cost" when selecting Yes', async () => {
       const response = await request(app)
         .post('/trillium/energy/reserve')
-        .send({ redirect: '/start', trilliumEnergyReserveClaim: 'Yes' })
-      expect(response.headers.location).toEqual('/start')
+        .send({ trilliumEnergyReserveClaim: 'Yes' })
+      expect(response.headers.location).toEqual('/trillium/energy/cost')
       expect(response.statusCode).toBe(302)
     })
 
@@ -140,19 +139,19 @@ describe('Test /deductions responses', () => {
       expect(response.statusCode).toBe(422)
     })
 
-    test('it redirects to the /deductions/climate-action-incentive page when selecting No', async () => {
+    test('it redirects to the provided redirect value when selecting No', async () => {
       const response = await request(app)
         .post('/trillium/longTermCare')
-        .send({ trilliumLongTermCareClaim: 'No' })
-      expect(response.headers.location).toEqual('/deductions/climate-action-incentive')
+        .send({ trilliumLongTermCareClaim: 'No', redirect: '/start' })
+      expect(response.headers.location).toEqual('/start')
       expect(response.statusCode).toBe(302)
     })
 
-    test('it redirects to the provided redirect value when selecting Yes', async () => {
+    test('it redirects to "/trillium/longTermCare/type" when selecting Yes', async () => {
       const response = await request(app)
         .post('/trillium/longTermCare')
-        .send({ redirect: '/start', trilliumLongTermCareClaim: 'Yes' })
-      expect(response.headers.location).toEqual('/start')
+        .send({ trilliumLongTermCareClaim: 'Yes' })
+      expect(response.headers.location).toEqual('/trillium/longTermCare/type')
       expect(response.statusCode).toBe(302)
     })
 

--- a/views/deductions/climate-action-incentive.pug
+++ b/views/deductions/climate-action-incentive.pug
@@ -2,7 +2,7 @@ extends ../base
 
 block variables
   -var title = __('Small and rural communities')
-  -var climateActionIncentiveIsRural = hasData(data, 'deductions.climateActionIncentiveIsRural') ? data.deductions.climateActionIncentiveIsRural : ''
+  -var climateActionIncentiveIsRural = !hasData(data, 'deductions.climateActionIncentiveIsRural') ? '' : data.deductions.climateActionIncentiveIsRural ? 'Yes' : 'No'
 
 block content
 

--- a/views/deductions/trillium-energy-reserve.pug
+++ b/views/deductions/trillium-energy-reserve.pug
@@ -11,6 +11,6 @@ block content
   form.cra-form(method='post')
     +radiosYesNo('trilliumEnergyReserveClaim', 'In 2018, did you live on a reserve?', trilliumEnergyReserveClaim)
 
-    input#redirect(name='redirect', type='hidden', value='/trillium/energy/cost')
+    input#redirect(name='redirect', type='hidden', value='/trillium/longTermCare')
 
     +formButtons()

--- a/views/deductions/trillium-longTermCare.pug
+++ b/views/deductions/trillium-longTermCare.pug
@@ -8,12 +8,12 @@ block content
 
   h1 #{title}
 
-  div 
+  div
     p #{__('You may live in a long-term care home or facility if costs such as nursing or personal support are combined with your rent.')}
 
   form.cra-form(method='post')
     +radiosYesNo('trilliumLongTermCareClaim', 'Did you live in a long-term care home in 2018?', trilliumLongTermCareClaim)
 
-    input#redirect(name='redirect', type='hidden', value='/trillium/longTermCare/type')
+    input#redirect(name='redirect', type='hidden', value='/deductions/climate-action-incentive')
 
     +formButtons()


### PR DESCRIPTION
Previously we always had "yes" or "no" pages in front of "amount" pages, so I wrote a pretty basic middleware that assumed this would always be the case.

Now that it is no longer the case, we have weird functions that do a bunch of copy+paste stuff and we gotta get rid of that nonsense.

Updated the doYesNo function so that it can handle nulling out more than just the "amount" variable, and it's no longer hardcoded to use the path + "/amount" url that we were assuming before.

The changes from how "doYesNo" worked before are:
- we pass in an array of fields as the second parameter rather than just the "Amount" string
- the redirect isn't hardcoded anymore, instead we're using the "routes" array to pick the next url to go to