### PR TITLE
Fix/Cheerio as a devDependency again

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "app-root-path": "^3.0.0",
     "applicationinsights": "^1.6.0",
-    "cheerio": "^1.0.0-rc.3",
     "compression": "^1.7.4",
     "cookie-parser": "~1.4.4",
     "csurf": "^1.10.0",
@@ -68,6 +67,7 @@
   },
   "devDependencies": {
     "axe-core": "^3.4.0",
+    "cheerio": "^1.0.0-rc.3",
     "cypress": "^3.6.1",
     "cypress-axe": "^0.5.1",
     "eslint": "^6.6.0",

--- a/routes/confirmation/confirmation.spec.js
+++ b/routes/confirmation/confirmation.spec.js
@@ -1,5 +1,5 @@
 const request = require('supertest')
-const { extractCsrfToken } = require('../../utils/index')
+const { extractCsrfToken } = require('../utils.spec')
 const app = require('../../app.js')
 
 describe('Test confirmation urls', () => {
@@ -16,8 +16,7 @@ describe('Test confirmation urls', () => {
 describe('Test /review', () => {
   const session = require('supertest-session')
 
-  let csrfToken,
-    cookie
+  let csrfToken, cookie
 
   beforeEach(async () => {
     let testSession = session(app)
@@ -28,7 +27,8 @@ describe('Test /review', () => {
 
   describe('POST responses', () => {
     test('it returns a 422 response if no values are posted', async () => {
-      const response = await request(app).post('/review')
+      const response = await request(app)
+        .post('/review')
         .set('Cookie', cookie)
         .send({ _csrf: csrfToken })
       expect(response.statusCode).toBe(422)

--- a/routes/deductions/deductions.spec.js
+++ b/routes/deductions/deductions.spec.js
@@ -1,12 +1,11 @@
 const request = require('supertest')
 const app = require('../../app.js')
-const { extractCsrfToken } = require('../../utils/index')
+const { extractCsrfToken } = require('../utils.spec')
 
 describe('Test /deductions responses', () => {
   const session = require('supertest-session')
 
-  let csrfToken,
-    cookie
+  let csrfToken, cookie
 
   beforeEach(async () => {
     const testSession = session(app)
@@ -110,7 +109,11 @@ describe('Test /deductions responses', () => {
           const response = await request(app)
             .post(yesNoResponse.url)
             .set('Cookie', cookie)
-            .send({ _csrf: csrfToken, [yesNoResponse.key]: 'Yes', redirect: yesNoResponse.yesRedir || '/' })
+            .send({
+              _csrf: csrfToken,
+              [yesNoResponse.key]: 'Yes',
+              redirect: yesNoResponse.yesRedir || '/',
+            })
           expect(response.statusCode).toBe(302)
           expect(response.headers.location).toEqual(
             yesNoResponse.yesRedir || `${yesNoResponse.url}/amount`,
@@ -122,9 +125,10 @@ describe('Test /deductions responses', () => {
 
   describe('Test /trillium/energy/reserve responses', () => {
     test('it returns a 422 with no option selected', async () => {
-      const response = await request(app).post('/trillium/energy/reserve')
+      const response = await request(app)
+        .post('/trillium/energy/reserve')
         .set('Cookie', cookie)
-        .send({ _csrf: csrfToken})
+        .send({ _csrf: csrfToken })
       expect(response.statusCode).toBe(422)
     })
 
@@ -159,7 +163,8 @@ describe('Test /deductions responses', () => {
 
   describe('Test /trillium/longTermCare responses', () => {
     test('it returns a 422 with no option selected', async () => {
-      const response = await request(app).post('/trillium/longTermCare')
+      const response = await request(app)
+        .post('/trillium/longTermCare')
         .set('Cookie', cookie)
         .send({ _csrf: csrfToken })
       expect(response.statusCode).toBe(422)
@@ -222,7 +227,8 @@ describe('Test /deductions responses', () => {
         })
 
         test('it returns a 500 response if no redirect is provided', async () => {
-          const response = await request(app).post(amountResponse.url)
+          const response = await request(app)
+            .post(amountResponse.url)
             .set('Cookie', cookie)
             .send({ _csrf: csrfToken })
           expect(response.statusCode).toBe(500)

--- a/routes/financial/financial.spec.js
+++ b/routes/financial/financial.spec.js
@@ -1,12 +1,11 @@
 const request = require('supertest')
 const app = require('../../app.js')
-const { extractCsrfToken } = require('../../utils/index')
+const { extractCsrfToken } = require('../utils.spec')
 
 describe('Test /financial responses', () => {
   const session = require('supertest-session')
 
-  let csrfToken,
-    cookie
+  let csrfToken, cookie
 
   beforeEach(async () => {
     let testSession = session(app)
@@ -14,7 +13,7 @@ describe('Test /financial responses', () => {
     cookie = getresp.headers['set-cookie']
     csrfToken = extractCsrfToken(getresp)
   })
-  
+
   test('it returns a 200 response for /financial/income', async () => {
     const response = await request(app).get('/financial/income')
     expect(response.statusCode).toBe(200)
@@ -49,10 +48,10 @@ describe('Test /financial responses', () => {
   test('it redirects to the checkAnswers when posting Yes and having come from the checkAnswers page', async () => {
     const response = await request(app)
       .post('/financial/income')
-      .query({ref: 'checkAnswers'})
+      .query({ ref: 'checkAnswers' })
       .set('Cookie', cookie)
       .send({ _csrf: csrfToken, confirmIncome: 'Yes', redirect: '/personal/maritalStatus' })
     expect(response.statusCode).toBe(302)
     expect(response.headers.location).toEqual('/checkAnswers')
-  }) 
+  })
 })

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -1,14 +1,12 @@
 const request = require('supertest')
 const session = require('supertest-session')
-const { extractCsrfToken } = require('../../utils/index')
+const { extractCsrfToken } = require('../utils.spec')
 const cheerio = require('cheerio')
 const app = require('../../app.js')
 
-let csrfToken,
-  cookie
+let csrfToken, cookie
 
 describe('Test /login responses', () => {
-
   beforeEach(async () => {
     const testSession = session(app)
     const getresp = await testSession.get('/login/code')
@@ -355,7 +353,7 @@ describe('Test /login responses', () => {
           const response = await request(app)
             .post('/login/dateOfBirth')
             .set('Cookie', cookie)
-            .send({ _csrf: csrfToken, ...badRequest.send})
+            .send({ _csrf: csrfToken, ...badRequest.send })
           expect(response.statusCode).toBe(422)
         })
       })
@@ -364,7 +362,7 @@ describe('Test /login responses', () => {
         const response = await request(app)
           .post('/login/dateOfBirth')
           .set('Cookie', cookie)
-          .send({ _csrf: csrfToken, ...goodDoBRequest})
+          .send({ _csrf: csrfToken, ...goodDoBRequest })
         expect(response.statusCode).toBe(302)
       })
 
@@ -372,7 +370,7 @@ describe('Test /login responses', () => {
         const response = await request(app)
           .post('/login/dateOfBirth')
           .set('Cookie', cookie)
-          .send({ 
+          .send({
             _csrf: csrfToken,
             dobDay: ' 9 ',
             dobMonth: ' 9 ',
@@ -478,7 +476,7 @@ describe('Test /login responses', () => {
           const response = await request(app)
             .post('/login/questions/dateOfResidence')
             .set('Cookie', cookie)
-            .send({ _csrf: csrfToken, ...badRequest.send})
+            .send({ _csrf: csrfToken, ...badRequest.send })
           expect(response.statusCode).toBe(422)
         })
       })
@@ -487,7 +485,7 @@ describe('Test /login responses', () => {
         const response = await request(app)
           .post('/login/questions/dateOfResidence')
           .set('Cookie', cookie)
-          .send({ _csrf: csrfToken, ...goodDoBRequest})
+          .send({ _csrf: csrfToken, ...goodDoBRequest })
         expect(response.statusCode).toBe(302)
       })
     })
@@ -498,7 +496,7 @@ describe('Test /login responses', () => {
           const response = await request(app)
             .post('/login/questions/bankruptcy')
             .set('Cookie', cookie)
-            .send({ _csrf: csrfToken, ...badRequest.send})
+            .send({ _csrf: csrfToken, ...badRequest.send })
           expect(response.statusCode).toBe(422)
         })
       })
@@ -536,7 +534,6 @@ describe('Test /login responses', () => {
       will be accepted.
     */
   describe('after entering an access code', () => {
-
     let authSession
 
     beforeEach(async () => {
@@ -562,7 +559,13 @@ describe('Test /login responses', () => {
       const response = await authSession
         .post('/login/dateOfBirth')
         .set('Cookie', cookie)
-        .send({ _csrf: csrfToken, dobDay: '23', dobMonth: '03', dobYear: '1909', redirect: '/personal/name' })
+        .send({
+          _csrf: csrfToken,
+          dobDay: '23',
+          dobMonth: '03',
+          dobYear: '1909',
+          redirect: '/personal/name',
+        })
       expect(response.statusCode).toBe(422)
     })
 
@@ -570,7 +573,13 @@ describe('Test /login responses', () => {
       const response = await authSession
         .post('/login/dateOfBirth')
         .set('Cookie', cookie)
-        .send({ _csrf: csrfToken, dobDay: '09', dobMonth: '09', dobYear: '1977', redirect: '/personal/name' })
+        .send({
+          _csrf: csrfToken,
+          dobDay: '09',
+          dobMonth: '09',
+          dobYear: '1977',
+          redirect: '/personal/name',
+        })
       expect(response.statusCode).toBe(302)
     })
   })
@@ -597,7 +606,8 @@ questionsAmounts.map(amountResponse => {
     })
 
     test('it returns a 422 response if no redirect is provided', async () => {
-      const response = await request(app).post(amountResponse.url)
+      const response = await request(app)
+        .post(amountResponse.url)
         .set('Cookie', cookie)
         .send({ _csrf: csrfToken })
       expect(response.statusCode).toBe(422)
@@ -617,7 +627,8 @@ questionsAmounts.map(amountResponse => {
         const response = await request(app)
           .post(amountResponse.url)
           .set('Cookie', cookie)
-          .send({ _csrf: csrfToken,
+          .send({
+            _csrf: csrfToken,
             [`${amountResponse.key}Amount`]: badAmount,
             [`${amountResponse.key}PaymentMethod`]: 'cheque',
             redirect: '/start',
@@ -630,10 +641,7 @@ questionsAmounts.map(amountResponse => {
       const response = await request(app)
         .post(amountResponse.url)
         .set('Cookie', cookie)
-        .send({ _csrf: csrfToken,
-          [`${amountResponse.key}Amount`]: '10',
-          redirect: '/start',
-        })
+        .send({ _csrf: csrfToken, [`${amountResponse.key}Amount`]: '10', redirect: '/start' })
       expect(response.statusCode).toBe(422)
     })
 
@@ -643,7 +651,8 @@ questionsAmounts.map(amountResponse => {
         const response = await request(app)
           .post(amountResponse.url)
           .set('Cookie', cookie)
-          .send({ _csrf: csrfToken,
+          .send({
+            _csrf: csrfToken,
             [`${amountResponse.key}Amount`]: goodAmount,
             [`${amountResponse.key}PaymentMethod`]: 'cheque',
             redirect: '/start',
@@ -657,7 +666,8 @@ questionsAmounts.map(amountResponse => {
       const response = await request(app)
         .post(amountResponse.url)
         .set('Cookie', cookie)
-        .send({ _csrf: csrfToken,
+        .send({
+          _csrf: csrfToken,
           [`${amountResponse.key}PaymentMethod`]: 'cheque',
           redirect: '/start',
         })
@@ -668,7 +678,8 @@ questionsAmounts.map(amountResponse => {
       const response = await request(app)
         .post(amountResponse.url)
         .set('Cookie', cookie)
-        .send({ _csrf: csrfToken,
+        .send({
+          _csrf: csrfToken,
           [`${amountResponse.key}Amount`]: '10',
           [`${amountResponse.key}PaymentMethod`]: 'bitcoin',
           redirect: '/start',
@@ -682,7 +693,8 @@ questionsAmounts.map(amountResponse => {
         const response = await request(app)
           .post(amountResponse.url)
           .set('Cookie', cookie)
-          .send({ _csrf: csrfToken,
+          .send({
+            _csrf: csrfToken,
             [`${amountResponse.key}Amount`]: '10',
             [`${amountResponse.key}PaymentMethod`]: paymentMethod,
             redirect: '/start',
@@ -811,7 +823,7 @@ describe('Test /login/questions/addresses responses', () => {
       const response = await request(app)
         .post('/login/questions/addresses')
         .set('Cookie', cookie)
-        .send({ ...badRequest.send, _csrf: csrfToken} )
+        .send({ ...badRequest.send, _csrf: csrfToken })
       expect(response.statusCode).toBe(422)
     })
   })
@@ -820,7 +832,7 @@ describe('Test /login/questions/addresses responses', () => {
     const response = await request(app)
       .post('/login/questions/addresses')
       .set('Cookie', cookie)
-      .send({ ...goodRequest, _csrf: csrfToken})
+      .send({ ...goodRequest, _csrf: csrfToken })
     expect(response.statusCode).toBe(302)
     expect(response.headers.location).toEqual('/personal/name')
   })

--- a/routes/personal/personal.spec.js
+++ b/routes/personal/personal.spec.js
@@ -1,12 +1,11 @@
 const request = require('supertest')
-const { extractCsrfToken } = require('../../utils/index')
+const { extractCsrfToken } = require('../utils.spec')
 const app = require('../../app.js')
 
 describe('Test /personal responses', () => {
   const session = require('supertest-session')
 
-  let csrfToken,
-    cookie
+  let csrfToken, cookie
 
   beforeEach(async () => {
     let testSession = session(app)
@@ -33,7 +32,8 @@ describe('Test /personal responses', () => {
 
   describe('Test /personal/name responses', () => {
     test('it returns a 422 with no option selected', async () => {
-      const response = await request(app).post('/personal/name')
+      const response = await request(app)
+        .post('/personal/name')
         .set('Cookie', cookie)
         .send({ _csrf: csrfToken })
       expect(response.statusCode).toBe(422)

--- a/routes/utils.spec.js
+++ b/routes/utils.spec.js
@@ -1,0 +1,31 @@
+const cheerio = require('cheerio')
+
+const extractCsrfToken = res => {
+  var $ = cheerio.load(res.text)
+  return $('[name=_csrf]').val()
+}
+
+describe('Test extractCsrfToken', () => {
+  test('returns correct token', async () => {
+    const htmlString = '<input type="hidden" name="_csrf" value="token"/>'
+    const extractedToken = extractCsrfToken({ text: htmlString })
+
+    expect(extractedToken).toEqual('token')
+  })
+
+  test('returns undefined when no _csrf field exists', async () => {
+    const htmlString = '<input type="text" name="notCSRF" value="token"/>'
+    const extractedToken = extractCsrfToken({ text: htmlString })
+
+    expect(extractedToken).toBeUndefined()
+  })
+
+  test('returns empty string when _csrf field is empty', async () => {
+    const htmlString = '<input type="hidden" name="_csrf" value=""/>'
+    const extractedToken = extractCsrfToken({ text: htmlString })
+
+    expect(extractedToken).toEqual('')
+  })
+})
+
+module.exports = { extractCsrfToken }

--- a/utils/index.js
+++ b/utils/index.js
@@ -3,7 +3,6 @@ const { validationResult } = require('express-validator')
 const API = require('./../api')
 const { routes: defaultRoutes } = require('../config/routes.config')
 const cookieConfig = require('../config/cookie.config')
-const cheerio = require('cheerio')
 
 /*
   original format is an array of error objects: https://express-validator.github.io/docs/validation-result-api.html
@@ -377,11 +376,6 @@ const isoDateHintText = date => {
   return `${dateParts[2]} ${dateParts[1]} ${dateParts[0]}`
 }
 
-const extractCsrfToken = (res) => {
-  var $ = cheerio.load(res.text)
-  return $('[name=_csrf]').val()
-}
-
 module.exports = {
   errorArray2ErrorObject,
   checkErrors,
@@ -398,5 +392,4 @@ module.exports = {
   isoDateHintText,
   getRouteWithIndexByPath,
   returnToCheckAnswers,
-  extractCsrfToken,
 }


### PR DESCRIPTION
## Move code around so that cheerio is a test dependency again

Since moving `extractCSRFToken` function to the `/utils/index.js` file, we were technically relying on the 'cheerio' package for the prod version of the application — not because the function was getting called in the prod version of the app, but because other functions in `/utils/index.js` _are_ getting called, and when trying to call them, the app would crash because `/utils/index.js` was missing an import.

The quick fix was to promote the cheerio dependency into our prod dependencies, but it's 100% _not_ a prod dependency so this PR fixes that.

This PR creates a new file from which we can import our extractCSRFToken test function, and has a few basic tests for it in the same file.

Having done that, we can put the cheerio lib back in as a 'devDependency', which is where it belongs.

Easy.