### PR TITLE
Remove left padding from benefits table on confirmation page

### DIFF
--- a/public/scss/components/_breakdown-table.scss
+++ b/public/scss/components/_breakdown-table.scss
@@ -56,7 +56,7 @@
     dl {
       border-bottom: none;
     }
-    
+
     max-width: 750px;
     border-bottom: 2px solid $color-grey-light;
   }
@@ -94,7 +94,7 @@
   &-key {
     margin-bottom: 5px;
     font-weight: 700;
-    
+
     @include md {
       padding-left: $space-md;
       font-weight: 400;
@@ -160,6 +160,14 @@
 
   h2.breakdown-table__heading {
     line-height: 1.5em;
+  }
+
+  .breakdown-table__row {
+    &-key,
+    &-value,
+    &-payment {
+      padding-left: 0;
+    }
   }
 
   .breakdown-table__row-key {


### PR DESCRIPTION
Left padding is something we do on the /checkAnswers page because we have titles in grey boxes.

On the /confirmation page, we don't have any titles like that, so we should align everything to the left edge of the page.

## Screenshots

### on desktop

no more left padding

| before | after |
|--------|-------|
|  <img width="1469" alt="Screen Shot 2020-02-07 at 4 59 30 PM" src="https://user-images.githubusercontent.com/2454380/74069165-70ed2580-49cb-11ea-89f4-bb4fbe401ad3.png">    |    <img width="1469" alt="Screen Shot 2020-02-07 at 4 59 28 PM" src="https://user-images.githubusercontent.com/2454380/74069166-7185bc00-49cb-11ea-91ab-ee7d28173ed3.png">  |

### on mobile

no more left padding

| before | after |
|--------|-------|
|   <img width="612" alt="Screen Shot 2020-02-07 at 5 00 04 PM" src="https://user-images.githubusercontent.com/2454380/74069153-6d599e80-49cb-11ea-988c-881d42240619.png">    |  <img width="612" alt="Screen Shot 2020-02-07 at 5 00 02 PM" src="https://user-images.githubusercontent.com/2454380/74069163-70548f00-49cb-11ea-9712-427fb37a17d2.png">   |



