### PR TITLE
Check the dateOfBirth on the /confirm-income page

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,6 +23,7 @@ const express = require('express'),
     currencyFilter,
     isoDateHintText,
     currencyWithoutUnit,
+    is65,
   } = require('./utils'),
   csrf = require('csurf'),
   cookieConfig = require('./config/cookie.config'),
@@ -58,7 +59,7 @@ app.use(function(req, res, next) {
 
 // set up rate limiter: maximum of five requests per minute
 var limiter = new rateLimit({
-  windowMs: 1*60*1000, // 1 minute
+  windowMs: 1 * 60 * 1000, // 1 minute
   max: 120,
 })
 // apply rate limiter to expensive request page(s) - just the one for now
@@ -116,6 +117,7 @@ app.locals.hasData = hasData
 app.locals.currencyFilter = currencyFilter
 app.locals.sortByLineNumber = sortByLineNumber
 app.locals.isoDateHintText = isoDateHintText
+app.locals.is65 = is65
 
 // configure routes
 require('./routes/start/start.controller')(app)

--- a/views/confirmation/income.pug
+++ b/views/confirmation/income.pug
@@ -7,7 +7,7 @@ block content
 
   h1 #{title}
 
-  if(data.login.ageYesNo === 'No')
+  if hasData(data, 'personal.dateOfBirth') && !is65(data.personal.dateOfBirth)
     p #{__('If your income is above $12,070:')}
   else
     p #{__('If your income is above $19,564:')}

--- a/views/offramp/name.pug
+++ b/views/offramp/name.pug
@@ -8,8 +8,6 @@ block content
 
   h1 #{title}
 
-  
-
   .offramp
     p #{__('You can still use this online service with the name CRA has on your file.')}
 

--- a/views/personal/name.pug
+++ b/views/personal/name.pug
@@ -22,7 +22,7 @@ block content
             div #{data.personal.firstName} #{data.personal.lastName}
 
   form.cra-form(method='post')
-    +radiosYesNo('name', 'Is this your name?')
+    +radiosYesNo('name', 'Is this your name?', confirmedName)
 
     input#redirect(name='redirect', type='hidden', value='/personal/address')
 


### PR DESCRIPTION
## Check `dateOfBirth` on confirm-income page, not `ageYesNo`

When someone's going through the eligibility flow, we ask them to tell us if they are over 65, but we don't really know if they are.

Later, as one of the last steps in the service, we ask people to confirm their income again, and we show different income amounts depending on if they are above or below 65.

We were using their same answer they gave to the eligibility question to check if they are over 65 or not, but that was actually the wrong way to go about it.

Similar to the "senior transit page", we know what age someone is because we have their date of birth back from the API.

This pull request changes the logic to show the income amount based on their date of birth, and not based on their previous answer they gave during the eligibility flow.