### PR TITLE
Hide DB row names from the login controller

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -5,36 +5,39 @@ const { cleanSIN } = require('../utils')
 
 const { verifyHash, hashString } = require('../utils/crypto.utils')
 
-
-const useJson = (() => { 
-  if (
-    process.env.USE_DB !== 'true' ||
-    process.env.NODE_ENV === 'test'
-  ) {
+const useJson = (() => {
+  if (process.env.USE_DB !== 'true' || process.env.NODE_ENV === 'test') {
     pool.end()
     //console.warn includes native code to colour the output— in case you're wondering
     if (process.env.NODE_ENV !== 'test') {
-      console.warn('\x1b[33m%s\x1b[0m','⚠ WARNING ⚠: running off of json file instead of local database')
+      // eslint-disable-next-line no-console
+      console.warn(
+        '\x1b[33m%s\x1b[0m',
+        '⚠ WARNING ⚠: running off of json file instead of local database',
+      )
     }
 
     return true
-  } 
-    
+  }
+
   return false
 })()
 
 var DB = (() => {
 
-  const validateCode = async (code) => {
-
+  const validateCode = async code => {
     if (useJson) {
-      return await jsonDB.find(user => verifyHash(code.toUpperCase(), user.code, {useInitialSalt: true})) || null
+      return (
+        (await jsonDB.find(user =>
+          verifyHash(code.toUpperCase(), user.code, { useInitialSalt: true }),
+        )) || null
+      )
     }
 
-    code = hashString(code, {useInitialSalt: true})
-    
+    code = hashString(code, { useInitialSalt: true })
+
     const { rows } = await pool.query('SELECT * FROM public.access_codes WHERE code = $1', [code])
-    
+
     return rows[0] || null
   }
 
@@ -44,7 +47,7 @@ var DB = (() => {
     let row
 
     if (useJson) {
-      code = (code.length === 9) ? hashString(code.toUpperCase(), {useInitialSalt: true}) : code
+      code = code.length === 9 ? hashString(code.toUpperCase(), { useInitialSalt: true }) : code
 
       row = jsonDB.find(user => user.code === code)
     } else {
@@ -56,17 +59,22 @@ var DB = (() => {
       row = rows[0]
     }
 
-    if (!row) { return { "error" :  true } }
+    if (!row) {
+      return { error: true }
+    }
 
-    const incorrectInfo = [verifyHash(sin, row.sin), verifyHash(dateOfBirth, row.date_of_birth)].filter(v => v === false) 
+    const incorrectInfo = [
+      verifyHash(sin, row.sin),
+      verifyHash(dateOfBirth, row.date_of_birth),
+    ].filter(v => v === false)
 
-    if(incorrectInfo.length > 1) {
-      return { "error" :  true }
+    if (incorrectInfo.length > 1) {
+      return { error: true }
     } else if (incorrectInfo.length) {
       return null
     }
 
-    return row 
+    return row
   }
 
   return {

--- a/db/index.js
+++ b/db/index.js
@@ -24,21 +24,36 @@ const useJson = (() => {
 })()
 
 var DB = (() => {
+  const _formatRow = row => {
+    if (!row) {
+      return row
+    }
+
+    // remap first_name to firstName and date_of_birth to dateOfBirth
+    const { first_name: firstName, date_of_birth: dateOfBirth, ...props } = row
+
+    return {
+      ...props,
+      firstName,
+      dateOfBirth,
+    }
+  }
 
   const validateCode = async code => {
     if (useJson) {
-      return (
+      const row =
         (await jsonDB.find(user =>
           verifyHash(code.toUpperCase(), user.code, { useInitialSalt: true }),
         )) || null
-      )
+
+      return _formatRow(row)
     }
 
     code = hashString(code, { useInitialSalt: true })
 
     const { rows } = await pool.query('SELECT * FROM public.access_codes WHERE code = $1', [code])
 
-    return rows[0] || null
+    return _formatRow(rows[0]) || null
   }
 
   const validateUser = async ({ code, sin, dateOfBirth }) => {
@@ -74,7 +89,7 @@ var DB = (() => {
       return null
     }
 
-    return row
+    return _formatRow(row)
   }
 
   return {

--- a/db/index.spec.js
+++ b/db/index.spec.js
@@ -1,10 +1,13 @@
 const DB = require('./index')
 
 const expectedRow = {
-  code: 'd75535de98ecea315854491c8d036f8f$ada904924ee513b2d85d4ef775bbd1d835979dd8341047714da8d000ccec8adc',
-  sin: '3c983be4174c2711a44953311ee69792$cd18d36c21efd729f3ee8aab191912fb9467dbaba0552652cc6c451ac8a5031a',
-  date_of_birth: '5d3ac41f0d7b0387a651f2ed2b1d883a$fc2a8d33353897b1c6d723904911b91c6edb09283f7784e93ded0ef9dc659ba2',
-  first_name: 'Gabrielle',
+  code:
+    'd75535de98ecea315854491c8d036f8f$ada904924ee513b2d85d4ef775bbd1d835979dd8341047714da8d000ccec8adc',
+  sin:
+    '3c983be4174c2711a44953311ee69792$cd18d36c21efd729f3ee8aab191912fb9467dbaba0552652cc6c451ac8a5031a',
+  dateOfBirth:
+    '5d3ac41f0d7b0387a651f2ed2b1d883a$fc2a8d33353897b1c6d723904911b91c6edb09283f7784e93ded0ef9dc659ba2',
+  firstName: 'Gabrielle',
   locked: false,
 }
 

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -214,7 +214,7 @@ const postLogin = async (req, res, next) => {
   // check access code + SIN + DoB
   const { code, sin, dateOfBirth } = req.session.login
   const row = await DB.validateUser({ code, sin, dateOfBirth })
- 
+
   // if no row is found, error and proceed to error page
   if (!row) {
     return res.redirect('/login/error/doesNotMatch')

--- a/routes/login/login.controller.js
+++ b/routes/login/login.controller.js
@@ -171,7 +171,7 @@ const postLoginCode = async (req, res, next) => {
 
   // populate the session.login with our submitted access code
   // eslint-disable-next-line
-  req.session.login = { code: row.code, firstName: row.first_name }
+  req.session.login = { code: row.code, firstName: row.firstName }
 
   next()
 }


### PR DESCRIPTION
The database rows aren't happy about uppercase letters, so it means we have to use snake_case row names (postgres convention) whereas the javascript variable names are all in camelCase (JS contvention).

We don't want different naming conventions in different parts of our code, so let's format the row names before they are returned. Pretty sure this works without making the code more complicated, but would like @katedee to have a look in particular.

This isn't strictly required, but I think it keeps the boundaries of the code clearer.


