### PR TITLE
Fix french form spacing

### DIFF
--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -141,13 +141,13 @@ form.cra-form {
       padding-left: $space-xl;
       margin-left: -$space-xl;
       z-index: 20;
-    }
 
-    &.fr {
-      padding-left: 0;
-      margin-left: 0;
-      padding-right: $space-xl + $space-xs;
-      margin-right: -$space-xl;
+      &.fr {
+        padding-left: $space-xs;
+        margin-left: 0;
+        padding-right: $space-xl + $space-xs;
+        margin-right: -$space-xl;
+      }
     }
   }
 


### PR DESCRIPTION
Due to some incorrect SCSS nesting, we were removing the left padding (and hugely bumping the right padding) on all text inputs when we just want to do it for the "with unit" inputs.

# Screenshots

| before | after |
|--------|-------|
|  ![image](https://user-images.githubusercontent.com/2454380/69589600-a2ed0f00-0fba-11ea-81d2-3bbd99572d5c.png)    | ![image](https://user-images.githubusercontent.com/2454380/69589685-ee9fb880-0fba-11ea-8260-0155204be462.png)  |





