### PR TITLE
Remove stepper from eligibility flow and name references during login

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -111,7 +111,6 @@ Cypress.Commands.add('login', user => {
   cy.injectAxe().checkA11y()
   cy.url().should('contain', '/login/sin')
   cy.get('h1').should('contain', 'Enter your Social insurance number (SIN)')
-  cy.get('h2').should('contain', `${user.personal.firstName}, thanks for your filing code.`)
   cy.get('form label').should('have.attr', 'for', 'sin')
   cy.get('form input#sin')
     .type(user.personal.sin)
@@ -124,10 +123,6 @@ Cypress.Commands.add('login', user => {
   cy.injectAxe().checkA11y()
   cy.url().should('contain', '/login/dateOfBirth')
   cy.get('h1').should('contain', 'Enter your date of birth')
-  cy.get('h2').should(
-    'contain',
-    `${user.personal.firstName}, thanks for your Social insurance number.`,
-  )
   cy.get('form label')
     .eq(0)
     .should('have.attr', 'for', 'dobDay')

--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -148,21 +148,6 @@ li:not(:last-of-type) {
   @extend %page-container;
 }
 
-.stepper {
-  margin-bottom: 0;
-
-  p {
-  margin-top: $space-md;
-  margin-bottom: $space-xxs;
-  color: $color-grey-dark;
-  }
-
-  + h1 {
-    margin-top: 0;
-  }
-
-}
-
 .pure-table {
   width: 100%;
   margin-bottom: $space-sm;

--- a/views/_includes/stepperMixin.pug
+++ b/views/_includes/stepperMixin.pug
@@ -1,3 +1,0 @@
-mixin stepper(currentStep, totalSteps)
-  .stepper
-    p #{__('Screening questions')} (#{__('Step ')} #{currentStep} #{__(' of ')} #{totalSteps})

--- a/views/base.pug
+++ b/views/base.pug
@@ -1,7 +1,6 @@
 include _includes/validationMessage
 include _includes/input-text
 include _includes/radiosMixin
-include _includes/stepperMixin
 include _includes/buttonMixin
 
 doctype html

--- a/views/login/dateOfBirth.pug
+++ b/views/login/dateOfBirth.pug
@@ -7,14 +7,10 @@ block variables
   -var dobDay = hasData(body, 'dobDay') ? body.dobDay : (hasData(data.login, 'dobDay') ? data.login.dobDay : '')
   -var dobMonth = hasData(body, 'dobMonth') ? body.dobMonth : (hasData(data.login, 'dobMonth') ? data.login.dobMonth : '')
   -var dobYear = hasData(body, 'dobYear') ? body.dobYear : (hasData(data.login, 'dobYear') ? data.login.dobYear : '')
-  -var firstName = hasData(data, 'login.firstName') ? data.login.firstName : (hasData(data, 'personal.firstName') ? data.personal.firstName : '' )
 
 block content
 
   h1 #{title}
-
-  if firstName
-    h2 #{firstName}, #{__('thanks for your Social insurance number')}.
 
   div
     form.cra-form(method='post')

--- a/views/login/eligibility-age.pug
+++ b/views/login/eligibility-age.pug
@@ -6,8 +6,6 @@ block variables
 
 block content
 
-  +stepper('1', '7')
-
   h1 #{title}
 
   form.cra-form(method='post')

--- a/views/login/eligibility-children.pug
+++ b/views/login/eligibility-children.pug
@@ -6,8 +6,6 @@ block variables
 
 block content
 
-  +stepper('3', '7')
-
   h1 #{title}
   
   form.cra-form(method='post')

--- a/views/login/eligibility-dependants-claim.pug
+++ b/views/login/eligibility-dependants-claim.pug
@@ -6,8 +6,6 @@ block variables
 
 block content
 
-  +stepper('4', '7')
-
   h1 #{title}
 
   form.cra-form(method='post')

--- a/views/login/eligibility-dependants.pug
+++ b/views/login/eligibility-dependants.pug
@@ -6,8 +6,6 @@ block variables
 
 block content
 
-  +stepper('4', '7')
-
   h1 #{title}
 
   div

--- a/views/login/eligibility-foreign-income.pug
+++ b/views/login/eligibility-foreign-income.pug
@@ -6,8 +6,6 @@ block variables
 
 block content
 
-  +stepper('7', '7')
-
   h1 #{title}
 
   form.cra-form(method='post')

--- a/views/login/eligibility-income-sources.pug
+++ b/views/login/eligibility-income-sources.pug
@@ -6,8 +6,6 @@ block variables
 
 block content
 
-  +stepper('6', '7')
-
   h1 #{title}
 
   form.cra-form(method='post')

--- a/views/login/eligibility-residence.pug
+++ b/views/login/eligibility-residence.pug
@@ -6,8 +6,6 @@ block variables
 
 block content
 
-  +stepper('2', '7')
-
   h1 #{title}
 
   div

--- a/views/login/eligibility-taxable-income.pug
+++ b/views/login/eligibility-taxable-income.pug
@@ -5,7 +5,6 @@ block variables
   -var taxableIncome = hasData(data, 'login.taxableIncome') ? data.login.taxableIncome : ''
 
 block content
-  +stepper('1', '7')
 
   h1 #{title}
 

--- a/views/login/eligibility-tuition-claim.pug
+++ b/views/login/eligibility-tuition-claim.pug
@@ -6,8 +6,6 @@ block variables
 
 block content
 
-  +stepper('5', '7')
-
   h1 #{title}
 
   div 

--- a/views/login/eligibility-tuition.pug
+++ b/views/login/eligibility-tuition.pug
@@ -6,8 +6,6 @@ block variables
 
 block content
 
-  +stepper('5', '7')
-
   h1 #{title}
 
   form.cra-form(method='post')

--- a/views/login/sin.pug
+++ b/views/login/sin.pug
@@ -4,14 +4,10 @@ include ../_includes/banner
 block variables
   -var title = __('Enter your Social insurance number (SIN)')
   -var sin = hasData(body, 'sin') ? body.sin : (hasData(data.login, 'sin') ? data.login.sin : '')
-  -var firstName = hasData(data, 'login.firstName') ? data.login.firstName : (hasData(data, 'personal.firstName') ? data.personal.firstName : '' )
 
 block content
 
   h1 #{title}
-
-  if firstName
-    h2 #{firstName}, #{__('thanks for your filing code')}.
 
   form.cra-form(method='post')
     div(class={['has-error']: errors && errors.sin})


### PR DESCRIPTION
## This PR consists of the following:

### 1) Removing the references to firstName on SIN and DOB pages
- The decision has been made to remove the name reference altogether, it was causing more confusion than clarity when looking at findings from usability testing

### 1) Removing the stepper from the Eligibility flow
- Since we don't feel it is a priority to implement this site-wide now that the partnership is coming to a close, we feel it is better to just remove it altogether as it would be confusing if someone ever was to pick the project back up in the near future