### PR TITLE
Fix/Details component in Edge

### DIFF
--- a/config/csp.config.js
+++ b/config/csp.config.js
@@ -13,5 +13,5 @@ module.exports = {
   fontSrc: ["'self'", 'https://fonts.gstatic.com'],
   imgSrc: ["'self'", 'data:'],
   scriptSrc: ["'self'"],
-  styleSrc: ["'self'", 'https://fonts.googleapis.com'],
+  styleSrc: ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
 }

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1,8 +1,11 @@
 /* eslint-disable */
 
-// Add a a polyfill for the 'details' HTML5 element for older browsers
-if (typeof Promise !== 'function' && document.querySelector('details') !== null) {
-  document.write('<script src="/js/details-element-polyfill.js"></script>');
+var elementIsNative = typeof HTMLDetailsElement != "undefined" && document.createElement("details") instanceof HTMLDetailsElement;
+if (!elementIsNative) {
+  // Add a polyfill for the 'details' HTML5 element for older browsers if there is a 'details' tag on the page
+  if (document.querySelector('details') !== null) {
+    document.write('<script src="/js/details-element-polyfill.js"></script>');
+  }
 }
 
 // Find all of the links with the 'button' role and add a click event to them
@@ -22,9 +25,10 @@ if (form) {
     evt.preventDefault();
 
     // remove the #hash component of the url (ie, the last part of /login/code#code)
-    if ('pushState' in history)
-    {  history.pushState('', document.title, window.location.pathname + window.location.search); }
+    if ('pushState' in history) {
+      history.pushState('', document.title, window.location.pathname + window.location.search);
+    }
+
     form.submit();
   });
 }
-

--- a/routes/start/start.spec.js
+++ b/routes/start/start.spec.js
@@ -100,7 +100,7 @@ describe('Test server responses', () => {
     */
     expect(response.headers['content-security-policy']).toEqual(
       // eslint-disable-next-line quotes
-      "default-src 'self'; connect-src 'self'; base-uri 'none'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; script-src 'self'; style-src 'self' https://fonts.googleapis.com",
+      "default-src 'self'; connect-src 'self'; base-uri 'none'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     )
   })
 })


### PR DESCRIPTION
This pull request fixes a couple of small issues in Edge 17-18 (not the Chromium one). 

1. Canadian flag is red, in line with the FIP
2. The details element (polyfill) works now

It turns out that both of these problems were caused by the same root: the CSP disabling inline styles.

The SVG uses inline styles to colour the flag component, and the details element polyfill ('details' isn't supported in Edge) uses inline styles to open and close. By allowing inline styles through, both of these issues are resolved.

## gifs 

| before | after |
|--------|-------|
| ![edge1](https://user-images.githubusercontent.com/2454380/72263942-dfff7600-35e7-11ea-98ab-5a384fcb137e.gif)  | ![edge2](https://user-images.githubusercontent.com/2454380/72263944-dfff7600-35e7-11ea-84ef-a0fca654dfa7.gif)   |





