### PR TITLE
remove dollar signs when posting amount values

### DIFF
--- a/schemas/utils.schema.js
+++ b/schemas/utils.schema.js
@@ -5,7 +5,7 @@ const currencySchema = (errorMessageString = 'errors.currency', { allowEmpty = t
         let formattedValue = value
 
         if (req.locale === 'fr') {
-          formattedValue = value.replace(',', '.').replace(' ', '').replace('$', '')
+          formattedValue = value.replace(',', '.').replace(' ', '').replace(/\$/g, '')
         } else if (formattedValue) {
           //including the commas makes it not a Number, and messes with formatting, so remove commas from en-CA format just for validation check
           formattedValue = value.replace(',', '')

--- a/schemas/utils.schema.js
+++ b/schemas/utils.schema.js
@@ -5,7 +5,7 @@ const currencySchema = (errorMessageString = 'errors.currency', { allowEmpty = t
         let formattedValue = value
 
         if (req.locale === 'fr') {
-          formattedValue = value.replace(',', '.').replace(' ', '')
+          formattedValue = value.replace(',', '.').replace(' ', '').replace('$', '')
         } else if (formattedValue) {
           //including the commas makes it not a Number, and messes with formatting, so remove commas from en-CA format just for validation check
           formattedValue = value.replace(',', '')

--- a/utils/index.js
+++ b/utils/index.js
@@ -222,13 +222,13 @@ const postAmount = (amount, locale) => {
   }
 
   if (locale === 'fr') {
-    const formattedAmount = amount.replace(',', '.').replace(/\s/g, '')
+    const formattedAmount = amount.replace(',', '.').replace(/\s/g, '').replace('$', '')
 
     return formattedAmount
   }
 
   //remove commas for English format inputs, just for consistency of storing
-  return amount.replace(/,/g, '')
+  return amount.replace(/,/g, '').replace('$', '')
 }
 
 /**

--- a/utils/index.js
+++ b/utils/index.js
@@ -222,13 +222,13 @@ const postAmount = (amount, locale) => {
   }
 
   if (locale === 'fr') {
-    const formattedAmount = amount.replace(',', '.').replace(/\s/g, '').replace('$', '')
+    const formattedAmount = amount.replace(',', '.').replace(/\s/g, '').replace(/\$/g, '')
 
     return formattedAmount
   }
 
   //remove commas for English format inputs, just for consistency of storing
-  return amount.replace(/,/g, '').replace('$', '')
+  return amount.replace(/,/g, '').replace(/\$/g, '')
 }
 
 /**

--- a/utils/index.spec.js
+++ b/utils/index.spec.js
@@ -123,7 +123,7 @@ describe('Test postAmount function', () => {
     },
     {
       input: '$1,000',
-      localse: 'en',
+      locale: 'en',
       expectedResult: '1000',
     },
     {

--- a/utils/index.spec.js
+++ b/utils/index.spec.js
@@ -122,6 +122,11 @@ describe('Test postAmount function', () => {
       expectedResult: '10341.28',
     },
     {
+      input: '$1,000',
+      localse: 'en',
+      expectedResult: '1000',
+    },
+    {
       input: '1,025',
       locale: 'en',
       expectedResult: '1025',


### PR DESCRIPTION
As detailed [in this card](https://trello.com/c/qTRdxcbZ/617-s-m-%F0%9F%95%B7adding-inputs-starting-with-dollar-signs-causes-a-bug), entering a dollar sign alongside the amount inputs causes `NaN` to display on CheckAnswers.

I've changed it so that we'll accept it on input, but strip it out in validation + formatting. This means navigating back to the page (or in case of errors being caught in schema validation) something like $100.30 will become 100.30 (or 100,30$ to  100,30 for french)