### PR TITLE
2 step cancel process

### DIFF
--- a/app.js
+++ b/app.js
@@ -127,6 +127,7 @@ require('./routes/deductions/deductions.controller')(app)
 require('./routes/vote/vote.controller')(app)
 require('./routes/confirmation/confirmation.controller')(app)
 require('./routes/offramp/offramp.controller')(app)
+require('./routes/cancel/cancel.controller')(app)
 
 // clear session
 app.get('/clear', (req, res) => {

--- a/config/routes.config.js
+++ b/config/routes.config.js
@@ -1,6 +1,7 @@
 //list our routes in the flow order in the app
 const routes = [
   { path: '/cancel' },
+  { path: '/clear' },
   { path: '/start' },
   { path: '/eligibility/age' },
   { path: '/eligibility/taxable-income' },

--- a/config/routes.config.js
+++ b/config/routes.config.js
@@ -1,5 +1,6 @@
 //list our routes in the flow order in the app
 const routes = [
+  { path: '/cancel' },
   { path: '/start' },
   { path: '/eligibility/age' },
   { path: '/eligibility/taxable-income' },

--- a/cypress/integration/full_run_with_amounts.spec.js
+++ b/cypress/integration/full_run_with_amounts.spec.js
@@ -303,7 +303,7 @@ describe('Full run through saying "yes" to everything', function() {
       id: 'confirmIncome', // click checkbox
     })
 
-    cy.continue('Continue')
+    cy.continue('Next')
   })
 
   // CHECK ANSWERS

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -116,7 +116,7 @@ Cypress.Commands.add('login', user => {
     .type(user.personal.sin)
     .should('have.value', user.personal.sin)
   cy.get('form button[type="submit"]')
-    .should('contain', 'Continue')
+    .should('contain', 'Next')
     .click()
 
   // LOGIN DOB
@@ -148,7 +148,7 @@ Cypress.Commands.add('login', user => {
     .should('have.value', dobYear)
 
   cy.get('form button[type="submit"]')
-    .should('contain', 'Continue')
+    .should('contain', 'Next')
     .click()
 })
 
@@ -187,7 +187,7 @@ Cypress.Commands.add('amount', ({ url, h1, id }) => {
     .type('25')
 })
 
-Cypress.Commands.add('continue', (label = 'Continue') => {
+Cypress.Commands.add('continue', (label = 'Next') => {
   cy.get('form button[type="submit"]')
     .should('contain', label)
     .click()

--- a/locales/en.json
+++ b/locales/en.json
@@ -437,13 +437,7 @@
   "Mailing address": "Mailing address",
   "Marital status": "Marital status",
   "Cancel your session": "Cancel your session",
-  "Do you want to cancel your session?": "Do you want to cancel your session?",
   "Are you sure you want to cancel your session?": "Are you sure you want to cancel your session?",
-<<<<<<< HEAD
-  "If you choose to cancel your session, none of your information will be saved or submitted. Your tax return will not be filed.": "If you choose to cancel your session, none of your information will be saved or submitted. Your tax return will not be filed."
-=======
-  "By cancelling the session, none of your information will be saved or submitted and your tax return will not be filed.": "By cancelling the session, none of your information will be saved or submitted and your tax return will not be filed.",
   "If you choose to cancel your session, none of your information will be saved or submitted. Your tax return will not be filed.": "If you choose to cancel your session, none of your information will be saved or submitted. Your tax return will not be filed.",
-  "Continue2": "Continue2"
->>>>>>> passing in path as back url
+  "Next": "Next"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -435,5 +435,9 @@
   "Start now": "Start now",
   "Date of birth": "Date of birth",
   "Mailing address": "Mailing address",
-  "Marital status": "Marital status"
+  "Marital status": "Marital status",
+  "Cancel your session": "Cancel your session",
+  "Do you want to cancel your session?": "Do you want to cancel your session?",
+  "Are you sure you want to cancel your session?": "Are you sure you want to cancel your session?",
+  "If you choose to cancel your session, none of your information will be saved or submitted. Your tax return will not be filed.": "If you choose to cancel your session, none of your information will be saved or submitted. Your tax return will not be filed."
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -439,5 +439,11 @@
   "Cancel your session": "Cancel your session",
   "Do you want to cancel your session?": "Do you want to cancel your session?",
   "Are you sure you want to cancel your session?": "Are you sure you want to cancel your session?",
+<<<<<<< HEAD
   "If you choose to cancel your session, none of your information will be saved or submitted. Your tax return will not be filed.": "If you choose to cancel your session, none of your information will be saved or submitted. Your tax return will not be filed."
+=======
+  "By cancelling the session, none of your information will be saved or submitted and your tax return will not be filed.": "By cancelling the session, none of your information will be saved or submitted and your tax return will not be filed.",
+  "If you choose to cancel your session, none of your information will be saved or submitted. Your tax return will not be filed.": "If you choose to cancel your session, none of your information will be saved or submitted. Your tax return will not be filed.",
+  "Continue2": "Continue2"
+>>>>>>> passing in path as back url
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4399,7 +4399,10 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.0.tgz",
       "integrity": "sha512-LGLpSsbkHUT0T+EKrIJltYoejYzUqg1eW+n6wm/FTte1pDiYjeKTxO0uJvrE3jgv6V9eBzMAjF6A8jH16C0+eQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "icu4c-data": "^0.64.2"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -4909,6 +4912,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "icu4c-data": {
+      "version": "0.64.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
+      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ==",
+      "dev": true
     },
     "ieee754": {
       "version": "1.1.13",

--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -190,6 +190,16 @@ li:not(:last-of-type) {
   button {
     margin-right: $space-sm;
   }
+
+  .cancel {
+    background-color: $color-red;
+    box-shadow: 0 2px 0 #570821;
+
+    &:hover,
+    &:focus {
+      background-color: #990626;
+    }
+  }
 }
 
 .visually-hidden {

--- a/routes/cancel/cancel.controller.js
+++ b/routes/cancel/cancel.controller.js
@@ -1,8 +1,6 @@
 module.exports = function(app) {
   app.get('/cancel', (req, res) => {
-    console.log(req.query)
-    const query = { back: '/eligibility/age' }
-    const back = query.back
+    const back = req.query.back
     return res.render('cancel/cancel', {
       data: req.session,
       back,

--- a/routes/cancel/cancel.controller.js
+++ b/routes/cancel/cancel.controller.js
@@ -1,0 +1,11 @@
+module.exports = function(app) {
+  app.get('/cancel', (req, res) => {
+    console.log(req.query)
+    const query = { back: '/eligibility/age' }
+    const back = query.back
+    return res.render('cancel/cancel', {
+      data: req.session,
+      back,
+    })
+  })
+}

--- a/routes/cancel/cancel.controller.js
+++ b/routes/cancel/cancel.controller.js
@@ -1,9 +1,8 @@
 const { routes } = require('../../config/routes.config')
 module.exports = function(app) {
   app.get('/cancel', (req, res) => {
-    const goodRoutes = routes.map(r => r.path)
     const back = req.query.back || '/clear'
-    const found = goodRoutes.includes(back)
+    const found = routes.find(r => r.path === back)
 
     if (!found) {
       throw new Error(`[GET /cancel] Bad query parameter "${back}": must be a valid URL path`)

--- a/routes/cancel/cancel.controller.js
+++ b/routes/cancel/cancel.controller.js
@@ -1,6 +1,14 @@
+const { routes } = require('../../config/routes.config')
 module.exports = function(app) {
   app.get('/cancel', (req, res) => {
-    const back = req.query.back
+    const goodRoutes = routes.map(r=>r.path)
+    const back = req.query.back || '/clear'
+    const found = goodRoutes.includes(back)
+
+    if (!found) {
+      throw new Error(`[GET /cancel] Bad query parameter "${back}": must be a valid URL path`)
+    }
+    console.log(found)
     return res.render('cancel/cancel', {
       data: req.session,
       back,

--- a/routes/cancel/cancel.controller.js
+++ b/routes/cancel/cancel.controller.js
@@ -1,14 +1,13 @@
 const { routes } = require('../../config/routes.config')
 module.exports = function(app) {
   app.get('/cancel', (req, res) => {
-    const goodRoutes = routes.map(r=>r.path)
+    const goodRoutes = routes.map(r => r.path)
     const back = req.query.back || '/clear'
     const found = goodRoutes.includes(back)
 
     if (!found) {
       throw new Error(`[GET /cancel] Bad query parameter "${back}": must be a valid URL path`)
     }
-    console.log(found)
     return res.render('cancel/cancel', {
       data: req.session,
       back,

--- a/routes/cancel/cancel.spec.js
+++ b/routes/cancel/cancel.spec.js
@@ -2,7 +2,7 @@ const request = require('supertest')
 const app = require('../../app.js')
 
 describe('Test /cancel responses', () => {
-  test(`it returns a 200 response for /cancel`, async () => {
+  test('it returns a 200 response for /cancel', async () => {
     const response = await request(app).get('/cancel')
     expect(response.statusCode).toBe(200)
   })

--- a/routes/cancel/cancel.spec.js
+++ b/routes/cancel/cancel.spec.js
@@ -1,0 +1,14 @@
+const request = require('supertest')
+const app = require('../../app.js')
+
+describe('Test /cancel responses', () => {
+  test(`it returns a 200 response for /cancel`, async () => {
+    const response = await request(app).get('/cancel')
+    expect(response.statusCode).toBe(200)
+  })
+
+  test('it returns a 500 response if no redirect is provided', async () => {
+    const response = await request(app).get('/cancel?back=evil')
+    expect(response.statusCode).toBe(500)
+  })
+})

--- a/routes/cancel/cancel.spec.js
+++ b/routes/cancel/cancel.spec.js
@@ -1,14 +1,27 @@
 const request = require('supertest')
 const app = require('../../app.js')
+const cheerio = require('cheerio')
 
 describe('Test /cancel responses', () => {
-  test('it returns a 200 response for /cancel', async () => {
+  test('it returns a 200 response for /cancel with no back path (routes to /clear on Go Back)', async () => {
     const response = await request(app).get('/cancel')
     expect(response.statusCode).toBe(200)
+
+    const $ = cheerio.load(response.text)
+    expect($('.buttons-row a + a').attr('href')).toEqual('/clear')
   })
 
-  test('it returns a 500 response if no redirect is provided', async () => {
-    const response = await request(app).get('/cancel?back=evil')
+  test('it returns a 500 response if back path is not whitelisted + has proper error message', async () => {
+    const response = await request(app).get('/cancel?back=/evil')
     expect(response.statusCode).toBe(500)
+    expect(response.error.message).toEqual('cannot GET /cancel?back=/evil (500)')
+  })
+
+  test('it returns a 200 response if back path is whitelisted (routes to back path on Go Back)', async () => {
+    const response = await request(app).get('/cancel?back=/start')
+    expect(response.statusCode).toBe(200)
+
+    const $ = cheerio.load(response.text)
+    expect($('.buttons-row a + a').attr('href')).toEqual('/start')
   })
 })

--- a/routes/confirmation/confirmation.controller.js
+++ b/routes/confirmation/confirmation.controller.js
@@ -43,6 +43,7 @@ module.exports = function(app) {
       data: req.session,
       prevRoute: getPreviousRoute(req),
       answerInfo: formatAnswerInfo(req),
+      path: req.path,
     })
   })
 }

--- a/routes/confirmation/confirmation.controller.js
+++ b/routes/confirmation/confirmation.controller.js
@@ -40,10 +40,10 @@ module.exports = function(app) {
 
   app.get('/checkAnswers', (req, res) => {
     res.render('confirmation/check-answers', {
-      data: req.session,
-      prevRoute: getPreviousRoute(req),
       answerInfo: formatAnswerInfo(req),
+      data: req.session,
       path: req.path,
+      prevRoute: getPreviousRoute(req),
     })
   })
 }

--- a/utils/index.js
+++ b/utils/index.js
@@ -155,6 +155,7 @@ const renderWithData = (template, { errorsKey } = {}) => {
     // send a 422 response if errors exist
     res.status(errors ? 422 : 200).render(template, {
       data: req.session,
+      path: req.path,
       prevRoute: getPreviousRoute(req),
       errors,
     })

--- a/utils/index.js
+++ b/utils/index.js
@@ -106,10 +106,11 @@ const checkErrors = template => {
 
     if (!errors.isEmpty()) {
       return res.status(422).render(template, {
-        prevRoute: getPreviousRoute(req),
-        data: req.session,
         body,
+        data: req.session,
         errors: errorArray2ErrorObject(errors),
+        path: req.path,
+        prevRoute: getPreviousRoute(req),
       })
     }
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -155,9 +155,9 @@ const renderWithData = (template, { errorsKey } = {}) => {
     // send a 422 response if errors exist
     res.status(errors ? 422 : 200).render(template, {
       data: req.session,
+      errors,
       path: req.path,
       prevRoute: getPreviousRoute(req),
-      errors,
     })
   }
 }

--- a/views/_includes/buttonMixin.pug
+++ b/views/_includes/buttonMixin.pug
@@ -1,4 +1,4 @@
-mixin formButtons(submitButtonText = 'Continue', cancelUrl='/clear', cancelText= 'Cancel')
+mixin formButtons(submitButtonText = 'Continue', cancelUrl='/cancel', cancelText= 'Cancel')
   input(type='hidden', name="_csrf", value=csrfToken)
   
   .buttons

--- a/views/_includes/buttonMixin.pug
+++ b/views/_includes/buttonMixin.pug
@@ -5,7 +5,10 @@ mixin formButtons(submitButtonText = 'Continue', cancelUrl='/cancel', cancelText
     .buttons--left
       button(type='submit') #{__(submitButtonText)}
     .buttons--right
-      a.transparent.full-width(href=cancelUrl role='button' draggable='false') #{__(cancelText)}
+      if path
+        a.transparent.full-width(href=`${cancelUrl}?back=${path}` role='button' draggable='false') #{__(cancelText)}
+      else
+        a.transparent.full-width(href=cancelUrl role='button' draggable='false') #{__(cancelText)}
 
 mixin linkButtons(confirmURL, linkButtonText = 'Confirm')
   .buttons-row

--- a/views/_includes/buttonMixin.pug
+++ b/views/_includes/buttonMixin.pug
@@ -1,4 +1,4 @@
-mixin formButtons(submitButtonText = 'Continue', cancelUrl='/cancel', cancelText= 'Cancel')
+mixin formButtons(submitButtonText = 'Next')
   input(type='hidden', name="_csrf", value=csrfToken)
   
   .buttons
@@ -6,13 +6,16 @@ mixin formButtons(submitButtonText = 'Continue', cancelUrl='/cancel', cancelText
       button(type='submit') #{__(submitButtonText)}
     .buttons--right
       if path
-        a.transparent.full-width(href=`${cancelUrl}?back=${path}` role='button' draggable='false') #{__(cancelText)}
+        a.transparent.full-width(href=`/cancel?back=${path}` role='button' draggable='false') #{__('Cancel')}
       else
-        a.transparent.full-width(href=cancelUrl role='button' draggable='false') #{__(cancelText)}
+        a.transparent.full-width(href=cancelUrl role='button' draggable='false') #{__('Cancel')}
 
 mixin linkButtons(confirmURL, linkButtonText = 'Confirm')
   .buttons-row
     a(href=confirmURL role='button' draggable='false') #{__(linkButtonText)}
-    if block
-        block
-    a.transparent(href='/clear' role='button' draggable='false') #{__('Cancel')}
+    if path
+      a.transparent(href=`/cancel?back=${path}` role='button' draggable='false') #{__('Cancel')}
+    else
+      a.transparent(href=`/cancel` role='button' draggable='false') #{__('Cancel')}
+
+      

--- a/views/_includes/buttonMixin.pug
+++ b/views/_includes/buttonMixin.pug
@@ -1,9 +1,9 @@
-mixin formButtons(submitButtonText = 'Next')
+mixin formButtons()
   input(type='hidden', name="_csrf", value=csrfToken)
   
   .buttons
     .buttons--left
-      button(type='submit') #{__(submitButtonText)}
+      button(type='submit') #{__('Next')}
     .buttons--right
       if path
         a.transparent.full-width(href=`/cancel?back=${path}` role='button' draggable='false') #{__('Cancel')}

--- a/views/cancel/cancel.pug
+++ b/views/cancel/cancel.pug
@@ -7,8 +7,6 @@ block content
 
   h1 #{title}
 
-  p #{back}
-
   div
     p #{__('Are you sure you want to cancel your session?')}
 

--- a/views/cancel/cancel.pug
+++ b/views/cancel/cancel.pug
@@ -1,0 +1,20 @@
+extends ../base
+
+block variables
+  -var title = __('Cancel your session')
+
+block content
+
+  h1 #{title}
+
+  p #{back}
+
+  div
+    p #{__('Are you sure you want to cancel your session?')}
+
+    p #{__('If you choose to cancel your session, none of your information will be saved or submitted. Your tax return will not be filed.')}
+
+    .buttons-row
+      a(class='cancel' href='/clear' role='button' draggable='false') #{__('Cancel your session')}
+
+      a.transparent(href=back role='button' draggable='false') #{__('Go back')}

--- a/views/confirmation/income.pug
+++ b/views/confirmation/income.pug
@@ -41,4 +41,4 @@ block content
 
     input#redirect(name='redirect', type='hidden', value='/checkAnswers')
 
-    +formButtons('Continue')
+    +formButtons()

--- a/views/deductions/senior-public-transit-amount.pug
+++ b/views/deductions/senior-public-transit-amount.pug
@@ -18,4 +18,4 @@ block content
 
     input#redirect(name='redirect', type='hidden', value='/deductions/climate-action-incentive')
 
-    +formButtons('Continue')
+    +formButtons()

--- a/views/deductions/trillium-energy-cost-amount.pug
+++ b/views/deductions/trillium-energy-cost-amount.pug
@@ -18,4 +18,4 @@ block content
 
     input#redirect(name='redirect', type='hidden', value='/vote/optIn')
 
-    +formButtons('Continue')
+    +formButtons()

--- a/views/deductions/trillium-longTermCare-amount.pug
+++ b/views/deductions/trillium-longTermCare-amount.pug
@@ -18,4 +18,4 @@ block content
 
     input#redirect(name='redirect', type='hidden', value='/trillium/energy/reserve')
 
-    +formButtons('Continue')
+    +formButtons()

--- a/views/deductions/trillium-longTermCare-roomAndBoard.pug
+++ b/views/deductions/trillium-longTermCare-roomAndBoard.pug
@@ -18,4 +18,4 @@ block content
 
     input#redirect(name='redirect', type='hidden', value='/trillium/energy/reserve')
 
-    +formButtons('Continue')
+    +formButtons()

--- a/views/deductions/trillium-propertyTax-amount.pug
+++ b/views/deductions/trillium-propertyTax-amount.pug
@@ -24,4 +24,4 @@ block content
 
     input#redirect(name='redirect', type='hidden', value='/trillium/longTermCare')
 
-    +formButtons('Continue')
+    +formButtons()

--- a/views/deductions/trillium-rent-amount.pug
+++ b/views/deductions/trillium-rent-amount.pug
@@ -20,4 +20,4 @@ block content
 
     include ../_includes/rentReceipts
 
-    +formButtons('Continue')
+    +formButtons()

--- a/views/login/eligibility-age.pug
+++ b/views/login/eligibility-age.pug
@@ -8,11 +8,9 @@ block content
 
   h1 #{title}
 
-  p #{path}
-
   form.cra-form(method='post')
     +radiosYesNo('ageYesNo', 'On December 31, 2019, were you age 65 or older?', ageYesNo)
 
-    input#redirect(name='redirect', type='hidden', value='/eligibility/taxable-income')
+    input#redirect(name='redirect' type='hidden' value='/eligibility/taxable-income')
 
-    +formButtons('Continue', `/cancel?back=${path}`)
+    +formButtons()

--- a/views/login/eligibility-age.pug
+++ b/views/login/eligibility-age.pug
@@ -8,9 +8,11 @@ block content
 
   h1 #{title}
 
+  p #{path}
+
   form.cra-form(method='post')
     +radiosYesNo('ageYesNo', 'On December 31, 2019, were you age 65 or older?', ageYesNo)
 
     input#redirect(name='redirect', type='hidden', value='/eligibility/taxable-income')
 
-    +formButtons('Continue', '/cancel?back=/eligibility/age')
+    +formButtons('Continue', `/cancel?back=${path}`)

--- a/views/login/eligibility-age.pug
+++ b/views/login/eligibility-age.pug
@@ -13,4 +13,4 @@ block content
 
     input#redirect(name='redirect', type='hidden', value='/eligibility/taxable-income')
 
-    +formButtons()
+    +formButtons('Continue', '/cancel?back=/eligibility/age')

--- a/views/login/eligibility-taxable-income.pug
+++ b/views/login/eligibility-taxable-income.pug
@@ -16,4 +16,4 @@ block content
 
     input#redirect(name='redirect' type='hidden' value='/eligibility/residence')
 
-    +formButtons()
+    +formButtons('Continue', '/cancel?back=/eligibility/taxable-income')

--- a/views/login/eligibility-taxable-income.pug
+++ b/views/login/eligibility-taxable-income.pug
@@ -16,4 +16,4 @@ block content
 
     input#redirect(name='redirect' type='hidden' value='/eligibility/residence')
 
-    +formButtons('Continue', '/cancel?back=/eligibility/taxable-income')
+    +formButtons()


### PR DESCRIPTION
## This PR consists of the following:

### Context
- More clarity was needed over the cancel feature that was previously in place
- Users found it confusing and it posed the risk of someone accidentally erasing their session without knowing the consequences

### Creating a `/cancel` page that users are routed to after hitting cancel
- a cancel page has been created which tells the user that by cancelling their session they will lose all their current data and that their tax return will not be filed.
- Routing needed to be considered for going back and forth between the cancel page and it's previous path
- Basic unit tests have been created for the page

### Changing 'Continue' to 'Next'
- Yedida has suggested changing 'Continue' to 'Next'

### GIF
![cancel2](https://user-images.githubusercontent.com/30609058/75294539-b21c6c80-57f6-11ea-9784-08a007bed22a.gif)
