### PR TITLE
Fix Cypress retaining information between fixtures!

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,5 +1,6 @@
 const user = require('./user.json')
 const { verifyHash } = require('./../utils/crypto.utils')
+const cloneDeep = require('clone-deep');
 
 var API = (function(userFound) {
   const _user = userFound
@@ -9,7 +10,7 @@ var API = (function(userFound) {
     code = (code.length === 9) ? code.toUpperCase() : code
     
     if (code && (code === _user.login.code || verifyHash(_user.login.code, code ,{useInitialSalt: true}))) {
-      return _user
+      return cloneDeep(_user)
     }
 
     return null

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -18,7 +18,7 @@
 import 'cypress-axe'
 
 Cypress.Cookies.defaults({
-  whitelist: '_csrf',
+  whitelist: ['_csrf', 'connect.sid'],
 })
 
 Cypress.Commands.add('login', user => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2307,7 +2307,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
       "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-      "dev": true,
       "requires": {
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
@@ -2317,8 +2316,7 @@
         "kind-of": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-          "dev": true
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         }
       }
     },
@@ -5437,7 +5435,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -5524,8 +5521,7 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
       "version": "0.1.2",
@@ -10556,7 +10552,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
       "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "dev": true,
       "requires": {
         "kind-of": "^6.0.2"
       },
@@ -10564,8 +10559,7 @@
         "kind-of": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-          "dev": true
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2303,6 +2303,25 @@
         "wrap-ansi": "^2.0.0"
       }
     },
+    "clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        }
+      }
+    },
     "clone-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
@@ -4425,7 +4444,10 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.0.tgz",
       "integrity": "sha512-LGLpSsbkHUT0T+EKrIJltYoejYzUqg1eW+n6wm/FTte1pDiYjeKTxO0uJvrE3jgv6V9eBzMAjF6A8jH16C0+eQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "icu4c-data": "^0.64.2"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -4932,6 +4954,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "icu4c-data": {
+      "version": "0.64.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
+      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ==",
+      "dev": true
     },
     "ieee754": {
       "version": "1.1.13",
@@ -10523,6 +10551,23 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        }
+      }
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   "devDependencies": {
     "axe-core": "^3.4.1",
     "cheerio": "^1.0.0-rc.3",
+    "clone-deep": "^4.0.1",
     "cypress": "^3.8.3",
     "cypress-axe": "^0.5.3",
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "app-root-path": "^3.0.0",
     "applicationinsights": "^1.7.0",
+    "clone-deep": "^4.0.1",
     "compression": "^1.7.4",
     "cookie-parser": "~1.4.4",
     "csurf": "^1.11.0",
@@ -71,7 +72,6 @@
   "devDependencies": {
     "axe-core": "^3.4.1",
     "cheerio": "^1.0.0-rc.3",
-    "clone-deep": "^4.0.1",
     "cypress": "^3.8.3",
     "cypress-axe": "^0.5.3",
     "eslint": "^6.8.0",


### PR DESCRIPTION
Background:

@katedee first noticed this bug awhile back when adding the 'yes with amounts' Cypress fixture. Cypress would retain all the user information added in the first fixture, causing problems in subsequent fixtures. We assumed this was a Cypress caching issue and worked around it.

TURNS OUT this was caused by the user object in our API being modified every time user info was changed (due to a shallow copy). API.getUser should always return a *fresh* user object, not one that has been modified.
- Added the clone-deep library as a dependency for our API file, which returns a deep clone of user.json to the app every time it is called
- This revealed that Cypress doesn't persist our session data at all between clicks, but the above bug was masking this. Whitelisted our session key within Cypress to allow our user info to persist within each fixture.

I originally had clone-deep as a dev dependency, but I think it needs to be a full dependency after thinking about it a little longer.