### PR TITLE
Add explicit max-height to FIP svg (for IE11)

### DIFF
--- a/public/scss/components/_header.scss
+++ b/public/scss/components/_header.scss
@@ -42,6 +42,8 @@ header {
   }
 
   .canada-flag {
+    height: auto;
+    min-height: 40px;
     width: 272px;
     margin-bottom: $space-sm;
 


### PR DESCRIPTION
On IE on Windows 7 and under, the SVG in the header has a height that is far too large, even though it visually is the right size. (that is, there is a lot of whitespace underneath the `img` element).

Checked how Canada.ca solves this problem and they set a max-height at `40px`, which seems to work and isn't too complicated. Looked up some stackoverflow questions but they mostly had complicated fixes so gonna go with this instead.

## Screenshots

| before | after |
|--------|-------|
| <img width="1475" alt="Screen Shot 2019-12-10 at 10 23 17 AM" src="https://user-images.githubusercontent.com/2454380/70542668-1eac9700-1b37-11ea-8a61-831d7f7e30f3.png">     | <img width="1475" alt="Screen Shot 2019-12-10 at 10 12 25 AM" src="https://user-images.githubusercontent.com/2454380/70542027-0d16bf80-1b36-11ea-846f-1f15ed93c718.png">   |




