### PR TITLE
Set explicit width on legend elements

### DIFF
--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -261,6 +261,7 @@ fieldset {
   padding: 0;
 
   legend {
+    width: 100%;
     border-bottom: 0;
     margin-bottom: $space-md;
 


### PR DESCRIPTION
Doesn't happen on other browsers, but on Edge we see the legend escaping the container without an explicit width.

Yeah, some of our text is a bit crunched together but this isn't really the solution.

## Screenshots

| before | after |
|--------|-------|
| <img width="1511" alt="Screen Shot 2020-01-23 at 8 36 40 PM" src="https://user-images.githubusercontent.com/2454380/73038414-5db15600-3e20-11ea-9135-b83a306f8b69.png">     | <img width="1511" alt="Screen Shot 2020-01-23 at 8 36 00 PM" src="https://user-images.githubusercontent.com/2454380/73038415-5db15600-3e20-11ea-9ef8-b4fecb1d8563.png">   |


