### PR TITLE
change so we're not validating sin against date of birth

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -1,8 +1,6 @@
 const { pool } = require('./config')
 const jsonDB = require('./db.json')
 
-const { cleanSIN } = require('../utils')
-
 const useJson = (() => { 
   if (
     process.env.USE_DB !== 'true' ||
@@ -33,20 +31,19 @@ var DB = (() => {
     return rows[0] || null
   }
 
-  const validateUser = async ({ code, sin, dateOfBirth }) => {
+  const validateUser = async ({ code, dateOfBirth }) => {
     code = code.toUpperCase()
-    sin = cleanSIN(sin)
 
     let row
 
     if (useJson) {
       row = jsonDB.find(user => {
-        if (user.sin === sin && user.dateOfBirth === dateOfBirth) {
+        if (user.dateOfBirth === dateOfBirth) {
           return user
         }
       })
     } else {
-      const { rows } = await pool.query('SELECT * FROM public.access_codes WHERE sin = $1 AND dob = $2', [sin, dateOfBirth])
+      const { rows } = await pool.query('SELECT * FROM public.access_codes WHERE dob = $1', [dateOfBirth])
 
       row = rows[0]
     }

--- a/db/index.spec.js
+++ b/db/index.spec.js
@@ -53,11 +53,6 @@ describe('test DB', () => {
       expect(row).toEqual(expectedRow)
     })
 
-    test('returns null without SIN', async () => {
-      const row = await DB.validateUser({ ...login, ...{ sin: '' } })
-      expect(row).toBe(null)
-    })
-
     test('returns null without DoB', async () => {
       const row = await DB.validateUser({ ...login, ...{ dateOfBirth: '' } })
       expect(row).toBe(null)
@@ -66,11 +61,6 @@ describe('test DB', () => {
     test('returns an error with wrong code', async () => {
       const row = await DB.validateUser({ ...login, ...{ code: 'B5G98S4K1' } }) // starts with 'A', not 'B'
       expect(row.error).not.toBeUndefined()
-    })
-
-    test('returns null with wrong SIN', async () => {
-      const row = await DB.validateUser({ ...login, ...{ sin: '947339283' } }) // starts with '8', not '9'
-      expect(row).toBe(null)
     })
 
     test('returns null with wrong DoB', async () => {

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -212,8 +212,8 @@ const postLogin = async (req, res, next) => {
   }
 
   // check access code + SIN + DoB
-  const { code, sin, dateOfBirth } = req.session.login
-  const row = await DB.validateUser({ code, sin, dateOfBirth })
+  const { code, dateOfBirth } = req.session.login
+  const row = await DB.validateUser({ code, dateOfBirth })
 
   // if no row is found, error and proceed to error page
   if (!row) {

--- a/routes/login/login.session.spec.js
+++ b/routes/login/login.session.spec.js
@@ -88,24 +88,6 @@ describe('Test /login SESSION responses', () => {
     expect(firstError.text()).toMatch('Please enter an access code')
   })
 
-  // TEST REDIRECT TO ERROR PAGE IF SIN IS WRONG
-  test('it returns a 200 on /login/error/doesNotMatch page when the SIN does not match the access code', async () => {
-    const response = await testSession
-      .post('/login/code')
-      .use(doAccessCode())
-      .then(() => {
-        return testSession.post('/login/sin').use(doSIN('117166934')) // wrong SIN
-      })
-      .then(() => {
-        return testSession.post('/login/dateOfBirth').use(doDateofBirth()) // date of birth is good
-      })
-    expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toBe('/login/error/doesNotMatch')
-
-    const response2 = await testSession.get(response.headers.location)
-    expect(response2.statusCode).toBe(200)
-  })
-
   // TEST REDIRECT TO ERROR PAGE IF DOB IS WRONG
   test('it returns a 200 on /login/error/doesNotMatch page when the DATE OF BIRTH does not match the access code', async () => {
     const response = await testSession


### PR DESCRIPTION
for user testing, we don't want to validate the sin entered against the dob on record

to do so, I've take the check out of validateUser for the db, and some associated tests that were comparing the sin against the user info.

There were a couple to make sure that sin isn't null, but our schema handles a minimum length/entry on that front.