### PR TITLE
Add middleware to extend doYesNo for longTermCare branching

### DIFF
--- a/api/user.json
+++ b/api/user.json
@@ -151,7 +151,7 @@
     "trilliumLongTermCareCost": null,
     "trilliumLongTermCareTypeClaim": null,
     "trilliumLongTermCareRoomAndBoardAmount": 0,
-    "trilliumLongTermCareIsFullAmount": null,
+    "trilliumLongTermCareAmountIsFull": null,
     "trilliumLongTermCareAmount": 0,
     "climateActionIncentiveIsRural": null
   },

--- a/cypress/fixtures/user.json
+++ b/cypress/fixtures/user.json
@@ -127,7 +127,7 @@
     "trilliumLongTermCareCost": null,
     "trilliumLongTermCareTypeClaim": null,
     "trilliumLongTermCareRoomAndBoardAmount": 0,
-    "trilliumLongTermCareIsFullAmount": null,
+    "trilliumLongTermCareAmountIsFull": null,
     "trilliumLongTermCareAmount": 0,
     "climateActionIncentiveIsRural": null
   },

--- a/routes/confirmation/checkAnswers.js
+++ b/routes/confirmation/checkAnswers.js
@@ -86,7 +86,7 @@ const answerInfo = [
         text: 'Long-term care costs',
         infoPath: ['deductions.trilliumLongTermCareAmount'],
         urlPath: '/trillium/longTermCare/type/amount',
-        displayIf: 'deductions.trilliumLongTermCareIsFullAmount',
+        displayIf: 'deductions.trilliumLongTermCareAmountIsFull',
       },
       {
         text: 'Did you live on a reserve?',


### PR DESCRIPTION
https://trello.com/c/qzJUdDs8/516-s-refactor-doyesno-function-to-support-branching-decisions

The new OTB long term care flow has a branching flow where both 'Yes' and 'No' lead to amounts pages. 

As per @pcraig3 suggestion, instead of refactoring doYesNo itself, I added a unique middleware that clears the required session data on a 'Yes' response as well as a 'No' response for this post. This did involve some refactoring, namely to split out the code that clears the session so it could be re-used, and splitting out the code to find the next route so it could also be re-used (to avoid having to directly import routes.config in other files)