### PR TITLE
Fix/check age gooder 👵

### DIFF
--- a/routes/deductions/deductions.controller.js
+++ b/routes/deductions/deductions.controller.js
@@ -8,7 +8,7 @@ const {
   renderWithData,
   checkErrors,
   postAmount,
-  getDateDelta,
+  is65,
 } = require('./../../utils')
 const {
   trilliumRentSchema,
@@ -31,8 +31,6 @@ const {
   trilliumlongTermCareAmountSchema,
   climateActionIncentiveSchema,
 } = require('./../../schemas')
-
-const SIXTY_FIVE_YEARS_IN_DAYS = 23725
 
 module.exports = function(app) {
   //Start of Trillum Section
@@ -303,9 +301,9 @@ module.exports = function(app) {
 
 // Only skip this page in production. For testing and development, we want to be able to see the senior transit pages just like any other.
 const seniorRedirect = (req, res, next) => {
-  const dobInDays = getDateDelta(req.session.personal.dateOfBirth)
   if (process.env.NODE_ENV === 'production') {
-    if (dobInDays <= SIXTY_FIVE_YEARS_IN_DAYS) {
+    // if under 65, skip this page
+    if (!is65(req.session.personal.dateOfBirth)) {
       return res.redirect('/trillium/rent')
     }
   }

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,5 +1,6 @@
 const validator = require('validator')
 const { validationResult } = require('express-validator')
+const parseISO = require('date-fns/parseISO')
 const API = require('./../api')
 const { routes: defaultRoutes } = require('../config/routes.config')
 const cookieConfig = require('../config/cookie.config')
@@ -233,7 +234,7 @@ const postAmount = (amount, locale) => {
 /**
  * Cleans a string of hyphens and spaces
  *
- * ie, "8-4-7339 2 8 3 " => "847 339 283"
+ * ie, "8-4-7339 2 8 3 " => "847339283"
  *
  * @param string sin a string assumed to be a SIN
  */
@@ -400,7 +401,8 @@ const getPreviousRoute = (req, routes = defaultRoutes) => {
        * - or is not an edit page, and is the next logical page
        */
       if (
-        ('editInfo' in previousRouteToCheck && hasData(session, previousRouteToCheck.editInfo, true)) ||
+        ('editInfo' in previousRouteToCheck &&
+          hasData(session, previousRouteToCheck.editInfo, true)) ||
         !('editInfo' in previousRouteToCheck)
       ) {
         return previousRouteToCheck
@@ -448,18 +450,41 @@ const getRouteWithIndexByPath = (path, routes = defaultRoutes) => {
   return routeWithIndex
 }
 
-const getNextRoute = (req) => {
+const getNextRoute = req => {
   const currentRoute = getRouteWithIndexByPath(req.path)
   return defaultRoutes[currentRoute.index + 1]
 }
 
-const getDateDelta = (dateOfBirth) => {
+const getDateDelta = dateOfBirth => {
   const today = new Date()
   const newDate = new Date(dateOfBirth)
   const diffTime = Math.abs(today - newDate)
   const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
 
   return diffDays
+}
+
+/**
+ * Expects an ISO date string to be passed in (eg, '1990-08-10'), and will
+ * return true if someone born on that date would be 65 in a given tax year.
+ *
+ * 65 is the age of seniority in Canada.
+ * default tax year is 2019
+ * throws an Error if the passed-in string isn't parseable as a date
+ *
+ * @param string dateOfBirth an iso date string formatted 'yyyy-mm-dd'
+ * @param obj { taxYear } the year to check someone's age
+ */
+const is65 = (dateOfBirth, { taxYear = 2019 } = {}) => {
+  const AGE_OF_SENIORITY = 65
+
+  if (isNaN(parseISO(dateOfBirth).getTime())) {
+    throw new Error(`[is65] Invalid date string: '${dateOfBirth}'`)
+  }
+
+  const yearOfBirth = dateOfBirth.split('-')[0]
+
+  return taxYear - yearOfBirth >= AGE_OF_SENIORITY
 }
 
 module.exports = {
@@ -484,4 +509,5 @@ module.exports = {
   postAmount,
   currencyWithoutUnit,
   getDateDelta,
+  is65,
 }

--- a/utils/index.js
+++ b/utils/index.js
@@ -455,15 +455,6 @@ const getNextRoute = req => {
   return defaultRoutes[currentRoute.index + 1]
 }
 
-const getDateDelta = dateOfBirth => {
-  const today = new Date()
-  const newDate = new Date(dateOfBirth)
-  const diffTime = Math.abs(today - newDate)
-  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
-
-  return diffDays
-}
-
 /**
  * Expects an ISO date string to be passed in (eg, '1990-08-10'), and will
  * return true if someone born on that date would be 65 in a given tax year.
@@ -508,6 +499,5 @@ module.exports = {
   returnToCheckAnswers,
   postAmount,
   currencyWithoutUnit,
-  getDateDelta,
   is65,
 }

--- a/utils/index.spec.js
+++ b/utils/index.spec.js
@@ -8,6 +8,7 @@ const {
   postAmount,
   currencyWithoutUnit,
   cleanSIN,
+  is65,
 } = require('./index')
 const API = require('./../api')
 
@@ -273,6 +274,41 @@ describe('Test cleanSIN function', () => {
   falseyVals.map(falseyVal => {
     test(`returns original value for falsey value: ${falseyVal}`, () => {
       expect(cleanSIN(falseyVal)).toEqual(falseyVal)
+    })
+  })
+})
+
+describe('Test is65 function', () => {
+  test('is65 throws Error for a bad date string', () => {
+    expect(() => {
+      is65('Hello I am old')
+    }).toThrow('[is65] Invalid date string:')
+  })
+
+  describe('is65 returns false for 1955', () => {
+    test('Jan 1st', () => {
+      expect(is65('1955-01-01')).toBe(false)
+    })
+    test('Dec 31st', () => {
+      expect(is65('1955-12-31')).toBe(false)
+    })
+  })
+
+  describe('is65 returns true for 1954', () => {
+    test('Jan 1st', () => {
+      expect(is65('1954-01-01')).toBe(true)
+    })
+    test('Dec 31st', () => {
+      expect(is65('1954-12-31')).toBe(true)
+    })
+  })
+
+  describe('is65 returns true for 1955 with a taxYear of 2020', () => {
+    test('Jan 1st', () => {
+      expect(is65('1955-01-01', { taxYear: 2020 })).toBe(true)
+    })
+    test('Dec 31st', () => {
+      expect(is65('1955-12-31', { taxYear: 2020 })).toBe(true)
     })
   })
 })


### PR DESCRIPTION
## Check if someone was 65 in 2019, not if they are currently 65

When we are asking people's ages, we want to know if they were that age for a given tax year, not for the current year (in this case, 2019).

If someone turned 65 in January, it doesn't affect their taxes from the previous year. We want to know if they were 65 on December 31 of the previous year.

This means we can remove the `getDateDelta` function. Knowing someone's actual date on the day they're using the service isn't necessary, so removed the `getDateDelta` function entirely.