### PR TITLE
Add demo users' info to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ This is a demo of a service to make tax filing faster and easier for a preselect
 
 Much of the information needed to file a tax return is already known to CRA. At the same time, low-confidence tax filers are very worried about making mistakes when submitting a tax return. The concept behind this demo application is to provide a wizard-like tax filing experience: presenting the tax filer with information that CRA already has about them and having them to confirm it rather than asking them type it in.
 
+| Demo user 1   | Demo user 2       |
+| ------------- | ----------------- |
+| Gabrielle Roy | Monique Corriveau |
+| `A5G98S4K1`   | `A5G98S4K3`       |
+| `540 739 869` | `435 073 143`     |
+| `09 09 1977`  | `03 03 1947`      |
+
 [While this repository is no longer actively maintained](https://github.com/cds-snc/cra-claim-tax-benefits/blob/master/docs/CONTINUING-DEVELOPMENT.md), the code is open and available for demonstration purposes or reuse. In addition to an end-to-end flow, it is an example of best-practice development for an API-driven, cloud-native frontend application.
 
 ## Table of contents

--- a/api/user.json
+++ b/api/user.json
@@ -62,8 +62,8 @@
       "ageYesNo": null
     },
     "personal": {
-      "firstName": "Alex",
-      "lastName": "Janvier",
+      "firstName": "Monique",
+      "lastName": "Corriveau",
       "confirmedName": null,
       "sin": "435073143",
       "dateOfBirth": "1947-03-03",

--- a/cypress/fixtures/checkAnswersRowsAbove65.json
+++ b/cypress/fixtures/checkAnswersRowsAbove65.json
@@ -2,7 +2,7 @@
   "rows": [
     {
       "key": "What is your name?",
-      "value": "Alex Janvier"
+      "value": "Monique Corriveau"
     },
     {
       "key": "What is your date of birth?",

--- a/cypress/fixtures/userAbove65.json
+++ b/cypress/fixtures/userAbove65.json
@@ -4,8 +4,8 @@
     "ageYesNo": null
   },
   "personal": {
-    "firstName": "Alex",
-    "lastName": "Janvier",
+    "firstName": "Monique",
+    "lastName": "Corriveau",
     "confirmedName": null,
     "sin": "435073143",
     "dateOfBirth": "1947-03-03",
@@ -45,7 +45,7 @@
     "trilliumLongTermCareAmount": 0,
     "climateActionIncentiveIsRural": null
   },
-"benefits": {
+  "benefits": {
     "cai": {
       "name": "Climate action incentive (CAI)",
       "description": "everyone gets this payment. You get 10% extra if you live outside a Census Metropolitan Area."
@@ -63,7 +63,7 @@
       "description": "a payment that helps with energy, sales and property tax. The government usually pays this amount on the 10th day of each month for 12 months."
     }
   },
-"vote": {
+  "vote": {
     "confirmOptIn": null,
     "citizen": null,
     "register": null


### PR DESCRIPTION
Also change our second demo user's name, in order to keep the theme we started with alive.
The theme is French-Canadian writers, signalling the intent of this service to eventually cover all of Canada.

Cleared it with Nancy and she says it's all good.

![image](https://user-images.githubusercontent.com/2454380/75900165-81e25880-5e0a-11ea-8688-10961613182a.png)
