### PR TITLE
Update address logic in the view to handle no apartment number

### DIFF
--- a/views/_includes/address.pug
+++ b/views/_includes/address.pug
@@ -1,8 +1,8 @@
 mixin address(data)
-  if hasData(data, 'personal.address.line2')
+  if hasData(data, 'personal.address.line2.en') && hasData(data, 'personal.address.line2.fr')
     div #{data.personal.address.line2[getLocale()]}-#{data.personal.address.line1[getLocale()]}
   else
-    div #{data.personal.address.line1}
+    div #{data.personal.address.line1[getLocale()]}
   if (getLocale() == "en")
     div #{data.personal.address.city}, #{data.personal.address.province}
   else


### PR DESCRIPTION
Since adding `en` and `fr` keys, our address template is displaying the address incorrectly when there's no apartment number.

The 'if' condition is not aware of the changes so it will always return true, inserting a hyphen before the street address every time. (eg, `-180 Lisgar`.)

Furthermore, the "else" case doesn't know about the language key either, so it prints out the object. (eg, `[Object object]`.)

This change to the template fixes both issues.

### Screenshots

| bad | bad | good |
|-----|-----|------|
| <img width="760" alt="Screen Shot 2020-01-27 at 2 40 32 PM" src="https://user-images.githubusercontent.com/2454380/73207608-fee72780-4112-11ea-8313-e5069eacfd40.png">  | <img width="760" alt="Screen Shot 2020-01-27 at 2 38 52 PM" src="https://user-images.githubusercontent.com/2454380/73207611-fee72780-4112-11ea-9f14-82c656f49957.png">  |   <img width="760" alt="Screen Shot 2020-01-27 at 2 39 52 PM" src="https://user-images.githubusercontent.com/2454380/73207609-fee72780-4112-11ea-9629-e71886971834.png"> |




