### PR TITLE
Add curly quote to Senior’s public transit page title

### DIFF
--- a/cypress/integration/full_run_simple.spec.js
+++ b/cypress/integration/full_run_simple.spec.js
@@ -68,7 +68,7 @@ describe('Full run through saying "no" to everything', function() {
   it('navigates the Senior Public Transit Tax Credit page', function() {
     cy.confirm({
       url: '/deductions/senior-public-transit',
-      h1: `Senior's public transit`,
+      h1: `Senior’s public transit`,
       id: 'seniorTransitClaim1',
     })
 
@@ -141,12 +141,12 @@ describe('Full run through saying "no" to everything', function() {
     cy.continue()
   })
 
-  // CONFIRM INCOME 
+  // CONFIRM INCOME
   it('navigates Confirm Income page', function() {
     cy.confirm({
       url: '/confirm-income',
       h1: 'Confirm 2019 income',
-      id: 'confirmIncome', 
+      id: 'confirmIncome',
     })
 
     cy.continue()

--- a/cypress/integration/full_run_with_amounts.spec.js
+++ b/cypress/integration/full_run_with_amounts.spec.js
@@ -68,7 +68,7 @@ describe('Full run through saying "yes" to everything', function() {
   it('navigates the Senior Public Transit Tax Credit page', function() {
     cy.confirm({
       url: '/deductions/senior-public-transit',
-      h1: `Senior's public transit`,
+      h1: `Senior’s public transit`,
       id: 'seniorTransitClaim0',
     })
 
@@ -294,7 +294,7 @@ describe('Full run through saying "yes" to everything', function() {
       h1: 'Confirm 2019 income',
       id: 'confirmIncome', // click checkbox
     })
-    
+
     cy.continue('Continue')
   })
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -559,7 +559,7 @@
   "Your SIN and date of birth do not match": "Your SIN and date of birth do not match",
   "Check that you entered both correctly": "Check that you entered both correctly",
   "Try again": "Try again",
-  "Senior's public transit": "Senior's public transit",
+  "Senior’s public transit": "Senior’s public transit",
   "Did you use public transit in 2019?": "Did you use public transit in 2019?",
   "Enter your total 2019 transit costs ": "Enter your total 2019 transit costs ",
   "The government might ask for your transit receipts.": "The government might ask for your transit receipts.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -524,7 +524,7 @@
   "Enter your long-term care home costs": "Enter your long-term care home costs",
   "How much were your total long-term care costs in 2019?": "How much were your total long-term care costs in 2019?",
   "Did you live in a long-term care home?": "Avez-vous vécu dans un foyer de soins de longue durée?",
-  "Senior's public transit": "Senior's public transit",
+  "Senior’s public transit": "Senior’s public transit",
   "Did you use public transit in 2019?": "Did you use public transit in 2019?",
   "Enter your total 2019 transit costs ": "Enter your total 2019 transit costs ",
   "The government might ask for your transit receipts.": "The government might ask for your transit receipts.",

--- a/views/deductions/senior-public-transit.pug
+++ b/views/deductions/senior-public-transit.pug
@@ -1,7 +1,7 @@
 extends ../base
 
 block variables
-  -var title = __(`Senior's public transit`)
+  -var title = __(`Senior’s public transit`)
   -var seniorTransitClaim = !hasData(data, 'deductions.seniorTransitClaim') ? '' : data.deductions.seniorTransitClaim ? 'Yes' : 'No'
 
 block content


### PR DESCRIPTION
We generally prefer the curly quote for our content.

| before                  | after                   |
|-------------------------|-------------------------|
| `Senior's` | `Senior’s` |