### PR TITLE
Remove tax-related information from the confirm income page

### DIFF
--- a/api/user.json
+++ b/api/user.json
@@ -148,27 +148,6 @@
     "trilliumLongTermCareAmount": 0,
     "climateActionIncentiveIsRural": null
   },
-  "refund": {
-    "totalPayable": {
-      "name": "Total payable",
-      "line": 435,
-      "amount": 1593.00
-    },
-    "totalDeducted": {
-      "name": "Total deducted",
-      "line": 437,
-      "amount": 2312.88
-    },
-    "totalCredits": {
-      "name": "Total Credits",
-      "amount": 2500.00
-    },
-    "totalRefund": {
-      "name": "Total refund",
-      "line": 484,
-      "amount": 719.88
-    }
-  },
   "benefits": {
     "climateActionIncentive": {
       "name": "Climate action incentive",

--- a/views/confirmation/review.pug
+++ b/views/confirmation/review.pug
@@ -7,8 +7,6 @@ block variables
   -var incomes = hasData(data, 'financial.incomes') ? data.financial.incomes : {}
   -var taxes = hasData(data, 'financial.taxes') ? data.financial.taxes : {}
   -var refund = hasData(data, 'refund') ? data.refund : {}
-  -var totalRefund = hasData(data, 'refund.totalRefund') ? data.refund.totalRefund : 0
-  -var refundLines = sortByLineNumber(data.deductions, taxes, incomes, refund)
   -var locale = getLocale()
   -
     var rows =[

--- a/views/confirmation/review.pug
+++ b/views/confirmation/review.pug
@@ -94,25 +94,6 @@ block content
             dt.breakdown-table__row-key #{__('Total benefits')}
             dd.breakdown-table__row-value #{currencyFilter(totalBenefits)}
 
-    div
-      .breakdown-table
-        h2.breakdown-table__heading
-          span #{__('Your expected 2018 refund')}
-          span +#{currencyFilter(totalRefund.amount)}
-
-        p.breakdown-table__subheading #{__('Detailed breakdown of tax refund')}
-
-        dl.breakdown-table-data
-          each refundLine in refundLines
-            -var lineNumber = refundLine.multiLine ? refundLine.multiLine : refundLine.line
-            .breakdown-table__row(
-              class={
-                ['breakdown-table__row--summary space-row']: refundLine.name === "Total Refund"
-              }
-            )
-              dt.breakdown-table__row-key #{__(`${refundLine.name} (${lineNumber})`)}
-              dd.breakdown-table__row-value #{currencyFilter(refundLine.amount)}
-
   form.cra-form(method='post')
     div(class={['has-error']: errors && errors.review})
       .multiple-choice.multiple-choice--checkboxes


### PR DESCRIPTION
As per:
https://trello.com/c/wtXhsHL3/457-s-remove-tax-related-information-from-the-confirm-income-page

I didn't clear the i18n keys or any other manipulation code around this block removal. I removed unused variables within the `pug` file. Do we keep any kind of scaffolding code around this block or we clean it all?

Thanks