### PR TITLE
Add client-side JS to remove the trailing URL hashes before a form submit

### DIFF
--- a/cypress/integration/remove_hashes.spec.js
+++ b/cypress/integration/remove_hashes.spec.js
@@ -1,0 +1,61 @@
+const { checkTableRows, getBenefitsBreakdownRows, getAddress } = require('../utils.js')
+
+describe('Removes hashes from URLs between form submit redirects', function() {
+  before(function() {
+    cy.visit('/clear')
+    cy.visit('/')
+  })
+
+  beforeEach(() => {
+    cy.fixture('user').as('user')
+    cy.injectAxe().checkA11y()
+  })
+
+  it('removes the #code hash after submitting a BAD code', function() {
+    cy.visit('/login/code')
+    // cause a validation error by clicking "continue" without a code
+    cy.code()
+
+    // clicking the validation error at the top puts an anchor link in the URL
+    cy.get('.error-list__link').click()
+    cy.url().should('contain', 'login/code#code')
+
+    // fill in the WRONG code and continue
+    cy.code({ code: 'BAD CODE' })
+
+    // check that #code is not part of the URL anymore
+    cy.url().should('not.contain', '#code')
+  })
+
+  it('removes the #code hash after submitting a GOOD code', function() {
+    cy.visit('/login/code')
+    // cause a validation error by clicking "continue" without a code
+    cy.code()
+
+    // clicking the validation error at the top puts an anchor link in the URL
+    cy.get('.error-list__link').click()
+    cy.url().should('contain', 'login/code#code')
+
+    // fill in the correct code and continue
+    cy.code({ code: this.user.login.code })
+
+    // check that #code is not part of the URL anymore
+    cy.url().should('not.contain', '#code')
+  })
+
+  it('removes the #content hash after submitting a good code', function() {
+    cy.visit('/login/code')
+
+    // click the skip link, causing an anchor link in the URL
+    cy.get('#skip-link')
+      .focus()
+      .click()
+    cy.url().should('contain', 'login/code#content')
+
+    // fill in the correct code and continue
+    cy.code({ code: this.user.login.code })
+
+    // check that #code is not part of the URL anymore
+    cy.url().should('not.contain', '#content')
+  })
+})

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -24,14 +24,7 @@ Cypress.Cookies.defaults({
 Cypress.Commands.add('login', user => {
   cy.injectAxe().checkA11y()
   cy.url().should('contain', '/login/code')
-  cy.get('h1').should('contain', 'Enter your personal filing code')
-  cy.get('form label').should('have.attr', 'for', 'code')
-  cy.get('form input#code')
-    .type(user.login.code)
-    .should('have.value', user.login.code)
-  cy.get('form button[type="submit"]')
-    .should('contain', 'Continue')
-    .click()
+  cy.code({ code: user.login.code })
 
   // LOGIN SIN
   cy.injectAxe().checkA11y()
@@ -50,7 +43,10 @@ Cypress.Commands.add('login', user => {
   cy.injectAxe().checkA11y()
   cy.url().should('contain', '/login/dateOfBirth')
   cy.get('h1').should('contain', 'Enter your date of birth')
-  cy.get('h2').should('contain', `${user.personal.firstName}, thanks for your Social insurance number.`)
+  cy.get('h2').should(
+    'contain',
+    `${user.personal.firstName}, thanks for your Social insurance number.`,
+  )
   cy.get('form label')
     .eq(0)
     .should('have.attr', 'for', 'dobDay')
@@ -78,6 +74,17 @@ Cypress.Commands.add('login', user => {
   cy.get('form button[type="submit"]')
     .should('contain', 'Continue')
     .click()
+})
+
+Cypress.Commands.add('code', ({ code } = {}) => {
+  cy.get('h1').should('contain', 'Enter your personal filing code')
+  cy.get('form label').should('have.attr', 'for', 'code')
+  if (code) {
+    cy.get('form input#code')
+      .type(code)
+      .should('have.value', code)
+  }
+  cy.continue()
 })
 
 Cypress.Commands.add('confirm', ({ url, h1, id }) => {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -2,15 +2,27 @@
 
 // Add a a polyfill for the 'details' HTML5 element for older browsers
 if (typeof Promise !== 'function' && document.querySelector('details') !== null) {
-  document.write('<script src="/js/details-element-polyfill.js"></script>')
+  document.write('<script src="/js/details-element-polyfill.js"></script>');
 }
 
 // Find all of the links with the 'button' role and add a click event to them
-var elements = document.querySelectorAll('a[role="button"]')
+var elements = document.querySelectorAll('a[role="button"]');
+
 for (var i = 0, len = elements.length; i < len; i++) {
-  elements[i].addEventListener('keydown', function(e) {
+  elements[i].addEventListener('keydown', function (e) {
     if (e.keyCode == 32) {
-      e.target.click()
+      e.target.click();
     }
-  })
+  });
+}
+
+var form = document.querySelector('#content form');
+if (form) {
+  form.addEventListener('submit', function (evt) {
+    evt.preventDefault();
+
+    // remove the #hash component of the url (ie, the last part of /login/code#code)
+    history.replaceState(null, null, ' ');
+    form.submit();
+  });
 }


### PR DESCRIPTION
**Added client-side JS to remove the hash portion of the URL before a form submits, and some cypress tests to verify this behaviour.**

Background 👇

Anchor links that are part of the URL are preserved when we submit a form, whether it succeeds or fails.

Examples:
- Hitting the "skip to main content" link on the 'code' page will add `#content` to the end of the URL, and then submitting either a right or wrong code won't get rid of it
- Clicking a validation error link in the error summary will put an anchor link in the URL (eg, `#code`), and then it stays there on the next page as well.

With real links we don't see this behaviour: ie, from `/start#content`, we can click "Start now" and the `#content` part of the URL disappears.

It looks like this is expected behaviour for a different use case:
- https://stackoverflow.com/questions/2286402/url-fragment-and-302-redirects

Basically, if a page is moved but you had a table of contents, the hash links should
still work. This isn't the context we have.

Even allowing that this seems to be the default behaviour, I would say that this is unexpected an unneeded more often than it's helpful.

What we should do instead is always strip the `#` anchor part of our URLs whenever we redirect on a POST route, whether it fails or passes.

## Screenshots

| before | after |
|--------|-------|
| #hash portion of URL never goes away      | #hash portion of URL disappears    |
|  ![hash1](https://user-images.githubusercontent.com/2454380/71280771-2edc2780-232a-11ea-89df-fc20c27f6016.gif)   | ![hash2](https://user-images.githubusercontent.com/2454380/71280768-2edc2780-232a-11ea-80e2-b92506363900.gif)   |




