### PR TITLE
Fix/the 404 post on IE11

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -22,7 +22,9 @@ if (form) {
     evt.preventDefault();
 
     // remove the #hash component of the url (ie, the last part of /login/code#code)
-    history.replaceState(null, null, ' ');
+    if ('pushState' in history)
+    {  history.pushState('', document.title, window.location.pathname + window.location.search); }
     form.submit();
   });
 }
+

--- a/public/scss/components/_header.scss
+++ b/public/scss/components/_header.scss
@@ -43,7 +43,7 @@ header {
 
   .canada-flag {
     height: auto;
-    min-height: 40px;
+    max-height: 40px;
     width: 272px;
     margin-bottom: $space-sm;
 


### PR DESCRIPTION
This pull request fixes two problems that we have on IE11.

1. A lot of space under the logo svg
2. Seeing a 404 after submitting the access code

### 1. A lot of space under the logo svg

Set min-height to max-height in the header. This was a mistake from a previous commit of mine.

Source: e22af1b

### 2. Seeing a 404 after submitting the access code

Our previous code for removing hashes from URLs wasn't working
in IE11, but this one does a check for non-compliant browsers,
as well as doesn't remove the last part of the URL on IE11
(that's why we were getting the 404).

This fixes a bug where trying to submit a post request on IE11
would cause a 404 error.

# gifs

### bad (404)
![ie1](https://user-images.githubusercontent.com/2454380/72013002-0493d080-322b-11ea-80e5-0326d2fc4b32.gif)

### good (works!)
![ie2](https://user-images.githubusercontent.com/2454380/72013004-0493d080-322b-11ea-9afe-b0a8c50d7fd1.gif)

