### PR TITLE
Use node:lts-alpine as base Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-slim
+FROM node:lts-alpine
 LABEL maintainer="paul.craig@cds-snc.ca"
 
 ARG GITHUB_SHA_ARG


### PR DESCRIPTION
Early on, we were using `lts-alpine` as our base image, but then one weekend the builds started failing mysteriously.

At that point, I swapped out the base container to `lts-slim`, which solved our problem.

Long-term, the `alpine` containers are better for us to be using, so changing it back now that the problem appears to be resolved.

Source:
- 5ac889103b20c3ff77d572f0cff0566f4873c9b3