### PR TITLE
Fix some values not being prefilled

### DIFF
--- a/routes/deductions/deductions.controller.js
+++ b/routes/deductions/deductions.controller.js
@@ -248,7 +248,6 @@ module.exports = function(app) {
       // if there is already data and this selection is the opposite of what's saved,
       // we need to clear the data
       if (req.session.deductions[claim] && req.session.deductions[claim] != (req.body[claim] === 'Yes' ? true : false)) {
-        console.log("clearing fields")
         clearSessionFields(req, fields)
       }
 

--- a/routes/deductions/deductions.controller.js
+++ b/routes/deductions/deductions.controller.js
@@ -245,11 +245,15 @@ module.exports = function(app) {
         'trilliumLongTermCareAmount',
         'trilliumLongTermCareAmountIsFull',
       ]
+      // if there is already data and this selection is the opposite of what's saved,
+      // we need to clear the data
+      if (req.session.deductions[claim] && req.session.deductions[claim] != (req.body[claim] === 'Yes' ? true : false)) {
+        console.log("clearing fields")
+        clearSessionFields(req, fields)
+      }
+
       // set the value in the session
       req.session.deductions[claim] = req.body[claim] === 'Yes' ? true : false
-
-      // clear associated fields regardless of yes / no answer
-      clearSessionFields(req, fields)
 
       // if yes still need to redirect to the proper page
       if (req.body[claim] === 'Yes') {

--- a/views/confirmation/income.pug
+++ b/views/confirmation/income.pug
@@ -3,6 +3,7 @@ extends ../base
 block variables
   -var title = __('Confirm 2019 income')
   -var isSenior = hasData(data, 'personal.dateOfBirth') && is65(data.personal.dateOfBirth)
+  -var incomeConfirmed = hasData(data, 'financial.incomeConfirmed')
 
 block content
 
@@ -31,7 +32,7 @@ block content
         if errors
           +validationMessage(errors.confirmIncome.msg, key)
         .multiple-choice__item
-          input(id='confirmIncome' name='confirmIncome' type="checkbox" value="confirmIncome" checked=(value =='confirmIncome') aria-describedby=(errors ? `confirmIncome-error` : false))
+          input(id='confirmIncome' name='confirmIncome' type="checkbox" value="confirmIncome" checked=(incomeConfirmed == true) aria-describedby=(errors ? `confirmIncome-error` : false))
           if !isSenior
             label(for='confirmIncome') #{__('Check this box to confirm your income was less than $12,070 in 2019')}
           else

--- a/views/deductions/trillium-longTermCare-amount.pug
+++ b/views/deductions/trillium-longTermCare-amount.pug
@@ -10,8 +10,6 @@ block content
 
   h1 #{title}
 
-  h2 #{data.deductions.trilliumLongTermCareAmount}
-
   div
     p #{__('The government might ask for your long-term care receipts.')}
 

--- a/views/deductions/trillium-longTermCare-amount.pug
+++ b/views/deductions/trillium-longTermCare-amount.pug
@@ -10,6 +10,8 @@ block content
 
   h1 #{title}
 
+  h2 #{data.deductions.trilliumLongTermCareAmount}
+
   div
     p #{__('The government might ask for your long-term care receipts.')}
 


### PR DESCRIPTION
https://trello.com/c/ISdkyjLO/662-xs-%F0%9F%90%9C-values-arent-being-pre-filled-all-the-time

- The confirm income box was a missing variable
- The amounts for long term care were being intentionally cleared to make sure if the selection had changed that the old data didn't stick around. I made it a little smarter so it only clears if the selection actually has been changed.