### PR TITLE
Pre security screening page

### DIFF
--- a/config/routes.config.js
+++ b/config/routes.config.js
@@ -19,6 +19,7 @@ const routes = [
   { path: '/offramp', editInfo: 'skip' },
   { path: '/login/sin' },
   { path: '/login/dateOfBirth' },
+  { path: '/login/notice' },
   { path: '/login/securityQuestion' },
   { path: '/login/questions', options: ['/login/securityQuestion2'] },
   { path: '/login/questions', options: securityQuestionUrls },

--- a/locales/en.json
+++ b/locales/en.json
@@ -501,5 +501,10 @@
   "Did you have home energy costs on a reserve?": "Did you have home energy costs on a reserve?",
   "Check your papers from any year you filed taxes": "Check your papers from any year you filed taxes",
   "Enter year of tax filing": "Enter year of tax filing",
-  "Enter your total income on line 101 for that year:": "Enter your total income on line 101 for that year:"
+  "Enter your total income on line 101 for that year:": "Enter your total income on line 101 for that year:",
+  "Notice of assessment": "Notice of assessment",
+  "CRA sends your notice of assessment about 2 weeks after you file taxes.": "CRA sends your notice of assessment about 2 weeks after you file taxes.",
+  "You can download the notice immediately after filing by answering security questions. You will be able to print or save the downloaded notice.": "You can download the notice immediately after filing by answering security questions. You will be able to print or save the downloaded notice.",
+  "The questions ask for information such as your previous addresses and banking details. You may need to check your records to find the answers.": "The questions ask for information such as your previous addresses and banking details. You may need to check your records to find the answers.",
+  "Do you want to answer security questions?": "Do you want to answer security questions?"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -474,5 +474,10 @@
   "If you are able to check both boxes, Elections Canada will put you on the voter’s list until you file taxes again.": "If you are able to check both boxes, Elections Canada will put you on the voter’s list until you file taxes again.",
   "Check the boxes if:": "Check the boxes if:",
   "You are a Canadian citizen.": "You are a Canadian citizen.",
-  "You allow CRA to give your name, address, date of birth and citizenship status to Elections Canada. Elections Canada uses the information to update voter records.": "You allow CRA to give your name, address, date of birth and citizenship status to Elections Canada. Elections Canada uses the information to update voter records."
+  "You allow CRA to give your name, address, date of birth and citizenship status to Elections Canada. Elections Canada uses the information to update voter records.": "You allow CRA to give your name, address, date of birth and citizenship status to Elections Canada. Elections Canada uses the information to update voter records.",
+  "Notice of assessment": "Notice of assessment",
+  "CRA sends your notice of assessment about 2 weeks after you file taxes.": "CRA sends your notice of assessment about 2 weeks after you file taxes.",
+  "You can download the notice immediately after filing by answering security questions. You will be able to print or save the downloaded notice.": "You can download the notice immediately after filing by answering security questions. You will be able to print or save the downloaded notice.",
+  "The questions ask for information such as your previous addresses and banking details. You may need to check your records to find the answers.": "The questions ask for information such as your previous addresses and banking details. You may need to check your records to find the answers.",
+  "Do you want to answer security questions?": "Do you want to answer security questions?"
 }

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -44,7 +44,12 @@ module.exports = function(app) {
     '/login/notice',
     checkSchema(noticeSchema),
     checkErrors('login/notice'),
-    postNotice,
+    (req, res, next) => {
+      if (req.body.noticeOfAssessment === 'No') {
+        return res.redirect('/checkAnswers')
+      }
+      next()
+    },
     doRedirect,
   )
 
@@ -213,15 +218,4 @@ const postSecurityQuestion = async (req, res) => {
 
   req.session.login.securityQuestion = url
   return res.redirect(url)
-}
-
-const postNotice = (req, res, next) => {
-  const noticeOfAssessment = req.body.noticeOfAssessment
-
-  if (noticeOfAssessment === 'No') {
-    return res.redirect('/')
-  }
-
-  req.session.login.noticeOfAssessment = true
-  next()
 }

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -11,6 +11,7 @@ const {
   loginSchema,
   sinSchema,
   dobSchema,
+  noticeSchema,
   securityQuestionSchema,
   childSchema,
   dateOfResidenceSchema,
@@ -37,6 +38,15 @@ module.exports = function(app) {
   // Date of Birth
   app.get('/login/dateOfBirth', renderWithData('login/dateOfBirth'))
   app.post('/login/dateOfBirth', checkSchema(dobSchema), postDateOfBirth, doRedirect)
+
+  app.get('/login/notice', renderWithData('login/notice'))
+  app.post(
+    '/login/notice',
+    checkSchema(noticeSchema),
+    checkErrors('login/notice'),
+    postNotice,
+    doRedirect,
+  )
 
   // Security question page
   app.get('/login/securityQuestion', renderWithData('login/securityQuestion'))
@@ -203,4 +213,15 @@ const postSecurityQuestion = async (req, res) => {
 
   req.session.login.securityQuestion = url
   return res.redirect(url)
+}
+
+const postNotice = (req, res, next) => {
+  const noticeOfAssessment = req.body.noticeOfAssessment
+
+  if (noticeOfAssessment === 'No') {
+    return res.redirect('/')
+  }
+
+  req.session.login.noticeOfAssessment = true
+  next()
 }

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -380,6 +380,50 @@ describe('Test /login responses', () => {
       })
     })
 
+    describe('Test /login/notice responses', () => {
+      const session = require('supertest-session')
+    
+      let csrfToken, cookie
+    
+      beforeEach(async () => {
+        let testSession = session(app)
+        const getresp = await testSession.get('/login/notice')
+        cookie = getresp.headers['set-cookie']
+        csrfToken = extractCsrfToken(getresp)
+      })
+    
+      test('it returns a 200 response for /login/notice', async () => {
+        const response = await request(app).get('/login/notice')
+        expect(response.statusCode).toBe(200)
+      })
+    
+      test('it returns a 422 with no option selected', async () => {
+        const response = await request(app)
+          .post('/login/notice')
+          .use(withCSRF(cookie, csrfToken))
+          .send({ redirect: '/' })
+        expect(response.statusCode).toBe(422)
+      })
+    
+      test('it returns a 302 and redirects to offramp when NO is selected', async () => {
+        const response = await request(app)
+          .post('/login/notice')
+          .use(withCSRF(cookie, csrfToken))
+          .send({ noticeOfAssessment: 'No', redirect: '/' })
+        expect(response.statusCode).toBe(302)
+        expect(response.headers.location).toEqual('/')
+      })
+    
+      test('it returns a 302 and redirects to the same page when YES is selected', async () => {
+        const response = await request(app)
+          .post('/login/notice')
+          .use(withCSRF(cookie, csrfToken))
+          .send({ noticeOfAssessment: 'Yes', redirect: '/login/securityQuestion' })
+        expect(response.statusCode).toBe(302)
+        expect(response.headers.location).toEqual('/login/securityQuestion')
+      })
+    })
+
     describe('for /login/questions/child', () => {
       beforeEach(async () => {
         const testSession = session(app)

--- a/routes/login/login.spec.js
+++ b/routes/login/login.spec.js
@@ -382,21 +382,21 @@ describe('Test /login responses', () => {
 
     describe('Test /login/notice responses', () => {
       const session = require('supertest-session')
-    
+
       let csrfToken, cookie
-    
+
       beforeEach(async () => {
         let testSession = session(app)
         const getresp = await testSession.get('/login/notice')
         cookie = getresp.headers['set-cookie']
         csrfToken = extractCsrfToken(getresp)
       })
-    
+
       test('it returns a 200 response for /login/notice', async () => {
         const response = await request(app).get('/login/notice')
         expect(response.statusCode).toBe(200)
       })
-    
+
       test('it returns a 422 with no option selected', async () => {
         const response = await request(app)
           .post('/login/notice')
@@ -404,23 +404,23 @@ describe('Test /login responses', () => {
           .send({ redirect: '/' })
         expect(response.statusCode).toBe(422)
       })
-    
+
       test('it returns a 302 and redirects to offramp when NO is selected', async () => {
         const response = await request(app)
           .post('/login/notice')
           .use(withCSRF(cookie, csrfToken))
-          .send({ noticeOfAssessment: 'No', redirect: '/' })
+          .send({ noticeOfAssessment: 'No', redirect: '/start' })
         expect(response.statusCode).toBe(302)
-        expect(response.headers.location).toEqual('/')
+        expect(response.headers.location).toEqual('/checkAnswers')
       })
-    
-      test('it returns a 302 and redirects to the same page when YES is selected', async () => {
+
+      test('it returns a 302 and redirects to the posted redirect value when YES is selected', async () => {
         const response = await request(app)
           .post('/login/notice')
           .use(withCSRF(cookie, csrfToken))
-          .send({ noticeOfAssessment: 'Yes', redirect: '/login/securityQuestion' })
+          .send({ noticeOfAssessment: 'Yes', redirect: '/start' })
         expect(response.statusCode).toBe(302)
-        expect(response.headers.location).toEqual('/login/securityQuestion')
+        expect(response.headers.location).toEqual('/start')
       })
     })
 

--- a/schemas/login.schema.js
+++ b/schemas/login.schema.js
@@ -3,7 +3,6 @@ const { validationArray, currencySchema, yesNoSchema } = require('./utils.schema
 const API = require('./../api')
 const { securityQuestionUrls } = require('../config/routes.config')
 
-
 const loginSchema = {
   code: {
     isLength: {
@@ -332,7 +331,7 @@ const taxReturnSchema = {
       errorMessage: 'errors.login.taxReturn.currency',
       options: { allow_negatives: false },
     },
-  }
+  },
 }
 
 module.exports = {

--- a/schemas/login.schema.js
+++ b/schemas/login.schema.js
@@ -1,7 +1,8 @@
 const validator = require('validator')
-const { validationArray, currencySchema } = require('./utils.schema')
+const { validationArray, currencySchema, yesNoSchema } = require('./utils.schema')
 const API = require('./../api')
 const { securityQuestionUrls } = require('../config/routes.config')
+
 
 const loginSchema = {
   code: {
@@ -110,6 +111,10 @@ const dobSchema = {
       options: { min: currentDate.getFullYear() - 200, max: currentDate.getFullYear() },
     },
   },
+}
+
+const noticeSchema = {
+  noticeOfAssessment: yesNoSchema(),
 }
 
 const securityQuestionSchema = {
@@ -334,6 +339,7 @@ module.exports = {
   loginSchema,
   dobSchema,
   sinSchema,
+  noticeSchema,
   securityQuestionSchema,
   childSchema,
   dateOfResidenceSchema,

--- a/views/login/notice.pug
+++ b/views/login/notice.pug
@@ -1,0 +1,20 @@
+extends ../base
+
+block variables
+  -var title = __('Notice of assessment')
+  -var noticeOfAssessment = !hasData(data, 'login.noticeOfAssessment') ? '' : data.login.noticeOfAssessment ? 'Yes' : 'No'
+
+block content
+
+  h1 #{title}
+
+  p #{__('CRA sends your notice of assessment about 2 weeks after you file taxes.')}
+  p #{__('You can download the notice immediately after filing by answering security questions. You will be able to print or save the downloaded notice.')}
+  p #{__('The questions ask for information such as your previous addresses and banking details. You may need to check your records to find the answers.')}
+
+  form.cra-form(method='post')
+    +radiosYesNo('noticeOfAssessment', 'Do you want to answer security questions?', noticeOfAssessment)
+
+    input#redirect(name='redirect', type='hidden', value='/login/securityQuestion')
+
+    +formButtons()


### PR DESCRIPTION
## This PR consists of the following

### This PR is based off of [this trello card](https://trello.com/c/nQSzEKf4)

### Creating the `/login/notice` page for pre-security question page screening
- Validation testing showed us that we need a page before the security questions if placed at the end of the flow as a break point between full and lite mode, otherwise the task is confusing
- Route was created
- login controller and schema we modified for this new page
- tests were updated
- french is missing

### Note 
I didn't add it to the flow, I figured it would be easier to do once the questions have been moved to the end of the flow, otherwise it would skip to a weird page and not really make sense

### GIF
![notice](https://user-images.githubusercontent.com/30609058/69587426-86010d80-0fb3-11ea-8fa8-fc8dde433a49.gif)
