### PR TITLE
Update ubuntu version used in CI

### DIFF
--- a/.github/workflows/testBuildDeploy.yml
+++ b/.github/workflows/testBuildDeploy.yml
@@ -2,7 +2,7 @@ name: Test, build, deploy
 on: push
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     strategy:
       matrix:
         node-version: [10.x, 12.x]


### PR DESCRIPTION
Cypress tests don't run anymore because the Ubuntu version changed.

We will change this back later but let's wait until the github action is updated.

Source:
- https://github.com/cypress-io/github-action/commit/263091cab1962eea06e293a19146e9d0241a1c32