### PR TITLE
Add Cypress full run with amounts

### DIFF
--- a/cypress/fixtures/checkAnswersRowsWithAmounts.json
+++ b/cypress/fixtures/checkAnswersRowsWithAmounts.json
@@ -1,0 +1,75 @@
+{ 
+  "rows": [
+    {
+      "key": "Name",
+      "value": "Gabrielle Roy"
+    },
+    {
+      "key": "Date of birth",
+      "value": "9 September 1977"
+    },
+    {
+      "key": "Province",
+      "value": "Ontario"
+    },
+    {
+      "key": "Mailing address",
+      "value": "Unit 202-303 Blake Blvd."
+    },
+    {
+      "key": "Is your income information correct?",
+      "value": "Yes"
+    },
+    {
+      "key": "Marital status",
+      "value": "Single"
+    },
+    {
+      "key": "Did you pay rent?",
+      "value": "Yes"
+    },
+    {
+      "key": "Rent paid",
+      "value": "$25.00"
+    },
+    {
+      "key": "Did you pay property tax?",
+      "value": "Yes"
+    },
+    {
+      "key": "Property tax paid",
+      "value": "$25.00"
+    },
+    {
+      "key": "Did you live in a student residence?",
+      "value": "Yes"
+    },
+    {
+      "key": "Did you live on a reserve?",
+      "value": "Yes"
+    },
+    {
+      "key": "Did you have home energy costs on a reserve?",
+      "value": "Yes"
+    },
+    {
+      "key": "Yearly energy costs on a reserve",
+      "value": "$25.00"
+    },
+    {
+      "key": "Did you live in a long-term care home?",
+      "value": "Yes"
+    },
+    {
+      "key": "Public or non-profit long-term care home?",
+      "value": "Yes"
+    },
+    {
+      "key": "Long-term care costs",
+      "value": "$25.00"
+    },
+    {
+      "key": "Did you live in a small and rural community?",
+      "value": "Yes"
+    }]
+  }

--- a/cypress/integration/full_run_simple.spec.js
+++ b/cypress/integration/full_run_simple.spec.js
@@ -5,7 +5,7 @@ const {
   getAddress,
 } = require('../utils.js')
 
-describe('Full run through', function() {
+describe('Full run through saying "no" to everything', function() {
   before(function() {
     cy.visit('/clear')
     cy.visit('/')

--- a/cypress/integration/full_run_simple.spec.js
+++ b/cypress/integration/full_run_simple.spec.js
@@ -3,7 +3,6 @@ const {
   allIncomeRows,
   getBenefitsBreakdownRows,
   getAddress,
-  logIn,
 } = require('../utils.js')
 
 describe('Full run through', function() {
@@ -17,8 +16,8 @@ describe('Full run through', function() {
     cy.injectAxe().checkA11y()
   })
 
+  // START PAGE
   it('successfully loads the home page', function() {
-    // START PAGE
     cy.checkA11y()
     cy.get('h1').should('contain', 'Claim Tax Benefits')
     cy.get('main a')
@@ -27,239 +26,179 @@ describe('Full run through', function() {
   })
 
   it('successfully logs in', function() {
-    logIn(cy, this.user)
+    cy.login(this.user)
   })
 
+  //CONFIRM NAME
   it('navigates the Confirm Name page', function() {
-    //CONFIRM NAME
-    cy.url().should('contain', '/personal/name')
-    cy.get('h1').should('contain', 'Check your name is correct')
-
-    cy.get('input#name0 + label').should('have.attr', 'for', 'name0')
-
-    cy.get('input#name0').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.confirm({
+      url: '/personal/name',
+      h1: 'Check your name is correct',
+      id: 'name0',
+    })
+    cy.continue()
   })
 
+  //CONFIRM RESIDENCE
   it('navigates the Confirm Residence page', function() {
-    //CONFIRM RESIDENCE
-    cy.url().should('contain', '/personal/residence')
-    cy.get('h1').should('contain', 'Enter your province or territory')
-
-    cy.get('form label').should('have.attr', 'for', 'residence')
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.confirm({
+      url: '/personal/residence',
+      h1: 'Enter your province or territory',
+      id: 'residence',
+    })
+    cy.continue()
   })
 
+  //CONFIRM MAILING
   it('navigates the Confirm Mailing page', function() {
-    //CONFIRM MAILING
-    cy.url().should('contain', '/personal/address')
-    cy.get('h1').should('contain', 'Check your mailing address')
+    cy.confirm({
+      url: '/personal/address',
+      h1: 'Check your mailing address',
+      id: 'confirmAddress0',
+    })
 
     //format address based on apartment/no apartment
     const addressText = getAddress(this.user.personal.address)
-
     addressText.map((text, index) => {
       cy.get('div.address div')
         .eq(index)
         .should('contain', text)
     })
 
-    cy.get('input#confirmAddress0 + label').should('have.attr', 'for', 'confirmAddress0')
-
-    cy.get('input#confirmAddress0').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  //CONFIRM INCOME
   it('navigates the Confirm Income page', function() {
-    //CONFIRM INCOME
-    cy.url().should('contain', '/financial/income')
-    cy.get('h1').should('contain', 'Check your income information for the 2018 tax year')
+    cy.confirm({
+      url: '/financial/income',
+      h1: 'Check your income information for the 2018 tax year',
+      id: 'confirmIncome0',
+    })
 
-    //check table data
     checkTableRows(cy, allIncomeRows(this.user))
 
-    cy.get('input#confirmIncome0 + label').should('have.attr', 'for', 'confirmIncome0')
-
-    cy.get('input#confirmIncome0').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  //CONFIRM MARITAL STATUS
   it('navigates the Confirm Marital Status page', function() {
-    //CONFIRM MARITAL STATUS
-    cy.url().should('contain', '/personal/maritalStatus')
-    cy.get('h1').should('contain', 'Check your marital status')
+    cy.confirm({
+      url: '/personal/maritalStatus',
+      h1: 'Check your marital status',
+      id: 'confirmMaritalStatus0',
+    })
 
-    cy.get('input#confirmMaritalStatus0 + label').should(
-      'have.attr',
-      'for',
-      'confirmMaritalStatus0',
-    )
-
-    cy.get('input#confirmMaritalStatus0').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  //TRILLIUM RENT
   it('navigates the Trillium Rent page', function() {
-    //TRILLIUM RENT
-    cy.url().should('contain', '/trillium/rent')
-    cy.get('h1').should('contain', 'Rent')
+    cy.confirm({
+      url: '/trillium/rent',
+      h1: 'Rent',
+      id: 'trilliumRentClaim1', // click No
+    })
 
-    cy.get('input#trilliumRentClaim1 + label').should('have.attr', 'for', 'trilliumRentClaim1')
-
-    cy.get('input#trilliumRentClaim1').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  //TRILLIUM PROPERTY TAX
   it('navigates the Trillium Property Tax page', function() {
-    //TRILLIUM PROPERTY TAX
-    cy.url().should('contain', '/trillium/propertyTax')
-    cy.get('h1').should('contain', 'Property tax')
+    cy.confirm({
+      url: '/trillium/propertyTax',
+      h1: 'Property tax',
+      id: 'trilliumPropertyTaxClaim1', // click No
+    })
 
-    cy.get('input#trilliumPropertyTaxClaim1 + label').should(
-      'have.attr',
-      'for',
-      'trilliumPropertyTaxClaim1',
-    )
-
-    cy.get('input#trilliumPropertyTaxClaim1').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  //TRILLIUM STUDENT RESIDENCE
   it('navigates the Trillium Student Residence page', function() {
-    //TRILLIUM STUDENT RESIDENCE
-    cy.url().should('contain', '/trillium/studentResidence')
-    cy.get('h1').should('contain', 'Student residence')
-    cy.get('input#trilliumStudentResidence1 + label').should(
-      'have.attr',
-      'for',
-      'trilliumStudentResidence1',
-    )
+    cy.confirm({
+      url: '/trillium/studentResidence',
+      h1: 'Student residence',
+      id: 'trilliumStudentResidence1', // click No
+    })
 
-    cy.get('input#trilliumStudentResidence1').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  //TRILLIUM HOME ENERGY
   it('navigates the Trillium Home Energy page', function() {
-    //TRILLIUM HOME ENERGY
-    cy.url().should('contain', '/trillium/energy/reserve')
-    cy.get('h1').should('contain', 'Home on reserve')
+    cy.confirm({
+      url: '/trillium/energy/reserve',
+      h1: 'Home on reserve',
+      id: 'trilliumEnergyReserveClaim1', // click No
+    })
 
-    cy.get('input#trilliumEnergyReserveClaim1 + label').should('have.attr', 'for', 'trilliumEnergyReserveClaim1')
-
-    cy.get('input#trilliumEnergyReserveClaim1').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  //TRILLIUM LONG TERM CARE
   it('navigates the Trillium Long Term Care page', function() {
-    //TRILLIUM LONG TERM CARE
-    cy.url().should('contain', '/trillium/longTermCare')
-    cy.get('h1').should('contain', 'Long-term care home')
-    cy.get('input#trilliumLongTermCareClaim1 + label').should(
-      'have.attr',
-      'for',
-      'trilliumLongTermCareClaim1',
-    )
+    cy.confirm({
+      url: '/trillium/longTermCare',
+      h1: 'Long-term care home',
+      id: 'trilliumLongTermCareClaim1', // click No
+    })
 
-    cy.get('input#trilliumLongTermCareClaim1').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
-  it('navigates  Incentive page', function() {
-    //CLIMATE ACTION INCENTIVE
-    cy.url().should('contain', '/deductions/climate-action-incentive')
-    cy.get('h1').should('contain', 'Small and rural communities')
+  //CLIMATE ACTION INCENTIVE
+  it('navigates Climate Action Incentive page', function() {
+    cy.confirm({
+      url: '/deductions/climate-action-incentive',
+      h1: 'Small and rural communities',
+      id: 'climateActionIncentiveIsRural1', // click No
+    })
 
-    cy.get('input#climateActionIncentiveIsRural1 + label').should(
-      'have.attr',
-      'for',
-      'climateActionIncentiveIsRural1',
-    )
-
-    cy.get('input#climateActionIncentiveIsRural1').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  // VOTER OPT IN
   it('navigates Voter Opt In page', function() {
-    cy.url().should('contain', '/vote/optIn')
-    cy.get('h1').should('contain', 'Register to vote')
+    cy.confirm({
+      url: '/vote/optIn',
+      h1: 'Register to vote',
+      id: 'confirmOptIn1', // click No
+    })
 
-    cy.get('input#confirmOptIn1 + label').should(
-      'have.attr',
-      'for',
-      'confirmOptIn1',
-    )
-
-    cy.get('input#confirmOptIn1').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  // CHECK ANSWERS
   it('navigates the Check Your Answers page', function() {
     cy.url().should('contain', '/checkAnswers')
     cy.get('h1').should('contain', 'Check your answers before filing')
     cy.fixture('checkAnswersRows.json').then(rows => {
       checkTableRows(cy, rows.rows)
     })
+
     cy.get('.buttons-row a')
       .contains('Agree')
       .click()
   })
 
+  //REVIEW
   it('navigates the Review page', function() {
-    //REVIEW
-    cy.url().should('contain', '/review')
-    cy.get('h1').should('contain', 'Review and file tax return')
+    cy.confirm({
+      url: '/review',
+      h1: 'Review and file tax return',
+      id: 'review', // click checkbox
+    })
 
     //check some table data
     //until we have a more firm grasp on how we're shaping the total refund, i'm just checking benefits
     checkTableRows(cy, getBenefitsBreakdownRows(this.user))
 
-    cy.get('input#review + label').should('have.attr', 'for', 'review')
-
-    cy.get('input#review').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'File your taxes now')
-      .click()
+    cy.continue('File your taxes now')
   })
 
+  // CONFIRMATION PAGE
   it('checks the Confirmation page', function() {
-    // CONFIRMATION PAGE
     cy.url().should('contain', '/confirmation')
     cy.get('h1').should('contain', 'You have filed your 2018 taxes')
     cy.get('th').should('contain', 'Your 2018 filing code is')

--- a/cypress/integration/full_run_with_amounts.spec.js
+++ b/cypress/integration/full_run_with_amounts.spec.js
@@ -5,7 +5,7 @@ const {
   getAddress,
 } = require('../utils.js')
 
-describe('Full run through', function() {
+describe('Full run through saying "yes" to everything', function() {
   before(function() {
     cy.visit('/clear')
     cy.visit('/')

--- a/cypress/integration/full_run_with_amounts.spec.js
+++ b/cypress/integration/full_run_with_amounts.spec.js
@@ -1,0 +1,374 @@
+const {
+  checkTableRows,
+  allIncomeRows,
+  getBenefitsBreakdownRows,
+  getAddress,
+  logIn,
+} = require('../utils.js')
+
+describe('Full run through', function() {
+  before(function() {
+    cy.visit('/clear')
+    cy.visit('/')
+  })
+
+  beforeEach(function() {
+    cy.fixture('user').as('user')
+    cy.injectAxe().checkA11y()
+  })
+
+  it('successfully loads the home page', function() {
+    // START PAGE
+    cy.checkA11y()
+    cy.get('h1').should('contain', 'Claim Tax Benefits')
+    cy.get('main a')
+      .should('contain', 'Start now')
+      .click()
+  })
+
+  it('successfully logs in', function() {
+    logIn(cy, this.user)
+  })
+
+  it('navigates the Confirm Name page', function() {
+    //CONFIRM NAME
+    cy.url().should('contain', '/personal/name')
+    cy.get('h1').should('contain', 'Check your name is correct')
+
+    cy.get('input#name0 + label').should('have.attr', 'for', 'name0')
+
+    cy.get('input#name0').click()
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+  })
+
+  it('navigates the Confirm Residence page', function() {
+    //CONFIRM RESIDENCE
+    cy.url().should('contain', '/personal/residence')
+    cy.get('h1').should('contain', 'Enter your province or territory')
+
+    cy.get('form label').should('have.attr', 'for', 'residence')
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+  })
+
+  it('navigates the Confirm Mailing page', function() {
+    //CONFIRM MAILING
+    cy.url().should('contain', '/personal/address')
+    cy.get('h1').should('contain', 'Check your mailing address')
+
+    //format address based on apartment/no apartment
+    const addressText = getAddress(this.user.personal.address)
+
+    addressText.map((text, index) => {
+      cy.get('div.address div')
+        .eq(index)
+        .should('contain', text)
+    })
+
+    cy.get('input#confirmAddress0 + label').should('have.attr', 'for', 'confirmAddress0')
+
+    cy.get('input#confirmAddress0').click()
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+  })
+
+  it('navigates the Confirm Income page', function() {
+    //CONFIRM INCOME
+    cy.url().should('contain', '/financial/income')
+    cy.get('h1').should('contain', 'Check your income information for the 2018 tax year')
+
+    //check table data
+    checkTableRows(cy, allIncomeRows(this.user))
+
+    cy.get('input#confirmIncome0 + label').should('have.attr', 'for', 'confirmIncome0')
+
+    cy.get('input#confirmIncome0').click()
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+  })
+
+  it('navigates the Confirm Marital Status page', function() {
+    //CONFIRM MARITAL STATUS
+    cy.url().should('contain', '/personal/maritalStatus')
+    cy.get('h1').should('contain', 'Check your marital status')
+
+    cy.get('input#confirmMaritalStatus0 + label').should(
+      'have.attr',
+      'for',
+      'confirmMaritalStatus0',
+    )
+
+    cy.get('input#confirmMaritalStatus0').click()
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+  })
+
+  it('navigates the Trillium Rent page', function() {
+    //TRILLIUM RENT
+    cy.url().should('contain', '/trillium/rent')
+    cy.get('h1').should('contain', 'Rent')
+
+    cy.get('input#trilliumRentClaim1 + label').should('have.attr', 'for', 'trilliumRentClaim1')
+
+    cy.get('input#trilliumRentClaim0').click()
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+  })
+
+  it('navigates the Trillium Rent AMOUNT page', function() {
+    //TRILLIUM RENT AMOUNT
+    cy.url().should('contain', '/trillium/rent/amount')
+    cy.get('h1').should('contain', 'Enter your rent')
+
+    cy.get('#trilliumRentAmount__label').should('have.attr', 'for', 'trilliumRentAmount')
+
+    cy.get('input#trilliumRentAmount').should('have.attr', 'placeholder', '0.00').should('have.attr', 'value', '').type('25')
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+
+    cy.url().should('contain', '/trillium/propertyTax')
+    cy.get('a.back-link').should('contain', 'Go back').click()
+    cy.url().should('contain', '/trillium/rent/amount')
+    cy.get('input#trilliumRentAmount').should('have.attr', 'value', '25.00')
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+  })
+
+  it('navigates the Trillium Property Tax page', function() {
+    //TRILLIUM PROPERTY TAX
+    cy.url().should('contain', '/trillium/propertyTax')
+    cy.get('h1').should('contain', 'Property tax')
+
+    cy.get('input#trilliumPropertyTaxClaim0 + label').should(
+      'have.attr',
+      'for',
+      'trilliumPropertyTaxClaim0',
+    )
+
+    cy.get('input#trilliumPropertyTaxClaim0').click()
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+  })
+
+  it('navigates the Property Tax AMOUNT page', function() {
+    //TRILLIUM PROPERTY TAX AMOUNT
+    cy.url().should('contain', '/trillium/propertyTax/amount')
+    cy.get('h1').should('contain', 'Enter your property tax')
+
+    cy.get('#trilliumPropertyTaxAmount__label').should('have.attr', 'for', 'trilliumPropertyTaxAmount')
+
+    cy.get('input#trilliumPropertyTaxAmount').should('have.attr', 'placeholder', '0.00').should('have.attr', 'value', '').type('25')
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+
+    cy.url().should('contain', '/trillium/studentResidence')
+    cy.get('a.back-link').should('contain', 'Go back').click()
+    cy.url().should('contain', '/trillium/propertyTax/amount')
+    cy.get('input#trilliumPropertyTaxAmount').should('have.attr', 'value', '25.00')
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+  })
+
+  it('navigates the Trillium Student Residence page', function() {
+    //TRILLIUM STUDENT RESIDENCE
+    cy.url().should('contain', '/trillium/studentResidence')
+    cy.get('h1').should('contain', 'Student residence')
+    cy.get('input#trilliumStudentResidence0 + label').should(
+      'have.attr',
+      'for',
+      'trilliumStudentResidence0',
+    )
+
+    cy.get('input#trilliumStudentResidence0').click()
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+  })
+
+  it('navigates the Trillium Home Energy page', function() {
+    //TRILLIUM HOME ENERGY
+    cy.url().should('contain', '/trillium/energy/reserve')
+    cy.get('h1').should('contain', 'Home on reserve')
+
+    cy.get('input#trilliumEnergyReserveClaim0 + label').should('have.attr', 'for', 'trilliumEnergyReserveClaim0')
+
+    cy.get('input#trilliumEnergyReserveClaim0').click()
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+  })
+
+  it('navigates the Trillium Energy Cost page', function() {
+    //TRILLIUM HOME ENERGY COST
+    cy.url().should('contain', '/trillium/energy/cost')
+    cy.get('h1').should('contain', 'Home energy costs on reserve')
+
+    cy.get('input#trilliumEnergyCostClaim0 + label').should('have.attr', 'for', 'trilliumEnergyCostClaim0')
+
+    cy.get('input#trilliumEnergyCostClaim0').click()
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+  })
+
+  it('navigates the Trillium Energy Cost AMOUNT page', function() {
+    //TRILLIUM HOME ENERGY COST AMOUNT
+    cy.url().should('contain', '/trillium/energy/cost/amount')
+    cy.get('h1').should('contain', 'Enter your home energy costs')
+
+    cy.get('#trilliumEnergyAmount__label').should('have.attr', 'for', 'trilliumEnergyAmount')
+
+    cy.get('input#trilliumEnergyAmount').should('have.attr', 'placeholder', '0.00').should('have.attr', 'value', '').type('25')
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+
+    cy.url().should('contain', '/trillium/longTermCare')
+    cy.get('a.back-link').should('contain', 'Go back').click()
+    cy.url().should('contain', '/trillium/energy/cost/amount')
+    cy.get('input#trilliumEnergyAmount').should('have.attr', 'value', '25.00')
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+  })
+
+  it('navigates the Trillium Long Term Care page', function() {
+    //TRILLIUM LONG TERM CARE
+    cy.url().should('contain', '/trillium/longTermCare')
+    cy.get('h1').should('contain', 'Long-term care home')
+    cy.get('input#trilliumLongTermCareClaim0 + label').should(
+      'have.attr',
+      'for',
+      'trilliumLongTermCareClaim0',
+    )
+
+    cy.get('input#trilliumLongTermCareClaim0').click()
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+  })
+
+  it('navigates the Trillium Long Term Care Type page', function() {
+    //TRILLIUM LONG TERM CARE TYPE
+    cy.url().should('contain', '/trillium/longTermCare/type')
+    cy.get('h1').should('contain', 'Public or non-profit long-term care')
+    cy.get('input#trilliumLongTermCareTypeClaim0 + label').should(
+      'have.attr',
+      'for',
+      'trilliumLongTermCareTypeClaim0',
+    )
+
+    cy.get('input#trilliumLongTermCareTypeClaim0').click()
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+  })
+
+  it('navigates the Trillium Long Term Care AMOUNT page', function() {
+    //TRILLIUM LONG TERM CARE AMOUNT
+    cy.url().should('contain', '/trillium/longTermCare/type/amount')
+    cy.get('h1').should('contain', 'Enter your long-term care home costs')
+
+    cy.get('#trilliumLongTermCareAmount__label').should('have.attr', 'for', 'trilliumLongTermCareAmount')
+
+    cy.get('input#trilliumLongTermCareAmount').should('have.attr', 'placeholder', '0.00').should('have.attr', 'value', '').type('25')
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+
+    cy.url().should('contain', '/deductions/climate-action-incentive')
+    cy.get('a.back-link').should('contain', 'Go back').click()
+    cy.url().should('contain', '/trillium/longTermCare/type/amount')
+    cy.get('input#trilliumLongTermCareAmount').should('have.attr', 'value', '25.00')
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+  })
+
+  it('navigates  Incentive page', function() {
+    //CLIMATE ACTION INCENTIVE
+    cy.url().should('contain', '/deductions/climate-action-incentive')
+    cy.get('h1').should('contain', 'Small and rural communities')
+
+    cy.get('input#climateActionIncentiveIsRural0 + label').should(
+      'have.attr',
+      'for',
+      'climateActionIncentiveIsRural0',
+    )
+
+    cy.get('input#climateActionIncentiveIsRural0').click()
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'Continue')
+      .click()
+  })
+
+  it('navigates the Check Your Answers page', function() {
+    cy.url().should('contain', '/checkAnswers')
+    cy.get('h1').should('contain', 'Check your answers before filing')
+    cy.fixture('checkAnswersRowsWithAmounts.json').then(rows => {
+      checkTableRows(cy, rows.rows)
+    })
+    cy.get('.buttons-row a')
+      .contains('Agree')
+      .click()
+  })
+
+  it('navigates the Review page', function() {
+    //REVIEW
+    cy.url().should('contain', '/review')
+    cy.get('h1').should('contain', 'Review and file tax return')
+
+    //check some table data
+    //until we have a more firm grasp on how we're shaping the total refund, i'm just checking benefits
+    checkTableRows(cy, getBenefitsBreakdownRows(this.user))
+
+    cy.get('input#review + label').should('have.attr', 'for', 'review')
+
+    cy.get('input#review').click()
+
+    cy.get('form button[type="submit"]')
+      .should('contain', 'File your taxes now')
+      .click()
+  })
+
+  it('checks the Confirmation page', function() {
+    // CONFIRMATION PAGE
+    cy.url().should('contain', '/confirmation')
+    cy.get('h1').should('contain', 'You have filed your 2018 taxes')
+    cy.get('th').should('contain', 'Your 2018 filing code is')
+    cy.get('td').should('contain', '5H3P9IO5816')
+  })
+})

--- a/cypress/integration/full_run_with_amounts.spec.js
+++ b/cypress/integration/full_run_with_amounts.spec.js
@@ -3,7 +3,6 @@ const {
   allIncomeRows,
   getBenefitsBreakdownRows,
   getAddress,
-  logIn,
 } = require('../utils.js')
 
 describe('Full run through', function() {
@@ -12,13 +11,13 @@ describe('Full run through', function() {
     cy.visit('/')
   })
 
-  beforeEach(function() {
+  beforeEach(() => {
     cy.fixture('user').as('user')
     cy.injectAxe().checkA11y()
   })
 
+  // START PAGE
   it('successfully loads the home page', function() {
-    // START PAGE
     cy.checkA11y()
     cy.get('h1').should('contain', 'Claim Tax Benefits')
     cy.get('main a')
@@ -27,314 +26,230 @@ describe('Full run through', function() {
   })
 
   it('successfully logs in', function() {
-    logIn(cy, this.user)
+    cy.login(this.user)
   })
 
+  //CONFIRM NAME
   it('navigates the Confirm Name page', function() {
-    //CONFIRM NAME
-    cy.url().should('contain', '/personal/name')
-    cy.get('h1').should('contain', 'Check your name is correct')
-
-    cy.get('input#name0 + label').should('have.attr', 'for', 'name0')
-
-    cy.get('input#name0').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.confirm({
+      url: '/personal/name',
+      h1: 'Check your name is correct',
+      id: 'name0',
+    })
+    cy.continue()
   })
 
+  //CONFIRM RESIDENCE
   it('navigates the Confirm Residence page', function() {
-    //CONFIRM RESIDENCE
-    cy.url().should('contain', '/personal/residence')
-    cy.get('h1').should('contain', 'Enter your province or territory')
-
-    cy.get('form label').should('have.attr', 'for', 'residence')
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.confirm({
+      url: '/personal/residence',
+      h1: 'Enter your province or territory',
+      id: 'residence',
+    })
+    cy.continue()
   })
 
+  //CONFIRM MAILING
   it('navigates the Confirm Mailing page', function() {
-    //CONFIRM MAILING
-    cy.url().should('contain', '/personal/address')
-    cy.get('h1').should('contain', 'Check your mailing address')
+    cy.confirm({
+      url: '/personal/address',
+      h1: 'Check your mailing address',
+      id: 'confirmAddress0',
+    })
 
     //format address based on apartment/no apartment
     const addressText = getAddress(this.user.personal.address)
-
     addressText.map((text, index) => {
       cy.get('div.address div')
         .eq(index)
         .should('contain', text)
     })
 
-    cy.get('input#confirmAddress0 + label').should('have.attr', 'for', 'confirmAddress0')
-
-    cy.get('input#confirmAddress0').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  //CONFIRM INCOME
   it('navigates the Confirm Income page', function() {
-    //CONFIRM INCOME
-    cy.url().should('contain', '/financial/income')
-    cy.get('h1').should('contain', 'Check your income information for the 2018 tax year')
+    cy.confirm({
+      url: '/financial/income',
+      h1: 'Check your income information for the 2018 tax year',
+      id: 'confirmIncome0',
+    })
 
-    //check table data
     checkTableRows(cy, allIncomeRows(this.user))
 
-    cy.get('input#confirmIncome0 + label').should('have.attr', 'for', 'confirmIncome0')
-
-    cy.get('input#confirmIncome0').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  //CONFIRM MARITAL STATUS
   it('navigates the Confirm Marital Status page', function() {
-    //CONFIRM MARITAL STATUS
-    cy.url().should('contain', '/personal/maritalStatus')
-    cy.get('h1').should('contain', 'Check your marital status')
+    cy.confirm({
+      url: '/personal/maritalStatus',
+      h1: 'Check your marital status',
+      id: 'confirmMaritalStatus0',
+    })
 
-    cy.get('input#confirmMaritalStatus0 + label').should(
-      'have.attr',
-      'for',
-      'confirmMaritalStatus0',
-    )
-
-    cy.get('input#confirmMaritalStatus0').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  //TRILLIUM RENT
   it('navigates the Trillium Rent page', function() {
-    //TRILLIUM RENT
-    cy.url().should('contain', '/trillium/rent')
-    cy.get('h1').should('contain', 'Rent')
+    cy.confirm({
+      url: '/trillium/rent',
+      h1: 'Rent',
+      id: 'trilliumRentClaim0', // click Yes
+    })
 
-    cy.get('input#trilliumRentClaim1 + label').should('have.attr', 'for', 'trilliumRentClaim1')
-
-    cy.get('input#trilliumRentClaim0').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  //TRILLIUM RENT AMOUNT
   it('navigates the Trillium Rent AMOUNT page', function() {
-    //TRILLIUM RENT AMOUNT
-    cy.url().should('contain', '/trillium/rent/amount')
-    cy.get('h1').should('contain', 'Enter your rent')
+    cy.amount({
+      url: '/trillium/rent/amount',
+      h1: 'Enter your rent',
+      id: 'trilliumRentAmount',
+    })
 
-    cy.get('#trilliumRentAmount__label').should('have.attr', 'for', 'trilliumRentAmount')
-
-    cy.get('input#trilliumRentAmount').should('have.attr', 'placeholder', '0.00').should('have.attr', 'value', '').type('25')
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
-
-    cy.url().should('contain', '/trillium/propertyTax')
-    cy.get('a.back-link').should('contain', 'Go back').click()
-    cy.url().should('contain', '/trillium/rent/amount')
-    cy.get('input#trilliumRentAmount').should('have.attr', 'value', '25.00')
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  //TRILLIUM PROPERTY TAX
   it('navigates the Trillium Property Tax page', function() {
-    //TRILLIUM PROPERTY TAX
-    cy.url().should('contain', '/trillium/propertyTax')
-    cy.get('h1').should('contain', 'Property tax')
+    cy.confirm({
+      url: '/trillium/propertyTax',
+      h1: 'Property tax',
+      id: 'trilliumPropertyTaxClaim0', // click Yes
+    })
 
-    cy.get('input#trilliumPropertyTaxClaim0 + label').should(
-      'have.attr',
-      'for',
-      'trilliumPropertyTaxClaim0',
-    )
-
-    cy.get('input#trilliumPropertyTaxClaim0').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  //TRILLIUM PROPERTY TAX AMOUNT
   it('navigates the Property Tax AMOUNT page', function() {
-    //TRILLIUM PROPERTY TAX AMOUNT
-    cy.url().should('contain', '/trillium/propertyTax/amount')
-    cy.get('h1').should('contain', 'Enter your property tax')
+    cy.amount({
+      url: '/trillium/propertyTax/amount',
+      h1: 'Enter your property tax',
+      id: 'trilliumPropertyTaxAmount',
+    })
 
-    cy.get('#trilliumPropertyTaxAmount__label').should('have.attr', 'for', 'trilliumPropertyTaxAmount')
-
-    cy.get('input#trilliumPropertyTaxAmount').should('have.attr', 'placeholder', '0.00').should('have.attr', 'value', '').type('25')
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
-
-    cy.url().should('contain', '/trillium/studentResidence')
-    cy.get('a.back-link').should('contain', 'Go back').click()
-    cy.url().should('contain', '/trillium/propertyTax/amount')
-    cy.get('input#trilliumPropertyTaxAmount').should('have.attr', 'value', '25.00')
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  //TRILLIUM STUDENT RESIDENCE
   it('navigates the Trillium Student Residence page', function() {
-    //TRILLIUM STUDENT RESIDENCE
-    cy.url().should('contain', '/trillium/studentResidence')
-    cy.get('h1').should('contain', 'Student residence')
-    cy.get('input#trilliumStudentResidence0 + label').should(
-      'have.attr',
-      'for',
-      'trilliumStudentResidence0',
-    )
+    cy.confirm({
+      url: '/trillium/studentResidence',
+      h1: 'Student residence',
+      id: 'trilliumStudentResidence0', // click Yes
+    })
 
-    cy.get('input#trilliumStudentResidence0').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  //TRILLIUM HOME ENERGY
   it('navigates the Trillium Home Energy page', function() {
-    //TRILLIUM HOME ENERGY
-    cy.url().should('contain', '/trillium/energy/reserve')
-    cy.get('h1').should('contain', 'Home on reserve')
+    cy.confirm({
+      url: '/trillium/energy/reserve',
+      h1: 'Home on reserve',
+      id: 'trilliumEnergyReserveClaim0', // click Yes
+    })
 
-    cy.get('input#trilliumEnergyReserveClaim0 + label').should('have.attr', 'for', 'trilliumEnergyReserveClaim0')
-
-    cy.get('input#trilliumEnergyReserveClaim0').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
-  it('navigates the Trillium Energy Cost page', function() {
-    //TRILLIUM HOME ENERGY COST
-    cy.url().should('contain', '/trillium/energy/cost')
-    cy.get('h1').should('contain', 'Home energy costs on reserve')
+  //TRILLIUM HOME ENERGY COST
+  it('navigates the Trillium Home Energy Cost page', function() {
+    cy.confirm({
+      url: '/trillium/energy/cost',
+      h1: 'Home energy costs on reserve',
+      id: 'trilliumEnergyCostClaim0', // click Yes
+    })
 
-    cy.get('input#trilliumEnergyCostClaim0 + label').should('have.attr', 'for', 'trilliumEnergyCostClaim0')
-
-    cy.get('input#trilliumEnergyCostClaim0').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
-  it('navigates the Trillium Energy Cost AMOUNT page', function() {
-    //TRILLIUM HOME ENERGY COST AMOUNT
-    cy.url().should('contain', '/trillium/energy/cost/amount')
-    cy.get('h1').should('contain', 'Enter your home energy costs')
+  //TRILLIUM HOME ENERGY COST AMOUNT
+  it('navigates the Trillium Home Energy Cost AMOUNT page', function() {
+    cy.amount({
+      url: '/trillium/energy/cost/amount',
+      h1: 'Enter your home energy costs',
+      id: 'trilliumEnergyAmount',
+    })
 
-    cy.get('#trilliumEnergyAmount__label').should('have.attr', 'for', 'trilliumEnergyAmount')
-
-    cy.get('input#trilliumEnergyAmount').should('have.attr', 'placeholder', '0.00').should('have.attr', 'value', '').type('25')
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
-
-    cy.url().should('contain', '/trillium/longTermCare')
-    cy.get('a.back-link').should('contain', 'Go back').click()
-    cy.url().should('contain', '/trillium/energy/cost/amount')
-    cy.get('input#trilliumEnergyAmount').should('have.attr', 'value', '25.00')
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  //TRILLIUM LONG TERM CARE
   it('navigates the Trillium Long Term Care page', function() {
-    //TRILLIUM LONG TERM CARE
-    cy.url().should('contain', '/trillium/longTermCare')
-    cy.get('h1').should('contain', 'Long-term care home')
-    cy.get('input#trilliumLongTermCareClaim0 + label').should(
-      'have.attr',
-      'for',
-      'trilliumLongTermCareClaim0',
-    )
+    cy.confirm({
+      url: '/trillium/longTermCare',
+      h1: 'Long-term care home',
+      id: 'trilliumLongTermCareClaim0', // click Yes
+    })
 
-    cy.get('input#trilliumLongTermCareClaim0').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  //TRILLIUM LONG TERM CARE TYPE
   it('navigates the Trillium Long Term Care Type page', function() {
-    //TRILLIUM LONG TERM CARE TYPE
-    cy.url().should('contain', '/trillium/longTermCare/type')
-    cy.get('h1').should('contain', 'Public or non-profit long-term care')
-    cy.get('input#trilliumLongTermCareTypeClaim0 + label').should(
-      'have.attr',
-      'for',
-      'trilliumLongTermCareTypeClaim0',
-    )
+    cy.confirm({
+      url: '/trillium/longTermCare/type',
+      h1: 'Public or non-profit long-term care',
+      id: 'trilliumLongTermCareTypeClaim0', // click Yes
+    })
 
-    cy.get('input#trilliumLongTermCareTypeClaim0').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  //TRILLIUM LONG TERM CARE AMOUNT
   it('navigates the Trillium Long Term Care AMOUNT page', function() {
-    //TRILLIUM LONG TERM CARE AMOUNT
-    cy.url().should('contain', '/trillium/longTermCare/type/amount')
-    cy.get('h1').should('contain', 'Enter your long-term care home costs')
+    cy.amount({
+      url: '/trillium/longTermCare/type/amount',
+      h1: 'Enter your long-term care home costs',
+      id: 'trilliumLongTermCareAmount',
+    })
 
-    cy.get('#trilliumLongTermCareAmount__label').should('have.attr', 'for', 'trilliumLongTermCareAmount')
-
-    cy.get('input#trilliumLongTermCareAmount').should('have.attr', 'placeholder', '0.00').should('have.attr', 'value', '').type('25')
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
-
-    cy.url().should('contain', '/deductions/climate-action-incentive')
-    cy.get('a.back-link').should('contain', 'Go back').click()
-    cy.url().should('contain', '/trillium/longTermCare/type/amount')
-    cy.get('input#trilliumLongTermCareAmount').should('have.attr', 'value', '25.00')
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
-  it('navigates  Incentive page', function() {
-    //CLIMATE ACTION INCENTIVE
-    cy.url().should('contain', '/deductions/climate-action-incentive')
-    cy.get('h1').should('contain', 'Small and rural communities')
+  //CLIMATE ACTION INCENTIVE
+  it('navigates Climate Action Incentive page', function() {
+    cy.confirm({
+      url: '/deductions/climate-action-incentive',
+      h1: 'Small and rural communities',
+      id: 'climateActionIncentiveIsRural0', // click Yes
+    })
 
-    cy.get('input#climateActionIncentiveIsRural0 + label').should(
-      'have.attr',
-      'for',
-      'climateActionIncentiveIsRural0',
-    )
-
-    cy.get('input#climateActionIncentiveIsRural0').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'Continue')
-      .click()
+    cy.continue()
   })
 
+  // VOTER OPT IN
+  it('navigates Voter Opt In page', function() {
+    cy.confirm({
+      url: '/vote/optIn',
+      h1: 'Register to vote',
+      id: 'confirmOptIn0', // click Yes
+    })
+
+    cy.continue()
+  })
+
+  // VOTER CONFIRMATION
+  it('navigates Voter Confirmation page', function() {
+    cy.url().should('contain', '/vote/confirmRegistration')
+    cy.get('h1').should('contain', 'Register to vote')
+
+    cy.get('input#voterCitizen + label').should('have.attr', 'for', 'voterCitizen')
+    cy.get('input#voterCitizen').click()
+
+    cy.get('input#voterConsent + label').should('have.attr', 'for', 'voterConsent')
+    cy.get('input#voterConsent').click()
+
+    cy.continue()
+  })
+
+  // CHECK ANSWERS
   it('navigates the Check Your Answers page', function() {
     cy.url().should('contain', '/checkAnswers')
     cy.get('h1').should('contain', 'Check your answers before filing')
@@ -346,26 +261,23 @@ describe('Full run through', function() {
       .click()
   })
 
+  //REVIEW
   it('navigates the Review page', function() {
-    //REVIEW
-    cy.url().should('contain', '/review')
-    cy.get('h1').should('contain', 'Review and file tax return')
+    cy.confirm({
+      url: '/review',
+      h1: 'Review and file tax return',
+      id: 'review', // click checkbox
+    })
 
     //check some table data
     //until we have a more firm grasp on how we're shaping the total refund, i'm just checking benefits
     checkTableRows(cy, getBenefitsBreakdownRows(this.user))
 
-    cy.get('input#review + label').should('have.attr', 'for', 'review')
-
-    cy.get('input#review').click()
-
-    cy.get('form button[type="submit"]')
-      .should('contain', 'File your taxes now')
-      .click()
+    cy.continue('File your taxes now')
   })
 
+  // CONFIRMATION PAGE
   it('checks the Confirmation page', function() {
-    // CONFIRMATION PAGE
     cy.url().should('contain', '/confirmation')
     cy.get('h1').should('contain', 'You have filed your 2018 taxes')
     cy.get('th').should('contain', 'Your 2018 filing code is')

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -20,3 +20,136 @@ import 'cypress-axe'
 Cypress.Cookies.defaults({
   whitelist: '_csrf',
 })
+
+Cypress.Commands.add('login', user => {
+  cy.injectAxe().checkA11y()
+  cy.url().should('contain', '/login/code')
+  cy.get('h1').should('contain', 'Enter your personal filing code')
+  cy.get('form label').should('have.attr', 'for', 'code')
+  cy.get('form input#code')
+    .type(user.login.code)
+    .should('have.value', user.login.code)
+  cy.get('form button[type="submit"]')
+    .should('contain', 'Continue')
+    .click()
+
+  // LOGIN SIN
+  cy.injectAxe().checkA11y()
+  cy.url().should('contain', '/login/sin')
+  cy.get('h1').should('contain', 'Enter your Social insurance number (SIN)')
+  cy.get('h2').should('contain', `${user.personal.firstName}, thanks for your filing code.`)
+  cy.get('form label').should('have.attr', 'for', 'sin')
+  cy.get('form input#sin')
+    .type(user.personal.sin)
+    .should('have.value', user.personal.sin)
+  cy.get('form button[type="submit"]')
+    .should('contain', 'Continue')
+    .click()
+
+  // LOGIN DOB
+  cy.injectAxe().checkA11y()
+  cy.url().should('contain', '/login/dateOfBirth')
+  cy.get('h1').should('contain', 'Enter your date of birth')
+
+  cy.get('form label')
+    .eq(0)
+    .should('have.attr', 'for', 'dobDay')
+  cy.get('form label')
+    .eq(1)
+    .should('have.attr', 'for', 'dobMonth')
+  cy.get('form label')
+    .eq(2)
+    .should('have.attr', 'for', 'dobYear')
+
+  const [dobYear, dobMonth, dobDay] = user.personal.dateOfBirth.split('-')
+
+  cy.get('form input#dobDay')
+    .type(dobDay)
+    .should('have.value', dobDay)
+
+  cy.get('form input#dobMonth')
+    .type(dobMonth)
+    .should('have.value', dobMonth)
+
+  cy.get('form input#dobYear')
+    .type(dobYear)
+    .should('have.value', dobYear)
+
+  cy.get('form button[type="submit"]')
+    .should('contain', 'Continue')
+    .click()
+
+  // LOGIN SECURITY QUESTIONS
+  cy.injectAxe().checkA11y()
+  cy.url().should('contain', '/login/securityQuestion')
+  cy.get('h1').should('contain', 'Choose a security question')
+
+  cy.get('form label')
+    .eq(3)
+    .should('have.attr', 'for', 'securityQuestion3')
+  cy.get('#securityQuestion3').check()
+
+  cy.get('form button[type="submit"]')
+    .should('contain', 'Continue')
+    .click()
+
+  // LOGIN TRILLIUM QUESTION
+  cy.injectAxe().checkA11y()
+  cy.url().should('contain', '/login/questions/dateOfResidence')
+  cy.get('h1').should('contain', 'Enter date you became a resident of Canada')
+
+  cy.get('form label')
+    .eq(0)
+    .should('have.attr', 'for', 'dobDay')
+  cy.get('#dobDay')
+    .type('1')
+    .should('have.value', '1')
+
+  cy.get('form label')
+    .eq(1)
+    .should('have.attr', 'for', 'dobMonth')
+  cy.get('#dobMonth')
+    .type('2')
+    .should('have.value', '2')
+
+  cy.get('form label')
+    .eq(2)
+    .should('have.attr', 'for', 'dobYear')
+  cy.get('#dobYear')
+    .type('1997')
+    .should('have.value', '1997')
+
+  cy.get('form button[type="submit"]')
+    .should('contain', 'Continue')
+    .click()
+})
+
+Cypress.Commands.add('confirm', ({ url, h1, id }) => {
+  cy.url().should('contain', url)
+  cy.get('h1').should('contain', h1)
+
+  if (url.endsWith('/residence')) {
+    cy.get('form label').should('have.attr', 'for', id)
+  } else {
+    cy.get(`input#${id} + label`).should('have.attr', 'for', id)
+    cy.get(`input#${id}`).click()
+  }
+})
+
+Cypress.Commands.add('amount', ({ url, h1, id }) => {
+  cy.url().should('contain', url)
+  cy.get('h1').should('contain', h1)
+
+  cy.get(`#${id}__label`).should('have.attr', 'for', id)
+
+  cy.get(`input#${id}`)
+    .should('have.attr', 'placeholder', '0.00')
+    .clear()
+    .type('25')
+})
+
+Cypress.Commands.add('continue', (label = 'Continue') => {
+  cy.get('form button[type="submit"]')
+    .should('contain', label)
+    .click()
+})

--- a/cypress/utils.js
+++ b/cypress/utils.js
@@ -22,7 +22,7 @@ const getIncomeBreakdownRows = user => {
 
   incomeRows.push({
     key: 'Total Income',
-    value:  `$${user.financial.incomes.totalIncome.amount.toLocaleString('en-US')}`,
+    value: `$${user.financial.incomes.totalIncome.amount.toLocaleString('en-US')}`,
   })
 
   return incomeRows
@@ -46,7 +46,7 @@ const getTaxBreakdownRows = user => {
 }
 
 const getBenefitsBreakdownRows = user => {
-  const benefitsKeys = Object.values(user.benefits);
+  const benefitsKeys = Object.values(user.benefits)
   const benefitsRows = benefitsKeys.map(source => {
     return {
       key: source.name,
@@ -70,114 +70,9 @@ const getAddress = address => {
   return fullAddress
 }
 
-const logIn = (cy, user) => {
-  // LOGIN CODE PAGE
-  cy.injectAxe().checkA11y()
-  cy.url().should('contain', '/login/code')
-  cy.get('h1').should('contain', 'Enter your personal filing code')
-  cy.get('form label').should('have.attr', 'for', 'code')
-  cy.get('form input#code')
-    .type(user.login.code)
-    .should('have.value', user.login.code)
-  cy.get('form button[type="submit"]')
-    .should('contain', 'Continue')
-    .click()
-
-  // LOGIN SIN
-  cy.injectAxe().checkA11y()
-  cy.url().should('contain', '/login/sin')
-  cy.get('h1').should('contain', 'Enter your Social insurance number (SIN)')
-  cy.get('h2').should('contain', `${user.personal.firstName}, thanks for your filing code.`)
-  cy.get('form label').should('have.attr', 'for', 'sin')
-  cy.get('form input#sin')
-    .type(user.personal.sin)
-    .should('have.value', user.personal.sin)
-  cy.get('form button[type="submit"]')
-    .should('contain', 'Continue')
-    .click()
-
-  // LOGIN DOB
-  cy.injectAxe().checkA11y()
-  cy.url().should('contain', '/login/dateOfBirth')
-  cy.get('h1').should('contain', 'Enter your date of birth')
-
-  cy.get('form label')
-    .eq(0)
-    .should('have.attr', 'for', 'dobDay')
-  cy.get('form label')
-    .eq(1)
-    .should('have.attr', 'for', 'dobMonth')
-  cy.get('form label')
-    .eq(2)
-    .should('have.attr', 'for', 'dobYear')
-
-  const [dobYear, dobMonth, dobDay] = user.personal.dateOfBirth.split('-')
-
-  cy.get('form input#dobDay')
-    .type(dobDay)
-    .should('have.value', dobDay)
-
-  cy.get('form input#dobMonth')
-    .type(dobMonth)
-    .should('have.value', dobMonth)
-
-  cy.get('form input#dobYear')
-    .type(dobYear)
-    .should('have.value', dobYear)
-
-  cy.get('form button[type="submit"]')
-    .should('contain', 'Continue')
-    .click()
-
-  // LOGIN SECURITY QUESTIONS
-  cy.injectAxe().checkA11y()
-  cy.url().should('contain', '/login/securityQuestion')
-  cy.get('h1').should('contain', 'Choose a security question')
-
-  cy.get('form label')
-    .eq(3)
-    .should('have.attr', 'for', 'securityQuestion3')
-  cy.get('#securityQuestion3').check()
-
-  cy.get('form button[type="submit"]')
-    .should('contain', 'Continue')
-    .click()
-
-  // LOGIN TRILLIUM QUESTION
-  cy.injectAxe().checkA11y()
-  cy.url().should('contain', '/login/questions/dateOfResidence')
-  cy.get('h1').should('contain', 'Enter date you became a resident of Canada')
-
-  cy.get('form label')
-    .eq(0)
-    .should('have.attr', 'for', 'dobDay')
-  cy.get('#dobDay')
-    .type('1')
-    .should('have.value', '1')
-
-  cy.get('form label')
-    .eq(1)
-    .should('have.attr', 'for', 'dobMonth')
-  cy.get('#dobMonth')
-    .type('2')
-    .should('have.value', '2')
-
-  cy.get('form label')
-    .eq(2)
-    .should('have.attr', 'for', 'dobYear')
-  cy.get('#dobYear')
-    .type('1997')
-    .should('have.value', '1997')
-
-  cy.get('form button[type="submit"]')
-    .should('contain', 'Continue')
-    .click()
-}
-
 module.exports = {
   checkTableRows,
   allIncomeRows,
   getBenefitsBreakdownRows,
   getAddress,
-  logIn,
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -495,5 +495,6 @@
   "Institution number": "Institution number",
   "3 digits": "3 digits",
   "Account number": "Account number",
-  "12 digits": "12 digits"
+  "12 digits": "12 digits",
+  "Did you have home energy costs on a reserve?": "Did you have home energy costs on a reserve?"
 }

--- a/utils/index.js
+++ b/utils/index.js
@@ -193,17 +193,16 @@ const doYesNo = (claim, fields) => {
   }
 }
 
-
 const postAmount = (amount, locale) => {
-  if(!amount || amount === '') {
+  if (!amount || amount === '') {
     return amount
   }
 
-  if(locale === 'fr') {
+  if (locale === 'fr') {
     const formattedAmount = amount.replace(',', '.').replace(/\s/g, '')
 
     return formattedAmount
-  } 
+  }
 
   //remove commas for English format inputs, just for consistency of storing
   return amount.replace(/,/g, '')
@@ -268,13 +267,13 @@ const hasData = (obj, key, returnVal = false) => {
 
 /**
  * @param {String} locale the locale we would like to format for, passed either as 'fr' or 'en' in our case
- * 
+ *
  * @param {String|Number} amount the number we're passing to format, which is passed either explicitly as a number or a string (we cast it as a number in currencyFilter, regardless)
- * 
+ *
  * Essentially calls currencyFilter, but removes the dollar sign unit
  */
 const currencyWithoutUnit = (locale = 'en', amount = 0) => {
-  return (amount !== '') ? currencyFilter(amount, locale).replace(/\$/g, '') : ''
+  return amount !== '' ? currencyFilter(amount, locale).replace(/\$/g, '') : ''
 }
 
 /**
@@ -282,17 +281,16 @@ const currencyWithoutUnit = (locale = 'en', amount = 0) => {
  * @param {String} locale the locale we would like to format for, passed either as 'fr' or 'en' in our case
  */
 const currencyFilter = (number, locale = 'en') => {
-
   const amount = Number(number)
 
-  const localeSetting = (locale === 'en') ? 'en-US' : 'fr-CA'
+  const localeSetting = locale === 'en' ? 'en-US' : 'fr-CA'
 
   const filteredAmount = amount.toLocaleString(localeSetting, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   })
 
-  if(locale === 'fr') {
+  if (locale === 'fr') {
     return `${filteredAmount}$`
   }
 

--- a/views/confirmation/check-answers.pug
+++ b/views/confirmation/check-answers.pug
@@ -22,7 +22,7 @@ block content
                   +address(data)
               else
                 //- we don't want to translate the name, dollar amounts, or birthday (formatting the birthday is done prior to hitting the template in checkAnswersFormat)
-                if (row.text.toLowerCase().includes('name') || row.text.includes('$') || row.text.toLowerCase().includes('birth'))
+                if (row.text.toLowerCase().includes('name') || row.data.includes('$') || row.text.toLowerCase().includes('birth'))
                   dd.breakdown-table__row-value #{row.data}
                 else
                   dd.breakdown-table__row-value #{__(row.data)}


### PR DESCRIPTION
## Cypress tests, with amounts!
Another Cypress test to run through the app, and say yes to questions and add amounts. This includes entering an amount, navigating one page forward, and then one page back to check the amount is there.

## Why do things cache?
Only issue is it seems to cache the input entered between runs. Nobody knows why.

~In order for a repeat run to work, I have to kill cypress, and re-run for a clean run--looking into this, but does anyone else want to take a crack at it?~

New code doesn't expect amounts to be empty. Just clears whatever's in the field and enters a new amount. Easy.