### PR TITLE
Remove tax info from income breakdown tables

### DIFF
--- a/cypress/fixtures/user.json
+++ b/cypress/fixtures/user.json
@@ -53,27 +53,6 @@
         "amount": 21305.10
       }
     },
-    "taxes": {
-      "federal": {
-        "name": "Net Federal tax",
-        "amount": 1060.00,
-        "line": 420
-      },
-      "provincial": {
-        "name": "Net Ontario tax",
-        "amount": 533.00,
-        "line": 428
-      },
-      "CPP": {
-        "name": "Canada Pension Plan (CPP)",
-        "amount": 1213.00
-      },
-      "EI": {
-        "name": "Employment Insurance (EI)",
-        "amount": 456.00
-      }
-    },
-    "totalTax": 3263.00,
     "taxableAmount": "$1,000.00"
   },
   "partner": null,

--- a/cypress/utils.js
+++ b/cypress/utils.js
@@ -38,23 +38,6 @@ const getIncomeBreakdownRows = user => {
   return incomeRows
 }
 
-const getTaxBreakdownRows = user => {
-  const taxKeys = Object.values(user.financial.taxes)
-  const taxRows = taxKeys.map(source => {
-    return {
-      key: `${source.name.replace('Net ', '')} deduction`,
-      value: `$${source.amount.toLocaleString('en-US')}`,
-    }
-  })
-
-  taxRows.push({
-    key: 'Total tax paid for 2018',
-    value: `$${user.financial.totalTax.toLocaleString('en-US')}`,
-  })
-
-  return taxRows
-}
-
 const getBenefitsBreakdownRows = user => {
   const benefitsKeys = Object.values(user.benefits)
   const benefitsRows = benefitsKeys.map(source => {

--- a/cypress/utils.js
+++ b/cypress/utils.js
@@ -79,7 +79,7 @@ const getBenefitsBreakdownRowsLite = user => {
   return benefitsLiteRows
 }
 
-const allIncomeRows = user => getIncomeBreakdownRows(user).concat(getTaxBreakdownRows(user))
+const allIncomeRows = user => getIncomeBreakdownRows(user)
 
 const getAddress = address => {
   const fullAddress = [`${address.city}, ${address.province}`, `${address.postalCode}`]

--- a/views/financial/income.pug
+++ b/views/financial/income.pug
@@ -38,23 +38,6 @@ block content
           dt.breakdown-table__row-key #{__(`Total Income for ${year}`)}
           dd.breakdown-table__row-value #{currencyFilter(totalIncome.amount, locale)}
 
-  .breakdown-table
-      h2.breakdown-table__heading
-        span #{__(`Total tax paid in ${year}`)}
-        span.breakdown-table__heading #{currencyFilter(totalTax, locale)}
-
-      p.breakdown-table__subheading #{__(`Detailed breakdown of taxes paid in ${year}`)}
-
-      dl.breakdown-table-data
-        each tax in taxes
-          .breakdown-table__row
-            dt.breakdown-table__row-key #{__(`${tax.name.replace('Net ', '').replace(/^\w/, c => c.toUpperCase())} deduction`)}
-            dd.breakdown-table__row-value #{currencyFilter(tax.amount, locale)}
-
-        .breakdown-table__row.breakdown-table__row--summary
-          dt.breakdown-table__row-key #{__(`Total tax paid for ${year}`)}
-          dd.breakdown-table__row-value #{currencyFilter(totalTax, locale)}
-
   form.cra-form(method='post')
     +radiosYesNo('confirmIncome', 'Is all of this information correct?', confirmedIncome)
 


### PR DESCRIPTION
## This PR consists of the following:
- Work for this PR is based off of the [[S/M] Remove tax paid info from /financial/income page]() trello card

### Data has been removed for the tax paid info on `/financial/income`
- `user.json` has been updated
-`/financial/income` has been updated
-`full_run_with_amounts_spec` has been updated

### Screenshot