### PR TITLE
Small changes to city names for Climate Action Incentive

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -393,7 +393,6 @@
   "The Climate Action Incentive": "The Climate Action Incentive",
   "Small and rural communities": "Small and rural communities",
   "Check if you live in a small and rural community": "Check if you live in a small and rural community",
-  "You live in a small and rural community if you live outside of:": "You live in a small and rural community if you live outside of:",
   "Barrie": "Barrie",
   "Belleville": "Belleville",
   "Brantford": "Brantford",
@@ -404,10 +403,8 @@
   "Kitchener-Cambridge-Waterloo": "Kitchener-Cambridge-Waterloo",
   "London": "London",
   "Oshawa": "Oshawa",
-  "Ottawa": "Ottawa",
   "Peterborough": "Peterborough",
   "St. Catharines-Niagara": "St. Catharines-Niagara",
-  "Sudbury": "Sudbury",
   "Thunder Bay": "Thunder Bay",
   "Windsor": "Windsor",
   "Did you live in a small and rural community in 2018?": "Did you live in a small and rural community in 2018?",
@@ -541,5 +538,10 @@
   "Please help us make it better": "Please help us make it better",
   "Now you can download a notice of assessment to print or save.": "Now you can download a notice of assessment to print or save.",
   "Your filing code": "Your filing code",
-  "The notice:": "The notice:"
+  "The notice:": "The notice:",
+  "You live in a small and rural community if you ": "You live in a small and rural community if you ",
+  "do not": "do not",
+  "Greater Sudbury": "Greater Sudbury",
+  "Ottawa-Gatineau (Ontario part)": "Ottawa-Gatineau (Ontario part)",
+  " live in:": " live in:"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -423,7 +423,6 @@
   "You may live in a long-term care home or facility if costs such as nursing or personal support are combined with your rent.": "Il est possible que vous viviez dans un foyer ou une résidence de soins de longue durée si des coûts de soins infirmiers ou d’assistance personnelle sont combinés à votre loyer.",
   "Small and rural communities": "Régions rurales et petites collectivités",
   "Check if you live in a small and rural community": "Vérifier si je vis dans une région rurale ou une petite collectivité",
-  "You live in a small and rural community if you live outside of:": "Vous vivez dans une région rurale ou une petite collectivité si vous habitez à l’extérieur de :",
   "Barrie": "Barrie",
   "Belleville": "Belleville",
   "Brantford": "Brantford",
@@ -434,10 +433,8 @@
   "Kitchener-Cambridge-Waterloo": "Kitchener-Cambridge-Waterloo",
   "London": "London",
   "Oshawa": "Oshawa",
-  "Ottawa": "Ottawa",
   "Peterborough": "Peterborough",
   "St. Catharines-Niagara": "St. Catharines-Niagara",
-  "Sudbury": "Sudbury",
   "Thunder Bay": "Thunder Bay",
   "Windsor": "Windsor",
   "Did you pay property tax?": "Avez-vous payé un impôt foncier?",
@@ -517,5 +514,10 @@
   "Please help us make it better": "Please help us make it better",
   "Now you can download a notice of assessment to print or save.": "Now you can download a notice of assessment to print or save.",
   "The notice:": "The notice:",
-  "thanks for your Social insurance number": "thanks for your Social insurance number"
+  "thanks for your Social insurance number": "thanks for your Social insurance number",
+  "You live in a small and rural community if you ": "You live in a small and rural community if you ",
+  "do not": "do not",
+  "Greater Sudbury": "Grand Sudbury",
+  "Ottawa-Gatineau (Ontario part)": "Ottawa-Gatineau (Ontario part)",
+  " live in:": " live in:"
 }

--- a/views/deductions/climate-action-incentive.pug
+++ b/views/deductions/climate-action-incentive.pug
@@ -16,11 +16,12 @@ block content
     div
       details.
         <summary><span>#{__('Check if you live in a small and rural community')}</span></summary>
-        <p>#{__('You live in a small and rural community if you live outside of:')}</p>
+        <p>#{__('You live in a small and rural community if you ')}<strong>#{__('do not')}</strong>#{__(' live in:')}</p>
         <ul>
           <li>#{__('Barrie')}</li>
           <li>#{__('Belleville')}</li>
           <li>#{__('Brantford')}</li>
+          <li>#{__('Greater Sudbury')}</li>
           <li>#{__('Greater Toronto Area')}</li>
           <li>#{__('Guelph')}</li>
           <li>#{__('Hamilton')}</li>
@@ -28,10 +29,9 @@ block content
           <li>#{__('Kitchener-Cambridge-Waterloo')}</li>
           <li>#{__('London')}</li>
           <li>#{__('Oshawa')}</li>
-          <li>#{__('Ottawa')}</li>
+          <li>#{__('Ottawa-Gatineau (Ontario part)')}</li>
           <li>#{__('Peterborough')}</li>
           <li>#{__('St. Catharines-Niagara')}</li>
-          <li>#{__('Sudbury')}</li>
           <li>#{__('Thunder Bay')}</li>
           <li>#{__('Windsor')}</li>
         </ul>


### PR DESCRIPTION
Updates the city names for the climate action incentive page, closes #387.

Also puts **do not** in bold, as requested.

## Screenshot

![image](https://user-images.githubusercontent.com/2454380/70267540-a7f54f80-176c-11ea-93e6-e15096281dcc.png)
