### PR TITLE
Re-add CI tests that were removed

### DIFF
--- a/.github/workflows/testBuildDeploy.yml
+++ b/.github/workflows/testBuildDeploy.yml
@@ -15,12 +15,21 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install npm dependencies
         run: npm install
+      - name: Run jest unit tests
+        run: npm test
+      - name: Run JS linter
+        run: npm run lint
       - name: Run Cypress end-to-end
         uses: cypress-io/github-action@v1
         with:
           # we have already installed all dependencies above
           install: false
           start: npm run start:cypress
+      - name: Run quality analysis on SonarCloud
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_SONAR_TOKEN }}
   deploy:
     name: Build container and deploy
     env:


### PR DESCRIPTION
In order to more effectively debug the cypress tests, I removed the other tests that would run first (I didn't want to wait for them every time) in PR #395.

Unfortunately, I merged the final PR without adding the tests back.

Kind of unfortunate, but no major harm done.