### PR TITLE
Add Cypress tests back

### DIFF
--- a/.github/workflows/testBuildDeploy.yml
+++ b/.github/workflows/testBuildDeploy.yml
@@ -2,21 +2,25 @@ name: Test, build, deploy
 on: push
 jobs:
   test:
-    name: Run tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+    name: Run tests
     steps:
       - uses: actions/checkout@master
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
       - name: Install npm dependencies
         run: npm install
-      - name: Run jest unit tests
-        run: npm test
-      - name: Run JS linter
-        run: npm run lint
-      - name: Run quality analysis on SonarCloud
-        uses: sonarsource/sonarcloud-github-action@master
-        env:
-          SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_SONAR_TOKEN }}
+      - name: Run Cypress end-to-end
+        uses: cypress-io/github-action@v1
+        with:
+          # we have already installed all dependencies above
+          install: false
+          start: npm run start:cypress
   deploy:
     name: Build container and deploy
     env:


### PR DESCRIPTION
Yesterday, I removed the Cypress tests from the application in Github actions, but that was for expedience. Really, we should put them back because they are making sure our page flow works and they are doing a11y checks for us.

Source: #391 

Found the official cypress github action and am running that one now

Looks way more legit + maintained: https://github.com/cypress-io/github-action

Read the README for setup instructions.