### PR TITLE
Prefill login pages with typed data when user is fixing errors

### DIFF
--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -213,13 +213,18 @@ const postLogin = async (req, res, next) => {
     return res.redirect('/login/code')
   }
 
+  req.session.login.dateOfBirth = _toISOFormat(req.body)
+  
+  // save each box as the user typed it for usability if there is an error
+  req.session.login.dobDay = req.body.dobDay
+  req.session.login.dobMonth = req.body.dobMonth
+  req.session.login.dobYear = req.body.dobYear
+
   // if no SIN, return to SIN page
   if (!req.session.login.sin) {
     _loginError(req, { id: 'sin', msg: 'errors.login.missingSIN' })
     return res.redirect('/login/sin')
   }
-
-  req.session.login.dateOfBirth = _toISOFormat(req.body)
 
   // check access code + SIN + DoB
   const { code, sin, dateOfBirth } = req.session.login

--- a/views/login/dateOfBirth.pug
+++ b/views/login/dateOfBirth.pug
@@ -4,9 +4,9 @@ include ../_includes/input-dates
 block variables
   -var title = __('Enter your date of birth')
   -var dateOfBirth = hasData(body, 'dateOfBirth') ? body.dateOfBirth : ''
-  -var dobDay = hasData(body, 'dobDay') ? body.dobDay : ''
-  -var dobMonth = hasData(body, 'dobMonth') ? body.dobMonth : ''
-  -var dobYear = hasData(body, 'dobYear') ? body.dobYear : ''
+  -var dobDay = hasData(body, 'dobDay') ? body.dobDay : (hasData(data.login, 'dobDay') ? data.login.dobDay : '')
+  -var dobMonth = hasData(body, 'dobMonth') ? body.dobMonth : (hasData(data.login, 'dobMonth') ? data.login.dobMonth : '')
+  -var dobYear = hasData(body, 'dobYear') ? body.dobYear : (hasData(data.login, 'dobYear') ? data.login.dobYear : '')
 
 block content
 

--- a/views/login/sin.pug
+++ b/views/login/sin.pug
@@ -3,7 +3,7 @@ include ../_includes/banner
 
 block variables
   -var title = __('Enter your Social insurance number (SIN)')
-  -var sin = hasData(body, 'sin') ? body.sin : ''
+  -var sin = hasData(body, 'sin') ? body.sin : (hasData(data.login, 'sin') ? data.login.sin : '')
 
 block content
 

--- a/views/login/sin.pug
+++ b/views/login/sin.pug
@@ -4,13 +4,14 @@ include ../_includes/banner
 block variables
   -var title = __('Enter your Social insurance number (SIN)')
   -var sin = hasData(body, 'sin') ? body.sin : (hasData(data.login, 'sin') ? data.login.sin : '')
+  -var firstName = hasData(data, 'login.firstName') ? data.login.firstName : (hasData(data, 'personal.firstName') ? data.personal.firstName : '' )
 
 block content
 
   h1 #{title}
 
-  if data.login
-    h2 #{data.login.firstName}, #{__('thanks for your filing code')}.
+  if firstName
+    h2 #{firstName}, #{__('thanks for your filing code')}.
 
   form.cra-form(method='post')
     div(class={['has-error']: errors && errors.sin})


### PR DESCRIPTION
Closes: https://trello.com/c/NEbn19FJ/453-s-put-the-previously-entered-sin-and-date-of-birth-back-in-the-login-fields

Essentially the same process as we're using elsewhere in the app, just checking the session.login variable for data.

I saved dobDay, dobMonth, and dobYear to session.login so that we could show the user exactly what they typed.