### PR TITLE
Small update to FR text on tuition page

### DIFF
--- a/locales/fr.json
+++ b/locales/fr.json
@@ -283,7 +283,7 @@
   "Waterloo": "Waterloo",
   "We are currently in the process of building this page. You can still proceed through your session by clicking Continue.": "Nous sommes actuellement en train de construire la page. Vous pouvez tout de même poursuivre votre session en cliquant sur « Continuer ».",
   "Welland": "Welland",
-  "Were you a student at a college, university or other educational institution in 2019?": "Avez-vous étudié à un collège, à une université ou à un établissement scolaire en 2019?",
+  "Were you a student at a college, university or other educational institution in 2019?": "Avez-vous étudié à un collège, à une université ou à un autre établissement scolaire en 2019?",
   "What is your date of birth?": "Quelle est votre date de naissance?",
   "What is your mailing address?": "Quelle est votre adresse postale?",
   "What is your marital status?": "Quel est votre état civil?",


### PR DESCRIPTION
We want to say: college, university, or any OTHER education institution.

See it here: https://cra-claim-ta-fix-french-iwkqg1.herokuapp.com/eligibility/tuition?lang=fr