### PR TITLE
Fix/french button french beta

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -442,5 +442,6 @@
   "Next": "Next",
   "paid monthly if $360 or more": "paid monthly if $360 or more",
   "or": "or",
-  "paid yearly if less than $360": "paid yearly if less than $360"
+  "paid yearly if less than $360": "paid yearly if less than $360",
+  "BETA": "BETA"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -439,6 +439,6 @@
   "paid monthly if $360 or more": "paid monthly if $360 or more",
   "or": "or",
   "paid yearly if less than $360": "paid yearly if less than $360",
-  "Next": "Next",
+  "Next": "Suivant",
   "BETA": "BÊTA"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -439,5 +439,6 @@
   "paid monthly if $360 or more": "paid monthly if $360 or more",
   "or": "or",
   "paid yearly if less than $360": "paid yearly if less than $360",
-  "Next": "Next"
+  "Next": "Next",
+  "BETA": "BÊTA"
 }

--- a/views/_includes/phaseBanner.pug
+++ b/views/_includes/phaseBanner.pug
@@ -1,4 +1,4 @@
 .phase-banner
   div
-    span BETA
+    span #{__('BETA')}
     span #{__('This site will change as we test ideas.')}

--- a/views/base.pug
+++ b/views/base.pug
@@ -10,7 +10,7 @@ html(lang=getLocale() === 'fr' ? 'fr' : 'en')
     // Required meta tags
     meta(charset='utf-8')
     meta(name='viewport', content='width=device-width, initial-scale=1, shrink-to-fit=no')
-    meta(name='description' content=`[ALPHA] ${__('A benefit signup prototype by the Canadian Digital Service')}`)
+    meta(name='description' content=`[${getLocale() === 'fr' ? 'BÊTA' : 'BETA'}] ${__('A benefit signup prototype by the Canadian Digital Service')}`)
     if GITHUB_SHA
       meta(name='keywords' content=`GITHUB_SHA=${GITHUB_SHA}`)
     link(rel='shortcut icon' href='/favicon.png' type='image/x-icon' sizes='32x32')


### PR DESCRIPTION
Update to fix two small things.

1. Update `BETA` to say `BÊTA` in French. This is consistent with the CDS website as well as the [`report-a-scam`](https://report-a-scam.cds-snc.ca/) service.
2. Add translation for "Next" button

Closes #544 

## Screenshots

| French BETA banner   | French Next button  |
|---------------|---------------|
| <img width="230" alt="Screen Shot 2020-03-03 at 11 19 56 AM" src="https://user-images.githubusercontent.com/2454380/75796467-afaf9a80-5d41-11ea-910f-8ea25e4d9e66.png">  |  <img width="245" alt="Screen Shot 2020-03-03 at 11 20 10 AM" src="https://user-images.githubusercontent.com/2454380/75796337-7ecf6580-5d41-11ea-8ae9-5b48e2f9a81d.png"> |

