### PR TITLE
Add an em dash to `/vote/citizen` page title

### DIFF
--- a/cypress/integration/full_run_with_amounts.spec.js
+++ b/cypress/integration/full_run_with_amounts.spec.js
@@ -277,7 +277,7 @@ describe('Full run through saying "yes" to everything', function() {
   it('navigates Voter Citizen page', function() {
     cy.confirm({
       url: '/vote/citizen',
-      h1: 'Register to vote - citizenship',
+      h1: 'Register to vote — citizenship',
       id: 'citizen', // click Yes
     })
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -217,7 +217,7 @@
   "Quinte West": "Quinte West",
   "Receipts for rent, long-term care, property tax and home energy costs, if you have them": "Receipts for rent, long-term care, property tax and home energy costs, if you have them",
   "Register or update voter information": "Register or update voter information",
-  "Register to vote - citizenship": "Register to vote - citizenship",
+  "Register to vote — citizenship": "Register to vote — citizenship",
   "Rent": "Rent",
   "Rent in Ontario": "Rent in Ontario",
   "Review": "Review",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -217,7 +217,7 @@
   "Quinte West": "Quinte West",
   "Receipts for rent, long-term care, property tax and home energy costs, if you have them": "de vos reçus ou factures de loyer, de frais de soins de longue durée, de taxes foncières, et de frais d’énergie résidentielle, si vous les avez.",
   "Register or update voter information": "S’inscrire ou mettre ses renseignements à jour",
-  "Register to vote - citizenship": "Inscription au vote – citoyenneté ",
+  "Register to vote — citizenship": "Inscription au vote — citoyenneté ",
   "Rent": "Loyer",
   "Rent in Ontario": "Loyer en Ontario",
   "Review": "Réviser",
@@ -438,5 +438,6 @@
   "Marital status": "État civil",
   "paid monthly if $360 or more": "paid monthly if $360 or more",
   "or": "or",
-  "paid yearly if less than $360": "paid yearly if less than $360"
+  "paid yearly if less than $360": "paid yearly if less than $360",
+  "Next": "Next"
 }

--- a/views/vote/citizen.pug
+++ b/views/vote/citizen.pug
@@ -2,7 +2,7 @@ extends ../base
 include ../_includes/banner
 
 block variables
-  -var title = __('Register to vote - citizenship')
+  -var title = __('Register to vote — citizenship')
   -var citizen = !hasData(data, 'vote.citizen') ? '' : data.vote.citizen
 
 block content


### PR DESCRIPTION
Before it was a hyphen and it was hard to look at.

## Screenshots

You see? Much better.

| before | after |
|--------|-------|
|   <img width="1377" alt="Screen Shot 2020-03-02 at 3 21 44 PM" src="https://user-images.githubusercontent.com/2454380/75714728-3d37af80-5c9a-11ea-8d7f-24a4f7884bf8.png">     |   <img width="1377" alt="Screen Shot 2020-03-02 at 3 21 46 PM" src="https://user-images.githubusercontent.com/2454380/75714714-3a3cbf00-5c9a-11ea-98c4-ced3d5c1c072.png">    |

