### PR TITLE
Alphabetize the benefits table

### DIFF
--- a/cypress/fixtures/user.json
+++ b/cypress/fixtures/user.json
@@ -153,18 +153,6 @@
     }
   },
  "benefits": {
-  "gsthstc": {
-     "name": "Goods and services tax/harmonized sales tax (GST/HST) credit",
-     "description": "up to $443 for one person, $580 if you have a marriage or common-law partner, and $153 for each child under age 19."
-  },
-  "ccb": {
-    "name": "Canada child benefit (CCB)",
-    "description": "a yearly amount which may be up to $6,639 for each child under age 6 and up to $5,602 for each child aged 6 to 17."
-  },
-  "otb": {
-    "name": "Ontario trillium benefit (OTB)",
-    "description": "a government payment that helps with energy, sales and property tax. The government usually pays this amount on the 10th day of each month for 12 months."
-  },
   "cai": {
     "name": "Climate action incentive (CAI)",
     "description": "everyone gets this payment. You get 10% extra if you live in a small and rural community."
@@ -172,6 +160,14 @@
   "dtc": {
     "name": "Disability tax credit (DTC)",
     "description": "an amount based on your situation. You may be able to get DTC if you have applied and CRA approves your application."
+  },
+  "gsthstc": {
+     "name": "Goods and services tax/harmonized sales tax (GST/HST) credit",
+     "description": "up to $443 for one person, $580 if you have a marriage or common-law partner, and $153 for each child under age 19."
+  },
+  "otb": {
+    "name": "Ontario trillium benefit (OTB)",
+    "description": "a government payment that helps with energy, sales and property tax. The government usually pays this amount on the 10th day of each month for 12 months."
   }
 },
  "vote": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -495,8 +495,6 @@
   "up to $443 for one person, $580 if you have a marriage or common-law partner, and $153 for each child under age 19.": "up to $443 for one person, $580 if you have a marriage or common-law partner, and $153 for each child under age 19.",
   "Learn more": "Learn more",
   "paid yearly": "paid yearly",
-  "Canada child benefit (CCB)": "Canada child benefit (CCB)",
-  "a yearly amount which may be up to $6,639 for each child under age 6 and up to $5,602 for each child aged 6 to 17.": "a yearly amount which may be up to $6,639 for each child under age 6 and up to $5,602 for each child aged 6 to 17.",
   "paid monthly": "paid monthly",
   "Ontario trillium benefit (OTB)": "Ontario trillium benefit (OTB)",
   "a government payment that helps with energy, sales and property tax. The government usually pays this amount on the 10th day of each month for 12 months.": "a government payment that helps with energy, sales and property tax. The government usually pays this amount on the 10th day of each month for 12 months.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -461,8 +461,6 @@
   "up to $443 for one person, $580 if you have a marriage or common-law partner, and $153 for each child under age 19.": "montant pouvant s’élever jusqu’à 443 $ pour une personne, jusqu’à 580 $ si vous êtes marié ou que vous avez un conjoint de fait, et jusqu’à 153 $ par enfant de moins de 19 ans.",
   "Learn more": "En savoir plus",
   "paid yearly": "versement annuel",
-  "Canada child benefit (CCB)": "L’Allocation canadienne pour enfants (ACE)",
-  "a yearly amount which may be up to $6,639 for each child under age 6 and up to $5,602 for each child aged 6 to 17.": "montant annuel pouvant s’élever jusqu’à 6 639 $ pour chaque enfant de moins de 6 ans, et jusqu’à 5 602 $ pour chaque enfant âgé de 6 à 17 ans.",
   "paid monthly": "versement mensuel",
   "Ontario trillium benefit (OTB)": "La Prestation Trillium de l’Ontario (PTO)",
   "a government payment that helps with energy, sales and property tax. The government usually pays this amount on the 10th day of each month for 12 months.": "paiement du gouvernement qui aide à assumer les coûts en énergie, en ventes et en impôts fonciers. Le gouvernement verse généralement le montant le 10e jour de chaque mois pendant 12 mois.",

--- a/views/_includes/benefits-table.pug
+++ b/views/_includes/benefits-table.pug
@@ -7,24 +7,6 @@
 -
   var rows =[
   {
-    "header":"Goods and services tax/harmonized sales tax (GST/HST) credit",
-    "description": "up to $443 for one person, $580 if you have a marriage or common-law partner, and $153 for each child under age 19.",
-    "linkURL":"https://www.canada.ca/en/revenue-agency/services/child-family-benefits/goods-services-tax-harmonized-sales-tax-gst-hst-credit.html",
-    "payment": "paid yearly"
-  },
-  {
-    "header":"Canada child benefit (CCB)",
-    "description": "a yearly amount which may be up to $6,639 for each child under age 6 and up to $5,602 for each child aged 6 to 17.",
-    "linkURL":"https://www.canada.ca/en/revenue-agency/services/child-family-benefits/canada-child-benefit-overview.html",
-    "payment":"paid monthly"
-  },
-  {
-    "header":"Ontario trillium benefit (OTB)",
-    "description": "a government payment that helps with energy, sales and property tax. The government usually pays this amount on the 10th day of each month for 12 months.",
-    "linkURL":"https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/province-ontario.html",
-    "payment":"paid monthly"
-  },
-  {
     "header":"Climate action incentive (CAI)",
     "description": "everyone gets this payment. You get 10% extra if you live in a small and rural community.",
     "linkURL":"https://www.canada.ca/en/revenue-agency/services/tax/individuals/topics/about-your-tax-return/tax-return/completing-a-tax-return/deductions-credits-expenses/line-449-climate-action-incentive.html",
@@ -34,6 +16,18 @@
     "header":"Disability tax credit (DTC)",
     "description": "an amount based on your situation. You may be able to get DTC if you have applied and CRA approves your application.",
     "linkURL":"https://www.canada.ca/en/revenue-agency/services/tax/individuals/segments/tax-credits-deductions-persons-disabilities/disability-tax-credit.html",
+    "payment":"paid monthly"
+  },
+  {
+    "header":"Goods and services tax/harmonized sales tax (GST/HST) credit",
+    "description": "up to $443 for one person, $580 if you have a marriage or common-law partner, and $153 for each child under age 19.",
+    "linkURL":"https://www.canada.ca/en/revenue-agency/services/child-family-benefits/goods-services-tax-harmonized-sales-tax-gst-hst-credit.html",
+    "payment": "paid yearly"
+  },
+  {
+    "header":"Ontario trillium benefit (OTB)",
+    "description": "a government payment that helps with energy, sales and property tax. The government usually pays this amount on the 10th day of each month for 12 months.",
+    "linkURL":"https://www.canada.ca/en/revenue-agency/services/child-family-benefits/provincial-territorial-programs/province-ontario.html",
     "payment":"paid monthly"
   },
   ]

--- a/views/confirmation/confirmation.pug
+++ b/views/confirmation/confirmation.pug
@@ -18,6 +18,7 @@ block content
           td 5H3P9IO5816
 
     p #{__('Use this code to call about your taxes or ask for help from CRA by:')}
+
     include ../_includes/phone-bullets
 
     p #{__('You will get a notice of assessment in about 2 weeks. The notice proves you filed taxes, and shows if you must pay tax.')}


### PR DESCRIPTION
This was left over from the work in #443.

- Listed the services on the benefits table in alphabetical order
- Removed the Canada Childcare benefit (CCB) because we aren't planning to offer it through our service this time around

## Screenshots

| before                  | after                   |
|-------------------------|-------------------------|
| <img width="1552" alt="Screen Shot 2020-01-28 at 11 08 35 AM" src="https://user-images.githubusercontent.com/2454380/73281933-ba18ca80-41be-11ea-9a56-8d01c5aebd97.png"> | <img width="1552" alt="Screen Shot 2020-01-28 at 11 08 33 AM" src="https://user-images.githubusercontent.com/2454380/73281935-ba18ca80-41be-11ea-9db2-de43adf648ce.png"> |

